### PR TITLE
Provide functionality for authorization using certificate 

### DIFF
--- a/include/odata/client/odata_client.h
+++ b/include/odata/client/odata_client.h
@@ -36,6 +36,10 @@ namespace odata { namespace client {
             }
         }
 
+        ::web::http::client::http_client_config& get_client_config(){
+            return m_client_proxy->get_client_config();
+        }
+
         const ::utility::string_t& get_service_root_url() const
         {
             return m_service_root_url;

--- a/include/odata/communication/http_communication.h
+++ b/include/odata/communication/http_communication.h
@@ -30,32 +30,36 @@ template<typename _Http_Imple, typename _Http_Response>
 class http_client_proxy
 {
 public:
-	http_client_proxy(const ::utility::string_t& baseAddress, std::shared_ptr<::odata::client::odata_client_credential> credential_setting)
-	{
-		m_client_impl = std::make_shared<_Http_Imple>(baseAddress, credential_setting);
-	}
+    http_client_proxy(const ::utility::string_t& baseAddress, std::shared_ptr<::odata::client::odata_client_credential> credential_setting)
+    {
+        m_client_impl = std::make_shared<_Http_Imple>(baseAddress, credential_setting);
+    }
 
-	http_client_proxy(std::shared_ptr<_Http_Imple> client_impl) : m_client_impl(client_impl)
-	{
-	}
+    http_client_proxy(std::shared_ptr<_Http_Imple> client_impl) : m_client_impl(client_impl)
+    {
+    }
 
     pplx::task<_Http_Response> send_http_request(const ::utility::string_t& method, const ::utility::string_t& request_uri, const ::utility::string_t accept)
-	{
-		return m_client_impl->send_http_request(method, request_uri, accept);
-	}
+    {
+        return m_client_impl->send_http_request(method, request_uri, accept);
+    }
 
     pplx::task<_Http_Response> send_http_request(const ::utility::string_t& method, const ::utility::string_t& request_uri, const ::utility::string_t accept, ::web::json::value object)
-	{
-		return m_client_impl->send_http_request(method, request_uri, accept, object);
-	}
+    {
+        return m_client_impl->send_http_request(method, request_uri, accept, object);
+    }
 
     ::utility::string_t base_uri()
     {
         return m_client_impl->base_uri();
     }
 
+    ::web::http::client::http_client_config& get_client_config(){
+        return m_client_impl->get_client_config();
+    }
+
 private:
-	std::shared_ptr<_Http_Imple>  m_client_impl;
+    std::shared_ptr<_Http_Imple>  m_client_impl;
 };
 
 }}

--- a/include/odata/communication/http_implement.h
+++ b/include/odata/communication/http_implement.h
@@ -20,32 +20,49 @@ namespace odata { namespace communication
 class http_client_impl
 {
 public:
-	http_client_impl(const ::utility::string_t& baseAddress, std::shared_ptr<::odata::client::odata_client_credential> credential_setting)
-	{
-		if (credential_setting)
-		{
-			::web::http::client::http_client_config client_config;
-			client_config.set_credentials(::web::http::client::credentials(credential_setting->get_username(), credential_setting->get_password()));
-			m_client = std::make_shared<::web::http::client::http_client>(::web::http::uri(baseAddress), client_config);
-		}
-		else
-		{
-            m_client = std::make_shared<::web::http::client::http_client>(::web::http::uri(baseAddress));
-		}
-		
-	}
-
-	::utility::string_t base_uri()
+    http_client_impl(const ::utility::string_t& address, std::shared_ptr<::odata::client::odata_client_credential> credential)
     {
-		return m_client->base_uri().to_string();
+        baseAddress = address;
+        credential_setting = credential;
     }
 
-	pplx::task<::web::http::http_response> send_http_request(const ::utility::string_t& method, const ::utility::string_t& request_uri, const ::utility::string_t accept);
-	pplx::task<::web::http::http_response> send_http_request(const ::utility::string_t& method, const ::utility::string_t& request_uri, const ::utility::string_t accept, ::web::json::value object);
+    ::utility::string_t base_uri()
+    {
+        return getOrCreateClient()->base_uri().to_string();
+    }
+
+    ::web::http::client::http_client_config& get_client_config(){
+        return client_config;
+    }
+
+    pplx::task<::web::http::http_response> send_http_request(const ::utility::string_t& method, const ::utility::string_t& request_uri, const ::utility::string_t accept);
+    pplx::task<::web::http::http_response> send_http_request(const ::utility::string_t& method, const ::utility::string_t& request_uri, const ::utility::string_t accept, ::web::json::value object);
 
 private:
-	std::shared_ptr<::web::http::client::http_client> m_client;
 
+    /// <summary>
+    /// If the client hasn't already been constructed, the method constructs one 
+    /// and returns it, while also caching it for future
+    /// </summary>
+    /// <Explanation>
+    /// Delays the construction of m_client until its first use
+    /// This allows others to use and modify the client_config object
+    /// (e.g. change the callback function associated with it) before
+    /// m_client is created.
+    /// </Explanation>
+    std::shared_ptr<::web::http::client::http_client>& getOrCreateClient()
+    {
+        if (m_client == nullptr)
+        {
+            if (credential_setting)  client_config.set_credentials(::web::http::client::credentials(credential_setting->get_username(), credential_setting->get_password()));
+            m_client = std::make_shared<::web::http::client::http_client>(::web::http::uri(baseAddress), client_config);
+        }
+        return m_client;
+    }
+    std::shared_ptr<::web::http::client::http_client> m_client;
+    ::utility::string_t baseAddress;
+    std::shared_ptr<::odata::client::odata_client_credential> credential_setting;
+    ::web::http::client::http_client_config client_config;
     ::web::http::http_request _build_get_request(::web::http::method method, ::web::http::uri_builder request_uri, const ::utility::string_t& accept = U("")) const;
     ::web::http::http_request _build_request(::web::http::method method, ::web::http::uri_builder request_uri, const ::utility::string_t& accept, ::web::json::value object) const;
 };

--- a/src/communication/http_implement.cpp
+++ b/src/communication/http_implement.cpp
@@ -66,7 +66,7 @@ pplx::task<http::http_response> http_client_impl::send_http_request(const ::util
 
 	auto request = _build_get_request(method, bldr, accept);
 
-    return m_client->request(request);
+    return getOrCreateClient()->request(request);
 }
 
 pplx::task<http::http_response> http_client_impl::send_http_request(const ::utility::string_t& method, const ::utility::string_t& request_uri, const ::utility::string_t accept, ::web::json::value object)
@@ -76,7 +76,7 @@ pplx::task<http::http_response> http_client_impl::send_http_request(const ::util
 
 	auto request = _build_request(method, bldr, accept, object);
 
-    return m_client->request(request);
+    return getOrCreateClient()->request(request);
 }
 
 }}


### PR DESCRIPTION
I exposed the client_config object, so that a third party can customize the callback function provided by it. We use that callback to add a certificate to the http request before the request actually gets sent over the wire. However, note that this change must take place before the m_client is created by http_implement.h.