### PR TITLE
Major improvements and fixes to the C++ OData client library, see below:

### DIFF
--- a/include/odata/client/odata_client.h
+++ b/include/odata/client/odata_client.h
@@ -18,159 +18,274 @@
 
 namespace odata { namespace client {
 
-    class odata_client
-    {
-    public:
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        /// <param name="baseAddress">The OData service endpoint used to create the client.</param>
-        odata_client(::utility::string_t baseAddress, client_options options = client_options()) :
-            m_options(options), m_service_root_url(std::move(baseAddress))
-        {
-            m_client_proxy = std::make_shared<::odata::communication::http_client_proxy<::odata::communication::http_client_impl, ::odata::communication::http_client_response>>(m_service_root_url, options.get_credential_setting());
+	struct http_result
+	{
+		http_result()                              = default;
+		http_result(http_result const&)            = default;
+		http_result(http_result&&)                 = default;
+		http_result(::web::http::http_headers const &headers, ::web::http::status_code status) : headers_(headers), status_(status) {}
+		http_result(::web::http::http_response const &response) : headers_(response.headers()), status_(response.status_code()) {}
+		http_result& operator=(http_result const&) = default;
+		http_result& operator=(http_result&&)      = default;
+		::web::http::http_headers headers_;
+		::web::http::status_code  status_;
+	};
 
-            if (m_service_root_url.back() == '/')
-            {
-                m_service_root_url.pop_back();
-            }
-        }
+	class odata_client
+	{
+	public:
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="baseAddress">The OData service endpoint used to create the client.</param>
+		odata_client(::odata::string_t baseAddress, client_options options = client_options()) :
+			m_client_proxy(), m_options(options), m_service_root_url(std::move(baseAddress)), m_model(), m_model_response_headers(), m_ShallLogCallback(), m_LogCallback()
+		{
+			m_client_proxy = ::odata::make_shared<::odata::communication::http_client_proxy<::odata::communication::http_client_impl, ::odata::communication::http_client_response>>(m_service_root_url, options.get_credential_setting());
 
-        ::web::http::client::http_client_config& get_client_config(){
-            return m_client_proxy->get_client_config();
-        }
+			if (m_service_root_url.back() == _XPLATSTR('/'))
+			{
+				m_service_root_url.pop_back();
+			}
+		}
 
-        const ::utility::string_t& get_service_root_url() const
-        {
-            return m_service_root_url;
-        }
+		::web::http::client::http_client_config& get_client_config()
+		{
+			return m_client_proxy->get_client_config();
+		}
 
-        ::utility::string_t get_relative_path(const ::utility::string_t& full_path)
-        {
-            if (::odata::common::is_relative_path(m_service_root_url, full_path))
-            {
-                return full_path;
-            }
+		const ::odata::string_t& get_service_root_url() const
+		{
+			return m_service_root_url;
+		}
 
-            return full_path.substr(m_service_root_url.length() + 1, full_path.length() - m_service_root_url.length());
-        }
+		::odata::string_t get_relative_path(const ::odata::string_t& full_path) const
+		{
+			if (::odata::common::is_relative_path(m_service_root_url, full_path))
+			{
+				return full_path;
+			}
 
-        /// <summary>
-        /// Retrieve the service's metadata (types, and other information).
-        /// </summary>
-        ODATACPP_CLIENT_API pplx::task<std::shared_ptr<::odata::edm::edm_model>> get_model();
+			return full_path.length() > m_service_root_url.length() ? full_path.substr(m_service_root_url.length() + 1, full_path.length() - m_service_root_url.length()) : _XPLATSTR(""); // Handles corner case of full_path = m_service_root_url!
+		}
 
-        /// <summary>
-        /// Get the elements of a given entity set.
-        /// </summary>
-        /// <param name="edm_entity_set">The entity set metadata record.</param>
-        /// <param name="query_exp">The OData query string to use for the request.</param>
-        /// <returns>The result entities with annotation infomation, possibly empty.</returns>
-        ODATACPP_CLIENT_API pplx::task<std::vector<std::shared_ptr<::odata::core::odata_entity_value>>> get_entities(const ::utility::string_t& edm_entity_set);
+		const client_options& get_options() const { return m_options; }
 
-        /// <summary>
-        /// Add an entity to a given entity set.
-        /// </summary>
-        /// <param name="edm_entity_set">The entity set metadata record.</param>
-        /// <param name="record">The entity to add.</param>
-        /// <returns>An entity instance representing the new entity after it was inserted.</returns>
-        ODATACPP_CLIENT_API pplx::task<::web::http::status_code> create_entity(const ::utility::string_t& entity_set_name, const std::shared_ptr<::odata::core::odata_entity_value>& entity_object);
+		/// <summary>
+		/// Retrieve the service's metadata (types, and other information).
+		/// </summary>
+		ODATACPP_CLIENT_API pplx::task<std::pair<std::shared_ptr<::odata::edm::edm_model>, http_result>> get_model();
 
-        /// <summary>
-        /// Update an existing entity of a given entity set.
-        /// </summary>
-        /// <param name="edm_entity_set">The entity set metadata record.</param>
-        /// <param name="key">The primary key of the record that should be modified.</param>
-        /// <param name="record">The entity value to write.</param>
-        /// <returns>An entity instance representing the new entity after it was modified.</returns>
-        /// <remarks>This does a surgical replacement of the record, modifying and adding properties found in the provided record.</remarks>
-        ODATACPP_CLIENT_API pplx::task<::web::http::status_code> patch_entity(const ::utility::string_t& entity_set_name, const std::shared_ptr<::odata::core::odata_entity_value>& entity_object);
+		/// <summary>
+		/// Get the elements of a given entity set.
+		/// </summary>
+		/// <param name="edm_entity_set">The entity set metadata record.</param>
+		/// <param name="query_exp">The OData query string to use for the request.</param>
+		/// <returns>The result entities with annotation infomation, possibly empty.</returns>
+		ODATACPP_CLIENT_API pplx::task<std::pair<std::vector<std::shared_ptr<::odata::core::odata_entity_value>>, http_result>> get_entities(const ::odata::string_t& edm_entity_set);
 
-        /// <summary>
-        /// Replace existing entity of a given entity set. 
-        /// </summary>
-        /// <param name="edm_entity_set">The entity set metadata record.</param>
-        /// <param name="key">The primary key of the record that should be modified.</param>
-        /// <param name="record">The entity value to write.</param>
-        /// <returns>An entity instance representing the new entity after it was modified.</returns>
-        /// <remarks>This does a total replacement of the existing entity with a given entity value.</remarks>
-        ODATACPP_CLIENT_API pplx::task<::web::http::status_code> put_entity(const ::utility::string_t& entity_set_name, const std::shared_ptr<::odata::core::odata_entity_value>& entity_object);  
+		/// <summary>
+		/// Add an entity to a given entity set.
+		/// </summary>
+		/// <param name="edm_entity_set">The entity set metadata record.</param>
+		/// <param name="record">The entity to add.</param>
+		/// <returns>An entity instance representing the new entity after it was inserted.</returns>
+		ODATACPP_CLIENT_API pplx::task<std::pair<nullptr_t, http_result>> create_entity(const ::odata::string_t& entity_set_name, const std::shared_ptr<::odata::core::odata_entity_value>& entity_object);
 
-        /// <summary>
-        /// Remove an entity from a given entity set.
-        /// </summary>
-        /// <param name="edm_entity_set">The entity set metadata record.</param>
-        /// <param name="key">The primary key of the record that should be deleted.</param>
-        ODATACPP_CLIENT_API pplx::task<::web::http::status_code> delete_entity(const ::utility::string_t& entity_set_name, const std::shared_ptr<::odata::core::odata_entity_value>& entity_object);
+		/// <summary>
+		/// Update an existing entity of a given entity set.
+		/// </summary>
+		/// <param name="edm_entity_set">The entity set metadata record.</param>
+		/// <param name="key">The primary key of the record that should be modified.</param>
+		/// <param name="record">The entity value to write.</param>
+		/// <returns>An entity instance representing the new entity after it was modified.</returns>
+		/// <remarks>This does a surgical replacement of the record, modifying and adding properties found in the provided record.</remarks>
+		ODATACPP_CLIENT_API pplx::task<std::pair<nullptr_t, http_result>> patch_entity(const ::odata::string_t& entity_set_name, const std::shared_ptr<::odata::core::odata_entity_value>& entity_object);
 
-        /// <summary>
-        /// Add a reference to a collection-valued navigation property.
-        /// </summary>
-        /// <param name="edm_entity_set">The path of the navigation property.</param>
-        /// <param name="key">The id of referenced entity.</param>
-        ODATACPP_CLIENT_API pplx::task<::web::http::status_code> add_reference(const ::utility::string_t& path, const ::utility::string_t& referenceEntityId);
+		/// <summary>
+		/// Replace existing entity of a given entity set.
+		/// </summary>
+		/// <param name="edm_entity_set">The entity set metadata record.</param>
+		/// <param name="key">The primary key of the record that should be modified.</param>
+		/// <param name="record">The entity value to write.</param>
+		/// <returns>An entity instance representing the new entity after it was modified.</returns>
+		/// <remarks>This does a total replacement of the existing entity with a given entity value.</remarks>
+		ODATACPP_CLIENT_API pplx::task<std::pair<nullptr_t, http_result>> put_entity(const ::odata::string_t& entity_set_name, const std::shared_ptr<::odata::core::odata_entity_value>& entity_object);
 
-        /// <summary>
-        /// Remove reference to a collection-valued or single-valued navigation property.
-        /// </summary>
-        /// <param name="edm_entity_set">The path of the navigation property.</param>
-        /// <param name="key">The id of referenced entity if the navigation property is collection-values, or empty if it is single-valued.</param>
-        ODATACPP_CLIENT_API pplx::task<::web::http::status_code> remove_reference(const ::utility::string_t& path, const ::utility::string_t& referenceEntityId);
+		/// <summary>
+		/// Remove an entity from a given entity set.
+		/// </summary>
+		/// <param name="edm_entity_set">The entity set metadata record.</param>
+		/// <param name="key">The primary key of the record that should be deleted.</param>
+		ODATACPP_CLIENT_API pplx::task<std::pair<nullptr_t, http_result>> delete_entity(const ::odata::string_t& entity_set_name, const std::shared_ptr<::odata::core::odata_entity_value>& entity_object);
 
-        /// <summary>
-        /// Update reference to a single-valued navigation property.
-        /// </summary>
-        /// <param name="edm_entity_set">The path of the navigation property.</param>
-        /// <param name="key">The id of referenced entity.</param>
-        ODATACPP_CLIENT_API pplx::task<::web::http::status_code> update_reference(const ::utility::string_t& path, const ::utility::string_t& referenceEntityId);
+		/// <summary>
+		/// Add a reference to a collection-valued navigation property.
+		/// </summary>
+		/// <param name="edm_entity_set">The path of the navigation property.</param>
+		/// <param name="key">The id of referenced entity.</param>
+		ODATACPP_CLIENT_API pplx::task<std::pair<nullptr_t, http_result>> add_reference(const ::odata::string_t& path, const ::odata::string_t& referenceEntityId);
 
-        /// <summary>
-        /// Get odata value of any odata type data defined in edm library including primitive, complex, entity type from server.
-        /// </summary>
-        /// <param name="path">The request path which can be set with select, filter, expand or even function or action options.</param>
-        ODATACPP_CLIENT_API pplx::task<std::vector<std::shared_ptr<::odata::core::odata_value>>> get_data_from_server(const ::utility::string_t& path);
+		/// <summary>
+		/// Remove reference to a collection-valued or single-valued navigation property.
+		/// </summary>
+		/// <param name="edm_entity_set">The path of the navigation property.</param>
+		/// <param name="key">The id of referenced entity if the navigation property is collection-values, or empty if it is single-valued.</param>
+		ODATACPP_CLIENT_API pplx::task<std::pair<nullptr_t, http_result>> remove_reference(const ::odata::string_t& path, const ::odata::string_t& referenceEntityId);
 
-        /// <summary>
-        /// The size of result data of a request maybe too large for one http response, so the server may return the data one page after another
-        /// </summary>
-        /// <param name="path">The request path which can be set with select, filter, expand or even function or action options.</param>
-        /// <param name="path">The result data set.</param>
-        /// <returns>The odata_payload class containing next link url, if no more data next link url is empty.</returns>
-        ODATACPP_CLIENT_API pplx::task<std::shared_ptr<::odata::core::odata_payload>> get_paged_data_from_server(const ::utility::string_t& path);
+		/// <summary>
+		/// Update reference to a single-valued navigation property.
+		/// </summary>
+		/// <param name="edm_entity_set">The path of the navigation property.</param>
+		/// <param name="key">The id of referenced entity.</param>
+		ODATACPP_CLIENT_API pplx::task<std::pair<nullptr_t, http_result>> update_reference(const ::odata::string_t& path, const ::odata::string_t& referenceEntityId);
 
-        /// <summary>
-        /// Send odata value of any odata type data defined in edm library including primitive, complex, entity type to server.
-        /// </summary>
-        /// <param name="path">Path of OData value.</param>
-        /// <param name="send_value">OData value to be sent to the server.</param>
-        /// <param name="send_type">POST, PATCH or PUT options.</param>
-        ODATACPP_CLIENT_API pplx::task<::web::http::status_code> send_data_to_server(const ::utility::string_t& path, const std::shared_ptr<::odata::core::odata_value>& send_value, const ::utility::string_t& send_type = HTTP_POST);
+		/// <summary>
+		/// Get odata value of any odata type data defined in edm library including primitive, complex, entity type from server.
+		/// </summary>
+		/// <param name="path">The request path which can be set with select, filter, expand or even function or action options.</param>
+		ODATACPP_CLIENT_API pplx::task<std::pair<std::vector<std::shared_ptr<::odata::core::odata_value>>, http_result>> get_data_from_server(const ::odata::string_t& path);
 
-        /// <summary>
-        /// Send a vector of odata parameters to server.
-        /// </summary>
-        /// <param name="path">Path to send the parameters, could be function/action path.</param>
-        /// <param name="send_parameters">OData parameters to be sent to the server.</param>
-        /// <param name="send_type">POST, PATCH or PUT options.</param>
-        ODATACPP_CLIENT_API pplx::task<::web::http::status_code> send_data_to_server(const ::utility::string_t& path, const std::vector<std::shared_ptr<::odata::core::odata_parameter>>& send_parameters, std::vector<std::shared_ptr<::odata::core::odata_value>>& returnd_value, const ::utility::string_t& send_type = HTTP_POST);
+		/// <summary>
+		/// The size of result data of a request maybe too large for one http response, so the server may return the data one page after another
+		/// </summary>
+		/// <param name="path">The request path which can be set with select, filter, expand or even function or action options.</param>
+		/// <param name="path">The result data set.</param>
+		/// <returns>The odata_payload class containing next link url, if no more data next link url is empty.</returns>
+		ODATACPP_CLIENT_API pplx::task<std::pair<std::shared_ptr<::odata::core::odata_payload>, http_result>> get_paged_data_from_server(const ::odata::string_t& path);
 
-        /// <summary>
-        /// Send empty data to server.
-        /// </summary>
-        /// <param name="path">Path of OData value.</param>
-        /// <param name="send_type">POST, PATCH or PUT options.</param>
-        ODATACPP_CLIENT_API pplx::task<::web::http::status_code> send_data_to_server(const ::utility::string_t& path, const ::utility::string_t& send_type = HTTP_POST);
-    private:
-        std::shared_ptr<::odata::edm::edm_model> schema_from_response(const ::odata::communication::http_client_response& response);
-        std::shared_ptr<::odata::core::odata_payload> entity_payload_from_response(const ::odata::communication::http_client_response&, const std::shared_ptr<::odata::edm::edm_entity_set>& set);
-        std::shared_ptr<::odata::core::odata_payload> parse_payload_from_response(const ::odata::communication::http_client_response&);
-        pplx::task<std::vector<std::shared_ptr<::odata::core::odata_entity_value>>> get_entities(const std::shared_ptr<::odata::edm::edm_entity_set>& edm_entity_set, const ::utility::string_t& path = U(""));
+		/// <summary>
+		/// Send odata value of any odata type data defined in edm library including primitive, complex, entity type to server.
+		/// </summary>
+		/// <param name="path">Path of OData value.</param>
+		/// <param name="send_value">OData value to be sent to the server.</param>
+		/// <param name="send_type">POST, PATCH or PUT options.</param>
+		ODATACPP_CLIENT_API pplx::task<std::pair<nullptr_t, http_result>> send_data_to_server(const ::odata::string_t& path, const std::shared_ptr<::odata::core::odata_value>& send_value, const ::odata::string_t& send_type = HTTP_POST);
 
-        static std::unordered_map<::utility::string_t, std::shared_ptr<::odata::edm::edm_model>> m_model_cache;
-        std::shared_ptr<::odata::communication::http_client_proxy<::odata::communication::http_client_impl, ::odata::communication::http_client_response>> m_client_proxy;
-        client_options m_options;
-        ::utility::string_t m_service_root_url;
-        std::shared_ptr<::odata::edm::edm_model> m_model;
-    };
+		/// <summary>
+		/// Send a vector of odata parameters to server.
+		/// </summary>
+		/// <param name="path">Path to send the parameters, could be function/action path.</param>
+		/// <param name="send_parameters">OData parameters to be sent to the server.</param>
+		/// <param name="send_type">POST, PATCH or PUT options.</param>
+		ODATACPP_CLIENT_API pplx::task<std::pair<nullptr_t, http_result>> send_data_to_server(const ::odata::string_t& path, const std::vector<std::shared_ptr<::odata::core::odata_parameter>>& send_parameters, std::vector<std::shared_ptr<::odata::core::odata_value>>& returned_value, const ::odata::string_t& send_type = HTTP_POST);
+
+		/// <summary>
+		/// Send empty data to server.
+		/// </summary>
+		/// <param name="path">Path of OData value.</param>
+		/// <param name="send_type">POST, PATCH or PUT options.</param>
+		ODATACPP_CLIENT_API pplx::task<std::pair<nullptr_t, http_result>> send_data_to_server(const ::odata::string_t& path, const ::odata::string_t& send_type = HTTP_POST);
+	private:
+		std::shared_ptr<::odata::edm::edm_model> schema_from_response(const ::odata::communication::http_client_response& response);
+		std::shared_ptr<::odata::core::odata_payload> entity_payload_from_response(const ::odata::communication::http_client_response&, const std::shared_ptr<::odata::edm::edm_entity_set>& set);
+		std::shared_ptr<::odata::core::odata_payload> parse_payload_from_response(const ::odata::communication::http_client_response&);
+		pplx::task<std::pair<std::vector<std::shared_ptr<::odata::core::odata_entity_value>>, http_result>> get_entities(const std::shared_ptr<::odata::edm::edm_entity_set>& edm_entity_set, const ::odata::string_t& path = _XPLATSTR(""));
+
+		static std::unordered_map<::odata::string_t, std::shared_ptr<::odata::edm::edm_model>> m_model_cache;
+		std::shared_ptr<::odata::communication::http_client_proxy<::odata::communication::http_client_impl, ::odata::communication::http_client_response>> m_client_proxy;
+		client_options m_options;
+		::odata::string_t m_service_root_url;
+		std::shared_ptr<::odata::edm::edm_model> m_model;
+
+		web::http::http_headers m_model_response_headers; //!< The http headers from the query for the model. These are kept separately as every command used will automatically query the model.
+
+	public:
+		void clear_request_header()
+		{
+			m_client_proxy->clear_request_header();
+		}
+		bool has_request_header(const ::odata::string_t& name) const
+		{
+			return m_client_proxy->has_request_header(name);
+		}
+		void add_request_header(const ::odata::string_t& name, const ::odata::string_t& value)
+		{
+			m_client_proxy->add_request_header(name, value);
+		}
+		void remove_request_header(const ::odata::string_t& name)
+		{
+			m_client_proxy->remove_request_header(name);
+		}
+		::odata::string_t match_request_header(const ::odata::string_t& name) const
+		{
+			return m_client_proxy->match_request_header(name);
+		}
+
+		web::http::http_headers const& get_model_response_header() const
+		{
+			return m_model_response_headers;
+		}
+		bool has_model_response_header(const ::odata::string_t& name) const
+		{
+			return m_model_response_headers.has(name);
+		}
+		::odata::string_t match_model_response_header(const ::odata::string_t& name) const
+		{
+			::odata::string_t value;
+			m_model_response_headers.match(name, value);
+			return value;
+		}
+
+		bool clear_metadata_model()
+		{
+			auto find_iter = m_model_cache.find(m_service_root_url);
+			if (find_iter == m_model_cache.end())
+			{
+				return false;
+			}
+
+			// Erase the model from the cache and from the instance itself
+			m_model_cache.erase(find_iter);
+			m_model.reset();
+			return true;
+		}
+
+		bool get_supress_odata_type() const
+		{
+			return m_options.get_suppress_odata_type();
+		}
+
+		void set_supress_odata_type(bool suppress_odata_type)
+		{
+			m_options.set_suppress_odata_type(suppress_odata_type);
+		}
+
+	// Logging capability for http responses. Be careful when using, this is a comment from
+	// the casablanca REST SDK method to_string():
+	// "Generates a string representation of the message, including the body when possible.
+	// Mainly this should be used for debugging purposes as it has to copy the message body
+	// and doesn't have excellent performance."
+	// Thus besides setting the callback itself we have a separate callback that needs to
+	// check in advance if any logging should happen, preventing th call to to_string()
+	// if logging is disabled by some means (e. g. logging level).
+	private:
+		std::function<bool()>                                                                       m_ShallLogCallback;
+		std::function<void(wchar_t const*, wchar_t const*, size_t, bool, ::odata::string_t const&)> m_LogCallback;
+
+		void doLog(wchar_t const* Function, wchar_t const *File, size_t Line, web::http::http_response const &response) const
+		{
+			if (m_LogCallback && m_ShallLogCallback && m_ShallLogCallback())
+			{
+				m_LogCallback(Function, File, Line, false, response.to_string()); // false == This is a response
+			}
+		}
+
+	public:
+		void SetLogCallbacks(std::function<bool()> ShallLogCallback, std::function<void(wchar_t const*, wchar_t const*, size_t, bool, ::odata::string_t const &)> LogCallback)
+		{
+			if (ShallLogCallback && LogCallback)
+			{
+				m_ShallLogCallback = ShallLogCallback;
+				m_LogCallback      = LogCallback;
+			}
+			else
+			{
+				m_ShallLogCallback = nullptr;
+				m_LogCallback      = nullptr;
+			}
+			m_client_proxy->SetLogCallbacks(ShallLogCallback, LogCallback);
+		}
+	};
 
 }}

--- a/include/odata/client/odata_client_options.h
+++ b/include/odata/client/odata_client_options.h
@@ -13,24 +13,24 @@ namespace odata { namespace client {
 class odata_client_credential
 {
 public:
-	odata_client_credential(::utility::string_t username, ::utility::string_t password) :
+	odata_client_credential(::odata::string_t username, ::odata::string_t password) :
 		m_username(std::move(username)), m_password(std::move(password))
 	{
 	}
 
-	const ::utility::string_t& get_username() const
+	const ::odata::string_t& get_username() const
 	{
 		return m_username;
 	}
 
-	const ::utility::string_t& get_password() const
+	const ::odata::string_t& get_password() const
 	{
 		return m_password;
 	}
 
 private:
-	::utility::string_t m_username;
-	::utility::string_t m_password;
+	::odata::string_t m_username;
+	::odata::string_t m_password;
 };
 
 /// <summary>
@@ -41,45 +41,45 @@ class odata_client;
 class client_options
 {
 public:
-    /// <summary>
-    /// Represents options used when creating an OData client instance.
-    /// </summary>
-	client_options() : m_prefer_json(true), m_verb_tunneling(false),m_json_mdlevel(U("minimal")), m_credential(nullptr)
-    {
-    }
-
-    /// <summary>
-    /// Sets the client to request responses formatted as JSON, when applicable
-    /// </summary>
-    client_options prefer_json(::utility::string_t mdlevel = U("minimal"))
-    {
-        m_prefer_json = true;
-        m_json_mdlevel = mdlevel;
-        return *this;
-    }
-
-    /// <summary>
-    /// Sets the client to request responses formatted as an Atom feed, when applicable
-    /// </summary>
-    client_options prefer_atom()
-    {
-        m_prefer_json = false;
-        m_json_mdlevel.clear();
-        return *this;
-    }
-
-    /// <summary>
-    /// Use verb tunneling when making non-GET/POST requests.
-    /// </summary>
-    client_options do_verb_tunneling()
-    {
-        m_verb_tunneling = true;
-        return *this;
-    }
-
-	void enable_client_credential(::utility::string_t username, ::utility::string_t password)
+	/// <summary>
+	/// Represents options used when creating an OData client instance.
+	/// </summary>
+	client_options() : m_prefer_json(true), m_verb_tunneling(false), m_json_mdlevel(_XPLATSTR("minimal")), m_credential(nullptr), m_suppress_odata_type(false)
 	{
-		m_credential = std::make_shared<odata_client_credential>(std::move(username), std::move(password));
+	}
+
+	/// <summary>
+	/// Sets the client to request responses formatted as JSON, when applicable
+	/// </summary>
+	client_options prefer_json(::odata::string_t mdlevel = _XPLATSTR("minimal"))
+	{
+		m_prefer_json = true;
+		m_json_mdlevel = mdlevel;
+		return *this;
+	}
+
+	/// <summary>
+	/// Sets the client to request responses formatted as an Atom feed, when applicable
+	/// </summary>
+	client_options prefer_atom()
+	{
+		m_prefer_json = false;
+		m_json_mdlevel.clear();
+		return *this;
+	}
+
+	/// <summary>
+	/// Use verb tunneling when making non-GET/POST requests.
+	/// </summary>
+	client_options do_verb_tunneling()
+	{
+		m_verb_tunneling = true;
+		return *this;
+	}
+
+	void enable_client_credential(::odata::string_t username, ::odata::string_t password)
+	{
+		m_credential = ::odata::make_shared<odata_client_credential>(std::move(username), std::move(password));
 	}
 
 	void disable_client_credential()
@@ -87,18 +87,29 @@ public:
 		m_credential = nullptr;
 	}
 
-	const std::shared_ptr<odata_client_credential>& get_credential_setting()
+	void set_suppress_odata_type(bool SuppressODataType)
+	{
+		m_suppress_odata_type = SuppressODataType;
+	}
+
+	const std::shared_ptr<odata_client_credential>& get_credential_setting() const
 	{
 		return m_credential;
+	}
+
+	bool get_suppress_odata_type() const
+	{
+		return m_suppress_odata_type;
 	}
 
 private:
 	friend class odata_client;
 
-    bool m_prefer_json;
-    bool m_verb_tunneling;
-    ::utility::string_t m_json_mdlevel;
+	bool                                     m_prefer_json;
+	bool                                     m_verb_tunneling;
+	::odata::string_t                        m_json_mdlevel;
 	std::shared_ptr<odata_client_credential> m_credential;
+	bool                                     m_suppress_odata_type;
 };
 
 }}

--- a/include/odata/codegen/code_generation.h
+++ b/include/odata/codegen/code_generation.h
@@ -15,111 +15,85 @@
 #include "odata/core/odata_core.h"
 #include "odata/core/odata_json_writer.h"
 
-namespace odata { namespace codegen { 
+namespace odata { namespace codegen {
 
 #define DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(property_name, edm_name, type) \
 public: \
-    const type& get_##property_name() { return property_name; } const \
+	const type& get_##property_name() const { return property_name; } \
 	void set_##property_name(const type& property_value) { property_name = property_value; } \
 protected: \
-	type property_name;  \
-    void get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
+	type property_name; \
+	void get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
 	void set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity);
 
 #define IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(myclass, property_name, edm_name, type) \
-    void myclass::get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
+	void myclass::get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
-        std::shared_ptr<::odata::core::odata_value> property_value; \
-		if (!pentity->get_property_value(U(#edm_name), property_value) || !property_value) \
-	    { \
-			return ; \
+		std::shared_ptr<::odata::core::odata_value> property_value; \
+		if (!pentity->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
+		{ \
+			return; \
 		} \
 		auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value); \
-	    if (primitive_value) \
-	    { \
-            property_name = primitive_value->as<type>(); \
-        } \
-    } \
+		if (primitive_value) \
+		{ \
+			property_name = primitive_value->as<type>(); \
+		} \
+	} \
 	void myclass::set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
-	    if (!pentity) \
-	    { \
-		    return ; \
-        } \
-		pentity->set_value(U(#edm_name), property_name); \
+		if (!pentity) \
+		{ \
+			return; \
+		} \
+		pentity->set_value(_XPLATSTR(#edm_name), property_name); \
 	}
-
-// because we have to support derived complex type, so complex object in entity are all set with pointer type
-#define DECLARE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(property_name, edm_name, type) \
-    DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(property_name, edm_name, type)
-
-#define IMPLEMENT_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(myclass, property_name, edm_name, type) \
-	IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(myclass, property_name, edm_name, type)
 
 #define DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(property_name, edm_name, type) \
 public : \
-	const type& get_##property_name() { return property_name; } const \
+	const type& get_##property_name() const { return property_name; } \
 	void set_##property_name(const type& property_value) { property_name = property_value; } \
 protected: \
-    type property_name;  \
-    void get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); \
+	type property_name; \
+	void get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); \
 	void set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex);
 
 #define IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(myclass, property_name, edm_name, type) \
-    void myclass::get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
+	void myclass::get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
 	{ \
-	    std::shared_ptr<::odata::core::odata_value> property_value; \
-        if (!pcomplex->get_property_value(U(#edm_name), property_value) || !property_value) \
-	    { \
-			return ; \
+		std::shared_ptr<::odata::core::odata_value> property_value; \
+		if (!pcomplex->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
+		{ \
+			return; \
 		} \
 		auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value); \
-	    if (primitive_value) \
-	    { \
-            property_name = primitive_value->as<type>(); \
-        } \
-    }\
+		if (primitive_value) \
+		{ \
+			property_name = primitive_value->as<type>(); \
+		} \
+	}\
 	void myclass::set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
 	{ \
-	    if (!pcomplex) \
-	    { \
-		    return ; \
-        } \
-		pcomplex->set_value(U(#edm_name), property_name); \
+		if (!pcomplex) \
+		{ \
+			return; \
+		} \
+		pcomplex->set_value(_XPLATSTR(#edm_name), property_name); \
 	}
-
-#define IMPLEMENT_EDM_INFO(myclass, name_space, type_name) \
-	::utility::string_t myclass::m_namespace = U(#name_space); \
-	::utility::string_t myclass::m_typename = U(#type_name); \
-	::utility::string_t myclass::get_full_name() \
-    { \
-        return myclass::m_namespace + U(".") + myclass::m_typename; \
-	} \
-    ::utility::string_t myclass::get_type_name() \
-	{ \
-		return m_typename; \
-	}
-
-#define DECLARE_ENTITY_CONSTRUCTOR(myclass) \
-	public: \
-	myclass(const std::shared_ptr<odata_service_context>& service_context); \
-	::utility::string_t get_root_url() { return m_service_context ? m_service_context->get_root_url() : U(""); } \
-    static create_map_for_entity_type::value_type _init_creator_map_values[]; \
-	static std::unordered_map<::utility::string_t, CREATE_CALL_FOR_ENTITY> _derived_entity_creator_map; 
 
 #define ENABLE_PROPERTY_IN_ENTITY_MAPPING() \
 public: \
-    void from_value(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
+	void from_value(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
 	virtual std::shared_ptr<::odata::core::odata_entity_value> to_value(); \
 	PROPMAP_ENTRY_IN_ENTITY* get_to_entity_map(); \
 	void set_to_entity_map(PROPMAP_ENTRY_IN_ENTITY* _map); \
 protected: \
-    static PROPMAP_ENTRY_IN_ENTITY _property_entrties[]; \
-    PROPMAP_ENTRY_IN_ENTITY* get_mapping_map(); \
-	static PROPMAP_ENTRY_IN_ENTITY _map_class_to_entity_entrties[]; \
+	static PROPMAP_ENTRY_IN_ENTITY _property_entries[]; \
+	PROPMAP_ENTRY_IN_ENTITY* get_mapping_map(); \
+	static PROPMAP_ENTRY_IN_ENTITY _map_class_to_entity_entries[]; \
 	PROPMAP_ENTRY_IN_ENTITY* m_to_entity_map; \
 	void map_entity_value_to_class_member(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
-	void map_class_member_to_entity_value(const std::shared_ptr<::odata::core::odata_entity_value>& entity_value); 
+	void map_class_member_to_entity_value(const std::shared_ptr<::odata::core::odata_entity_value>& entity_value);
 
 #define ENABLE_PROPERTY_IN_COMPLEX_MAPPING() \
 public: \
@@ -128,192 +102,210 @@ public: \
 	PROPMAP_ENTRY_IN_COMPLEX* get_to_complex_map(); \
 	void set_to_complex_map(PROPMAP_ENTRY_IN_COMPLEX* _map); \
 protected: \
-    static PROPMAP_ENTRY_IN_COMPLEX _property_entrties[]; \
-    PROPMAP_ENTRY_IN_COMPLEX* get_mapping_map(); \
-	static PROPMAP_ENTRY_IN_COMPLEX _map_class_to_complex_entrties[]; \
+	static PROPMAP_ENTRY_IN_COMPLEX _property_entries[]; \
+	PROPMAP_ENTRY_IN_COMPLEX* get_mapping_map(); \
+	static PROPMAP_ENTRY_IN_COMPLEX _map_class_to_complex_entries[]; \
 	PROPMAP_ENTRY_IN_COMPLEX* m_to_complex_map; \
 	void map_complex_value_to_class_member(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); \
-	void map_class_member_to_complex_value(const std::shared_ptr<::odata::core::odata_complex_value>& complex_value); 
+	void map_class_member_to_complex_value(const std::shared_ptr<::odata::core::odata_complex_value>& complex_value);
 
 
 #define DECLARE_EDM_INFO() \
-    protected: \
-	static ::utility::string_t m_namespace; \
-	static ::utility::string_t m_typename; \
+	protected: \
+	static ::odata::string_t m_namespace; \
+	static ::odata::string_t m_typename; \
 	public: \
-	static ::utility::string_t get_full_name(); \
-	static ::utility::string_t get_type_name(); \
+	static ::odata::string_t get_full_name(); \
+	static ::odata::string_t get_type_name();
+
+#define IMPLEMENT_EDM_INFO(myclass, name_space, type_name) \
+	::odata::string_t myclass::m_namespace = _XPLATSTR(#name_space); \
+	::odata::string_t myclass::m_typename = _XPLATSTR(#type_name); \
+	::odata::string_t myclass::get_full_name() \
+	{ \
+		return myclass::m_namespace + _XPLATSTR(".") + myclass::m_typename; \
+	} \
+	::odata::string_t myclass::get_type_name() \
+	{ \
+		return m_typename; \
+	}
 
 #define BEGIN_PROPERTY_IN_ENTITY_MAPPING(myclass) \
-    PROPMAP_ENTRY_IN_ENTITY* myclass::get_mapping_map()  \
-    { \
-        return _property_entrties;  \
-    } \
+	PROPMAP_ENTRY_IN_ENTITY* myclass::get_mapping_map() \
+	{ \
+		return _property_entries; \
+	} \
 	PROPMAP_ENTRY_IN_ENTITY* myclass::get_to_entity_map() \
 	{ \
-	    if (!m_to_entity_map) \
-	        m_to_entity_map = _map_class_to_entity_entrties; \
-	    return m_to_entity_map;  \
+		if (!m_to_entity_map) \
+			m_to_entity_map = _map_class_to_entity_entries; \
+		return m_to_entity_map; \
 	} \
 	void myclass::set_to_entity_map(PROPMAP_ENTRY_IN_ENTITY* _map) \
 	{ \
-	    m_to_entity_map = _map; \
+	m_to_entity_map = _map; \
 	} \
-    PROPMAP_ENTRY_IN_ENTITY myclass::_property_entrties[] =   \
-    {
+	PROPMAP_ENTRY_IN_ENTITY myclass::_property_entries[] = \
+	{
 
 #define BEGIN_PROPERTY_IN_ENTITY_MAPPING_WITH_BASE_CLASS(myclass, parentclass) \
-    BEGIN_PROPERTY_IN_ENTITY_MAPPING(myclass)
+	BEGIN_PROPERTY_IN_ENTITY_MAPPING(myclass)
 
 #define END_PROPERTY_IN_ENTITY_MAPPING(myclass) \
-        {(PROP_MAP_CALL_IN_ENTITY)0}   \
-    };  \
+		{(PROP_MAP_CALL_IN_ENTITY)0} \
+	}; \
 	std::shared_ptr<::odata::core::odata_entity_value> myclass::to_value() \
 	{ \
-	    if (!m_service_context || !m_service_context->get_edm_model()) { return nullptr; } \
-	    auto entity_type = m_service_context->get_edm_model()->find_entity_type(m_typename); \
-		auto entity_value = std::make_shared<::odata::core::odata_entity_value>(entity_type); \
+		if (!m_service_context || !m_service_context->get_edm_model()) { return nullptr; } \
+		auto entity_type = m_service_context->get_edm_model()->find_entity_type(m_typename); \
+		auto entity_value = ::odata::make_shared<::odata::core::odata_entity_value>(entity_type); \
 		map_class_member_to_entity_value(entity_value); \
 		if (!m_namespace.empty() && !m_typename.empty()) \
-        { \
-		    entity_value->set_value(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE, std::make_shared<odata_primitive_value>(std::make_shared<::odata::edm::edm_payload_annotation_type>(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE), U("#") + m_namespace + U(".") + m_typename)); \
-	    } \
+		{ \
+			entity_value->set_value(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE, ::odata::make_shared<odata_primitive_value>(::odata::make_shared<::odata::edm::edm_payload_annotation_type>(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE), _XPLATSTR("#") + m_namespace + _XPLATSTR(".") + m_typename)); \
+		} \
 		return entity_value; \
 	} \
-    void myclass::from_value(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
+	void myclass::from_value(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
-	    map_entity_value_to_class_member(pentity); \
+		map_entity_value_to_class_member(pentity); \
 	}
 
 #define END_PROPERTY_IN_ENTITY_MAPPING_WITH_BASE_CLASS(myclass, parentclass) \
-        {(PROP_MAP_CALL_IN_ENTITY)0}   \
-    };  \
+		{(PROP_MAP_CALL_IN_ENTITY)0} \
+	}; \
 	std::shared_ptr<::odata::core::odata_entity_value> myclass::to_value() \
 	{ \
-	    if (!m_service_context || !m_service_context->get_edm_model()) { return nullptr; } \
+		if (!m_service_context || !m_service_context->get_edm_model()) { return nullptr; } \
 		auto entity_value = parentclass::to_value(); \
-	    auto entity_type = m_service_context->get_edm_model()->find_entity_type(m_typename); \
+		auto entity_type = m_service_context->get_edm_model()->find_entity_type(m_typename); \
 		entity_value->set_value_type(entity_type); \
 		map_class_member_to_entity_value(entity_value); \
 		if (!m_namespace.empty() && !m_typename.empty()) \
-        { \
-entity_value->set_value(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE, std::make_shared<odata_primitive_value>(std::make_shared<::odata::edm::edm_payload_annotation_type>(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE), U("#") + m_namespace + U(".") + m_typename)); \
-	    } \
+		{ \
+entity_value->set_value(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE, ::odata::make_shared<odata_primitive_value>(::odata::make_shared<::odata::edm::edm_payload_annotation_type>(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE), _XPLATSTR("#") + m_namespace + _XPLATSTR(".") + m_typename)); \
+		} \
 		return entity_value; \
 	} \
-    void myclass::from_value(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
+	void myclass::from_value(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
-	    parentclass::from_value(pentity); \
-	    map_entity_value_to_class_member(pentity); \
+		parentclass::from_value(pentity); \
+		map_entity_value_to_class_member(pentity); \
 	}
 
 #define ON_PROPERTY_IN_ENTITY_MAPPING(myclass, property_name) \
-	{(PROP_MAP_CALL_IN_ENTITY)&myclass::get_##property_name##_from_entity},   
+	{(PROP_MAP_CALL_IN_ENTITY)&myclass::get_##property_name##_from_entity},
+
+#define ON_OPEN_PROPERTY_IN_ENTITY_MAPPING(myclass) \
+	{(PROP_MAP_CALL_IN_ENTITY)&myclass::get_open_properties_from_entity},
 
 #define BEGIN_PROPERTY_IN_COMPLEX_MAPPING(myclass) \
-    PROPMAP_ENTRY_IN_COMPLEX* myclass::get_mapping_map()  \
-    { \
-        return _property_entrties;  \
-    } \
+	PROPMAP_ENTRY_IN_COMPLEX* myclass::get_mapping_map() \
+	{ \
+		return _property_entries; \
+	} \
 	PROPMAP_ENTRY_IN_COMPLEX* myclass::get_to_complex_map() \
 	{ \
-	    if (!m_to_complex_map) \
-	        m_to_complex_map = _map_class_to_complex_entrties; \
-	    return m_to_complex_map;  \
+		if (!m_to_complex_map) \
+			m_to_complex_map = _map_class_to_complex_entries; \
+		return m_to_complex_map; \
 	} \
 	void myclass::set_to_complex_map(PROPMAP_ENTRY_IN_COMPLEX* _map) \
 	{ \
-	    m_to_complex_map = _map; \
+		m_to_complex_map = _map; \
 	} \
-    PROPMAP_ENTRY_IN_COMPLEX myclass::_property_entrties[] =   \
-    {   
+	PROPMAP_ENTRY_IN_COMPLEX myclass::_property_entries[] = \
+	{
 
 #define BEGIN_PROPERTY_IN_COMPLEX_MAPPING_WITH_BASE_CLASS(myclass, parentclass) \
 	BEGIN_PROPERTY_IN_COMPLEX_MAPPING(myclass)
 
 #define END_PROPERTY_IN_COMPLEX_MAPPING(myclass) \
-        {(PROP_MAP_CALL_IN_COMPLEX)0 }   \
-    };  \
+		{(PROP_MAP_CALL_IN_COMPLEX)0 } \
+	}; \
 	std::shared_ptr<::odata::core::odata_complex_value> myclass::to_value() \
 	{ \
-	    if (!m_service_context || !m_service_context->get_edm_model()) { return nullptr; } \
-	    auto complex_type = m_service_context->get_edm_model()->find_complex_type(m_typename); \
-		auto complex_value = std::make_shared<::odata::core::odata_complex_value>(complex_type); \
+		if (!m_service_context || !m_service_context->get_edm_model()) { return nullptr; } \
+		auto complex_type = m_service_context->get_edm_model()->find_complex_type(m_typename); \
+		auto complex_value = ::odata::make_shared<::odata::core::odata_complex_value>(complex_type); \
 		map_class_member_to_complex_value(complex_value); \
 		if (!m_namespace.empty() && !m_typename.empty()) \
-        { \
-		    complex_value->set_value(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE, std::make_shared<odata_primitive_value>(std::make_shared<::odata::edm::edm_payload_annotation_type>(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE), U("#") + m_namespace + U(".") + m_typename)); \
-	    } \
+		{ \
+			complex_value->set_value(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE, ::odata::make_shared<odata_primitive_value>(::odata::make_shared<::odata::edm::edm_payload_annotation_type>(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE), _XPLATSTR("#") + m_namespace + _XPLATSTR(".") + m_typename)); \
+		} \
 		return complex_value; \
 	} \
 	void myclass::from_value(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
 	{ \
-	    map_complex_value_to_class_member(pcomplex); \
+		map_complex_value_to_class_member(pcomplex); \
 	}
 
 #define END_PROPERTY_IN_COMPLEX_MAPPING_WITH_BASE_CLASS(myclass, parentclass) \
-        {(PROP_MAP_CALL_IN_COMPLEX)0 }   \
-    };  \
+	{(PROP_MAP_CALL_IN_COMPLEX)0 } \
+	}; \
 	std::shared_ptr<::odata::core::odata_complex_value> myclass::to_value() \
 	{ \
-	    if (!m_service_context || !m_service_context->get_edm_model()) { return nullptr; } \
-	    auto complex_type = m_service_context->get_edm_model()->find_complex_type(m_typename); \
+		if (!m_service_context || !m_service_context->get_edm_model()) { return nullptr; } \
+		auto complex_type = m_service_context->get_edm_model()->find_complex_type(m_typename); \
 		auto complex_value = parentclass::to_value(); \
 		complex_value->set_value_type(complex_type); \
 		map_class_member_to_complex_value(complex_value); \
 		if (!m_namespace.empty() && !m_typename.empty()) \
-        { \
-		    complex_value->set_value(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE, std::make_shared<odata_primitive_value>(std::make_shared<::odata::edm::edm_payload_annotation_type>(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE), U("#") + m_namespace + U(".") + m_typename)); \
-	    } \
+		{ \
+			complex_value->set_value(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE, ::odata::make_shared<odata_primitive_value>(::odata::make_shared<::odata::edm::edm_payload_annotation_type>(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE), _XPLATSTR("#") + m_namespace + _XPLATSTR(".") + m_typename)); \
+		} \
 		return complex_value; \
 	} \
 	void myclass::from_value(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
 	{ \
-	    parentclass::from_value(pcomplex); \
-	    map_complex_value_to_class_member(pcomplex); \
+		parentclass::from_value(pcomplex); \
+		map_complex_value_to_class_member(pcomplex); \
 	}
 
 #define ON_PROPERTY_IN_COMPLEX_MAPPING(myclass, property_name) \
 	{(PROP_MAP_CALL_IN_COMPLEX)&myclass::get_##property_name##_from_complex}, \
+
+#define ON_OPEN_PROPERTY_IN_COMPLEX_MAPPING(myclass) \
+	{(PROP_MAP_CALL_IN_COMPLEX)&myclass::get_open_properties_from_complex}, \
+
+#define DECLARE_ENTITY_CONSTRUCTOR(myclass) \
+	public: \
+	myclass(const std::shared_ptr<odata_service_context>& service_context); \
+	::odata::string_t get_root_url() { return m_service_context ? m_service_context->get_root_url() : _XPLATSTR(""); } \
+	static create_map_for_entity_type::value_type _init_creator_map_values[]; \
+	static std::unordered_map<::odata::string_t, CREATE_CALL_FOR_ENTITY> _derived_entity_creator_map;
 
 #define BEGIN_ENTITY_CONSTRUCTOR(myclass, baseclass) \
 	myclass::myclass(const std::shared_ptr<odata_service_context>& service_context) \
 	: baseclass(service_context), m_to_entity_map(nullptr)
 
 #define ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(property_name, property_value) \
-	    , property_name(property_value)
+		, property_name(property_value)
+
+#define ON_OPEN_PROPERTY_IN_ENTITY_CONSTRUCTOR() \
+		, open_property_dictionary()
 
 #define END_ENTITY_CONSTRUCTOR(myclass, baseclass) \
-	{ } 
+	{ }
 
 #define DECLARE_COMPLEX_CONSTRUCTOR(myclass) \
 	public: \
 	myclass(const std::shared_ptr<odata_service_context>& service_context); \
-    static create_map_for_complex_type::value_type _init_creator_map_values[]; \
-	static std::unordered_map<::utility::string_t, CREATE_CALL_FOR_COMPLEX> _derived_complex_creator_map; 
+	static create_map_for_complex_type::value_type _init_creator_map_values[]; \
+	static std::unordered_map<::odata::string_t, CREATE_CALL_FOR_COMPLEX> _derived_complex_creator_map;
 
 #define BEGIN_COMPLEX_CONSTRUCTOR(myclass, baseclass) \
 	myclass::myclass(const std::shared_ptr<odata_service_context>& service_context) \
-	    : baseclass(service_context), m_to_complex_map(nullptr)
+	: baseclass(service_context), m_to_complex_map(nullptr)
 
 #define ON_PROPERTY_IN_COMPLEX_CONSTRUCTOR(property_name, property_value) \
-	    , property_name(property_value)
+		, property_name(property_value)
+
+#define ON_OPEN_PROPERTY_IN_COMPLEX_CONSTRUCTOR() \
+		, open_property_dictionary()
 
 #define END_COMPLEX_CONSTRUCTOR(myclass, baseclass) \
-    { } 
-
-#define DECLARE_COMPLEX_DESTRUCTOR(myclass) \
-	public: \
-	~myclass();
-
-#define BEGIN_COMPLEX_DESTRUCTOR(myclass) \
-	myclass::~myclass() \
-	{ 
-
-#define ON_PROPERTY_IN_COMPLEX_DESTRUCTOR(property_name) 
-
-#define END_COMPLEX_DESTRUCTOR(myclass) \
-	}
+	{ }
 
 #define DECLARE_ENTITY_DESTRUCTOR(myclass) \
 	public: \
@@ -321,65 +313,50 @@ entity_value->set_value(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_
 
 #define BEGIN_ENTITY_DESTRUCTOR(myclass) \
 	myclass::~myclass() \
-	{ 
+	{
 
 #define ON_PROPERTY_IN_ENTITY_DESTRUCTOR(property_name)
+
+#define ON_OPEN_PROPERTY_IN_ENTITY_DESTRUCTOR()
 
 #define END_ENTITY_DESTRUCTOR(myclass) \
 	}
 
-#define BEGIN_SERIALIZE_PROPERTY_IN_COMPLEX_MAPPING(myclass) \
-	PROPMAP_ENTRY_IN_COMPLEX myclass::_map_class_to_complex_entrties[] =   \
-    { 
+#define DECLARE_COMPLEX_DESTRUCTOR(myclass) \
+	public: \
+	~myclass();
 
-#define ON_SERIALIZE_PROPERTY_IN_COMPLEX_MAPPING(myclass, property_name) \
-	    {(PROP_MAP_CALL_IN_COMPLEX)&myclass::set_##property_name##_to_complex},
+#define BEGIN_COMPLEX_DESTRUCTOR(myclass) \
+	myclass::~myclass() \
+	{
 
-#define END_SERIALIZE_PROPERTY_IN_COMPLEX_MAPPING(myclass) \
-	    {(PROP_MAP_CALL_IN_COMPLEX)0} \
-	}; \
-	void myclass::map_complex_value_to_class_member(const shared_ptr<::odata::core::odata_complex_value>& pentity) \
-	{ \
-		for (int i = 0;; i++) \
-		{ \
-			PROPMAP_ENTRY_IN_COMPLEX pentry = get_mapping_map()[i]; \
-			if (pentry.pfn == 0) \
-			{ \
-				break; \
-			} \
-			(this->*((PROP_MAP_CALL_IN_COMPLEX)pentry.pfn))(pentity); \
-		} \
-	} \
-	void myclass::map_class_member_to_complex_value(const std::shared_ptr<::odata::core::odata_complex_value>& complex_value) \
-	{ \
-		for (int i = 0;; i++) \
-		{ \
-			PROPMAP_ENTRY_IN_COMPLEX pentry = get_to_complex_map()[i]; \
-			if (pentry.pfn == 0) \
-			{ \
-				break; \
-			} \
-			(this->*((PROP_MAP_CALL_IN_COMPLEX)pentry.pfn))(complex_value); \
-		} \
+#define ON_PROPERTY_IN_COMPLEX_DESTRUCTOR(property_name)
+
+#define ON_OPEN_PROPERTY_IN_COMPLEX_DESTRUCTOR()
+
+#define END_COMPLEX_DESTRUCTOR(myclass) \
 	}
 
 #define BEGIN_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(myclass) \
-	PROPMAP_ENTRY_IN_ENTITY myclass::_map_class_to_entity_entrties[] =   \
-    { 
+	PROPMAP_ENTRY_IN_ENTITY myclass::_map_class_to_entity_entries[] = \
+	{
 
 #define ON_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(myclass, property_name) \
-	    {(PROP_MAP_CALL_IN_ENTITY)&myclass::set_##property_name##_to_entity},
+		{(PROP_MAP_CALL_IN_ENTITY)&myclass::set_##property_name##_to_entity},
+
+#define ON_SERIALIZE_OPEN_PROPERTY_IN_ENTITY_MAPPING(myclass) \
+		{(PROP_MAP_CALL_IN_ENTITY)&myclass::set_open_properties_to_entity},
 
 #define END_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(myclass) \
-	    {(PROP_MAP_CALL_IN_ENTITY)0} \
+		{(PROP_MAP_CALL_IN_ENTITY)0} \
 	}; \
 	void myclass::map_entity_value_to_class_member(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
-	    if (m_edit_link.empty()) \
-	    { \
-		    m_edit_link = odata_entity_model_builder::compute_edit_link(get_root_url(), pentity, U(""), false); \
+		if (m_edit_link.empty()) \
+		{ \
+			m_edit_link = odata_entity_model_builder::compute_edit_link(get_root_url(), pentity, _XPLATSTR(""), false); \
 		} \
-		for (int i = 0;; i++) \
+		for (size_t i = 0;; ++i) \
 		{ \
 			PROPMAP_ENTRY_IN_ENTITY pentry = get_mapping_map()[i]; \
 			if (pentry.pfn == 0) \
@@ -391,7 +368,7 @@ entity_value->set_value(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_
 	} \
 	void myclass::map_class_member_to_entity_value(const std::shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
-		for (int i = 0;; i++) \
+		for (size_t i = 0;; ++i) \
 		{ \
 			PROPMAP_ENTRY_IN_ENTITY pentry = get_to_entity_map()[i]; \
 			if (pentry.pfn == 0) \
@@ -402,50 +379,189 @@ entity_value->set_value(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_
 		} \
 	}
 
+#define BEGIN_SERIALIZE_PROPERTY_IN_COMPLEX_MAPPING(myclass) \
+	PROPMAP_ENTRY_IN_COMPLEX myclass::_map_class_to_complex_entries[] = \
+	{
+
+#define ON_SERIALIZE_PROPERTY_IN_COMPLEX_MAPPING(myclass, property_name) \
+		{(PROP_MAP_CALL_IN_COMPLEX)&myclass::set_##property_name##_to_complex},
+
+#define ON_SERIALIZE_OPEN_PROPERTY_IN_COMPLEX_MAPPING(myclass) \
+		{(PROP_MAP_CALL_IN_COMPLEX)&myclass::set_open_properties_to_complex},
+
+#define END_SERIALIZE_PROPERTY_IN_COMPLEX_MAPPING(myclass) \
+		{(PROP_MAP_CALL_IN_COMPLEX)0} \
+	}; \
+	void myclass::map_complex_value_to_class_member(const shared_ptr<::odata::core::odata_complex_value>& pentity) \
+	{ \
+		for (size_t i = 0;; ++i) \
+		{ \
+			PROPMAP_ENTRY_IN_COMPLEX pentry = get_mapping_map()[i]; \
+			if (pentry.pfn == 0) \
+			{ \
+				break; \
+			} \
+			(this->*((PROP_MAP_CALL_IN_COMPLEX)pentry.pfn))(pentity); \
+		} \
+	} \
+	void myclass::map_class_member_to_complex_value(const std::shared_ptr<::odata::core::odata_complex_value>& complex_value) \
+	{ \
+		for (size_t i = 0;; ++i) \
+		{ \
+			PROPMAP_ENTRY_IN_COMPLEX pentry = get_to_complex_map()[i]; \
+			if (pentry.pfn == 0) \
+			{ \
+				break; \
+			} \
+			(this->*((PROP_MAP_CALL_IN_COMPLEX)pentry.pfn))(complex_value); \
+		} \
+	}
+
 #define DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(navigation_property_name, edm_name, type) \
 public: \
-	const std::shared_ptr<type>& get_##navigation_property_name() { return navigation_property_name; } const \
+	const std::shared_ptr<type>& get_##navigation_property_name() const { return navigation_property_name; } \
 	void set_##navigation_property_name(const std::shared_ptr<type>& navigation_value) { navigation_property_name = navigation_value; } \
-	::pplx::task<void> load_##navigation_property_name(const std::shared_ptr<odata_query_builder>& builder = nullptr); \
+	::pplx::task<std::pair<std::shared_ptr<type>, ::odata::client::http_result>> load_##navigation_property_name(const std::shared_ptr<odata_query_builder>& builder = nullptr); \
 protected: \
-	std::shared_ptr<type> navigation_property_name;  \
-	void get_##navigation_property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); 
+	std::shared_ptr<type> navigation_property_name; \
+	void get_##navigation_property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
+	void set_##navigation_property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity);
 
 #define IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(myclass, navigation_property_name, edm_name, type) \
 	void myclass::get_##navigation_property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
-        std::shared_ptr<::odata::core::odata_value> property_value; \
-		if (!pentity->get_property_value(U(#edm_name), property_value) || !property_value) \
-	    { \
-			return ; \
+		std::shared_ptr<::odata::core::odata_value> property_value; \
+		if (!pentity->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
+		{ \
+			return; \
 		} \
-	    if (property_value->get_value_type()->get_type_kind() == ::odata::edm::edm_type_kind_t::Entity) \
-	    { \
+		if (property_value->get_value_type()->get_type_kind() == ::odata::edm::edm_type_kind_t::Entity) \
+		{ \
 			auto entity_value = std::dynamic_pointer_cast<::odata::core::odata_entity_value>(property_value); \
 			navigation_property_name = create_instance_from_entity<type>(entity_value, m_service_context); \
-        } \
-    } \
-	::pplx::task<void> myclass::load_##navigation_property_name(const std::shared_ptr<odata_query_builder>& builder) \
+		} \
+	} \
+	::pplx::task<std::pair<std::shared_ptr<type>, ::odata::client::http_result>> myclass::load_##navigation_property_name(const std::shared_ptr<odata_query_builder>& builder) \
 	{ \
-	    if (m_service_context) \
+		if (m_service_context) \
 		{\
-		    ::utility::string_t path = m_service_context->get_relative_path(m_edit_link) + U("/") + U(#edm_name); \
+		::odata::string_t path = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/") + _XPLATSTR(#edm_name); \
 			auto query = m_service_context->create_query<odata_singleton_query_executor<type>, odata_query_builder>(path); \
 			if (builder) { query->set_query_builder(builder); } \
 			return query->execute_query().then( \
-				[this] (const std::shared_ptr<type>& ret_value) -> void \
-			    { \
-				    navigation_property_name = ret_value; \
-			    }); \
+				[this] (const std::pair<std::shared_ptr<type>, ::odata::client::http_result>& ret_value) -> std::pair<std::shared_ptr<type>, ::odata::client::http_result> \
+				{ \
+					navigation_property_name = ret_value.first; \
+					return ret_value; \
+				}); \
 		}\
-		return ::pplx::task_from_result(); \
-	} 
+		return ::pplx::task_from_result(std::make_pair(std::shared_ptr<type>(), ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1)))); \
+	} \
+	void myclass::set_##navigation_property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
+	{ \
+		if (!pentity || !navigation_property_name) \
+		{ \
+			return; \
+		} \
+		auto entity_type = std::dynamic_pointer_cast<::odata::edm::edm_entity_type>(pentity->get_value_type()); \
+		if (!entity_type) \
+		{ \
+			return; \
+		} \
+		auto edm_property = entity_type->find_property(_XPLATSTR(#edm_name)); \
+		if (!edm_property) \
+		{ \
+			return; \
+		} \
+		auto property_type = edm_property->get_property_type(); \
+		auto navigation_value_type = std::dynamic_pointer_cast<::odata::edm::edm_navigation_type>(property_type); \
+		if (!navigation_value_type) \
+		{ \
+			return; \
+		} \
+		if (!navigation_value_type->is_contained()) \
+		{ \
+			pentity->set_value(_XPLATSTR(#edm_name) + odata::core::odata_json_constants::PAYLOAD_ANNOTATION_BIND, m_service_context->get_relative_path(navigation_property_name->get_edit_link())); \
+			return; \
+		} \
+		pentity->set_value(_XPLATSTR(#edm_name), navigation_property_name->to_value()); \
+	}
+
+#define DECLARE_NAVIGATION_PROPERTY_IN_COMPLEX_MAPPING(navigation_property_name, edm_name, type) \
+public: \
+	const std::shared_ptr<type>& get_##navigation_property_name() const { return navigation_property_name; } \
+	void set_##navigation_property_name(const std::shared_ptr<type>& navigation_value) { navigation_property_name = navigation_value; } \
+	::pplx::task<std::pair<std::shared_ptr<type>, ::odata::client::http_result>> load_##navigation_property_name(const std::shared_ptr<odata_query_builder>& builder = nullptr); \
+protected: \
+	std::shared_ptr<type> navigation_property_name; \
+	void get_##navigation_property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); \
+	void set_##navigation_property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex);
+
+#define IMPLEMENT_NAVIGATION_PROPERTY_IN_COMPLEX_MAPPING(myclass, navigation_property_name, edm_name, type) \
+	void myclass::get_##navigation_property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
+	{ \
+		std::shared_ptr<::odata::core::odata_value> property_value; \
+		if (!pcomplex->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
+		{ \
+			return; \
+		} \
+		if (property_value->get_value_type()->get_type_kind() == ::odata::edm::edm_type_kind_t::Entity) \
+		{ \
+			auto entity_value = std::dynamic_pointer_cast<::odata::core::odata_entity_value>(property_value); \
+			navigation_property_name = create_instance_from_entity<type>(entity_value, m_service_context); \
+		} \
+	} \
+	::pplx::task<std::pair<std::shared_ptr<type>, ::odata::client::http_result>> myclass::load_##navigation_property_name(const std::shared_ptr<odata_query_builder>& builder) \
+	{ \
+		if (m_service_context) \
+		{\
+			::odata::string_t path = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/") + _XPLATSTR(#edm_name); \
+			auto query = m_service_context->create_query<odata_singleton_query_executor<type>, odata_query_builder>(path); \
+			if (builder) { query->set_query_builder(builder); } \
+			return query->execute_query().then( \
+				[this] (const std::pair<std::shared_ptr<type>, ::odata::client::http_result>& ret_value) -> std::pair<std::shared_ptr<type>, ::odata::client::http_result> \
+				{ \
+					navigation_property_name = ret_value.first; \
+					return ret_value; \
+				}); \
+		}\
+		return ::pplx::task_from_result(std::make_pair(std::shared_ptr<type>(), ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1)))); \
+	} \
+	void myclass::set_##navigation_property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
+	{ \
+		if (!pcomplex || !navigation_property_name) \
+		{ \
+			return; \
+		} \
+		auto entity_type = std::dynamic_pointer_cast<::odata::edm::edm_entity_type>(pcomplex->get_value_type()); \
+		if (!entity_type) \
+		{ \
+			return; \
+		} \
+		auto edm_property = entity_type->find_property(_XPLATSTR(#edm_name)); \
+		if (!edm_property) \
+		{ \
+			return; \
+		} \
+		auto property_type = edm_property->get_property_type(); \
+		auto navigation_value_type = std::dynamic_pointer_cast<::odata::edm::edm_navigation_type>(property_type); \
+		if (!navigation_value_type) \
+		{ \
+			return; \
+		} \
+		if (!navigation_value_type->is_contained()) \
+		{ \
+			pcomplex->set_value(_XPLATSTR(#edm_name) + odata::core::odata_json_constants::PAYLOAD_ANNOTATION_BIND, m_service_context->get_relative_path(navigation_property_name->get_edit_link())); \
+			return; \
+		} \
+		pcomplex->set_value(_XPLATSTR(#edm_name), navigation_property_name->to_value()); \
+	}
 
 #define DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(property_name, edm_name, type) \
 public: \
-	const std::vector<type>& get_##property_name() { return property_name; } const \
+	const std::vector<type>& get_##property_name() const { return property_name; } \
 	void set_##property_name(std::vector<type> values) { property_name = std::move(values); } \
-	void add_to_##property_name(const type& property_value) { property_name.push_back(property_value); } \
+	void add_to_##property_name(const type& property_value) { property_name.emplace_back(property_value); } \
 protected: \
 	std::vector<type> property_name; \
 	void get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
@@ -455,127 +571,127 @@ protected: \
 	void myclass::get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
 		std::shared_ptr<::odata::core::odata_value> property_value; \
-		if (!pentity->get_property_value(U(#edm_name), property_value) || !property_value) \
+		if (!pentity->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
 		{ \
-			return ; \
+			return; \
 		} \
 		auto property_collection_value = static_pointer_cast<::odata::core::odata_collection_value>(property_value); \
 		if (!property_collection_value) \
 		{ \
-			return ; \
+			return; \
 		} \
-		for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); iter++) \
+		for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); ++iter) \
 		{ \
-		    auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(*iter); \
+			auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(*iter); \
 			if (!primitive_value) \
-	        { \
-			    continue ; \
+			{ \
+				continue; \
 			} \
-			property_name.push_back(primitive_value->as<type>()); \
+			property_name.emplace_back(primitive_value->as<type>()); \
 		} \
 	} \
 	void myclass::set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
 		if (!pentity || !pentity->get_value_type()) \
 		{ \
-			return ; \
+			return; \
 		} \
-	    auto entity_type = std::dynamic_pointer_cast<::odata::edm::edm_entity_type>(pentity->get_value_type()); \
+		auto entity_type = std::dynamic_pointer_cast<::odata::edm::edm_entity_type>(pentity->get_value_type()); \
 		if (!entity_type) \
 		{ \
-			return ; \
+			return; \
 		} \
-		auto edm_property = entity_type->find_property(U(#edm_name)); \
+		auto edm_property = entity_type->find_property(_XPLATSTR(#edm_name)); \
 		if (!edm_property) \
 		{ \
-			return ; \
+			return; \
 		} \
 		auto property_type = edm_property->get_property_type(); \
 		auto collection_value_type = std::dynamic_pointer_cast<::odata::edm::edm_collection_type>(property_type); \
 		if (!collection_value_type) \
 		{ \
-			return ; \
+			return; \
 		} \
-		std::shared_ptr<::odata::core::odata_collection_value> collection_value = std::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
-		for (size_t i = 0; i < property_name.size(); i++) \
+		std::shared_ptr<::odata::core::odata_collection_value> collection_value = ::odata::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
+		for (size_t i = 0; i < property_name.size(); ++i) \
 		{ \
 			collection_value->add_collection_value(odata_primitive_value::make_primitive_value(property_name[i])); \
 		} \
-		pentity->set_value(U(#edm_name), collection_value); \
+		pentity->set_value(_XPLATSTR(#edm_name), collection_value); \
 	}
 
 #define DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(property_name, edm_name, type) \
 public: \
-	const std::vector<type>& get_##property_name() { return property_name; } const \
+	const std::vector<type>& get_##property_name() const { return property_name; } \
 	void set_##property_name(const std::vector<type>& values) { property_name = values; } \
-	void add_to_##property_name(const type& property_value) { property_name.push_back(property_value); } \
+	void add_to_##property_name(const type& property_value) { property_name.emplace_back(property_value); } \
 protected: \
 	std::vector<type> property_name; \
 	void get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); \
-	void set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); 
+	void set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex);
 
 #define IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(myclass, property_name, edm_name, type) \
 	void myclass::get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
 	{ \
 		std::shared_ptr<::odata::core::odata_value> property_value; \
-		if (!pcomplex->get_property_value(U(#edm_name), property_value) || !property_value) \
+		if (!pcomplex->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
 		{ \
-			return ; \
+			return; \
 		} \
 		auto property_collection_value = static_pointer_cast<::odata::core::odata_collection_value>(property_value); \
 		if (!property_collection_value) \
 		{ \
-			return ; \
+			return; \
 		} \
-		for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); iter++) \
+		for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); ++iter) \
 		{ \
-		    auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(*iter); \
+			auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(*iter); \
 			if (!primitive_value) \
-	        { \
-			    continue ; \
+			{ \
+				continue; \
 			} \
-			property_name.push_back(primitive_value->as<type>()); \
+			property_name.emplace_back(primitive_value->as<type>()); \
 		} \
 	} \
 	void myclass::set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
 	{ \
 		if (!pcomplex || !pcomplex->get_value_type()) \
 		{ \
-			return ; \
+			return; \
 		} \
-	    auto complex_type = std::dynamic_pointer_cast<::odata::edm::edm_complex_type>(pcomplex->get_value_type()); \
+		auto complex_type = std::dynamic_pointer_cast<::odata::edm::edm_complex_type>(pcomplex->get_value_type()); \
 		if (!complex_type) \
 		{ \
-			return ; \
+			return; \
 		} \
-		auto edm_property = complex_type->find_property(U(#edm_name)); \
+		auto edm_property = complex_type->find_property(_XPLATSTR(#edm_name)); \
 		if (!edm_property) \
 		{ \
-			return ; \
+			return; \
 		} \
 		auto property_type = edm_property->get_property_type(); \
 		auto collection_value_type = std::dynamic_pointer_cast<::odata::edm::edm_collection_type>(property_type); \
 		if (!collection_value_type) \
 		{ \
-			return ; \
+			return; \
 		} \
-		std::shared_ptr<::odata::core::odata_collection_value> collection_value = std::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
-		for (size_t i = 0; i < property_name.size(); i++) \
+		std::shared_ptr<::odata::core::odata_collection_value> collection_value = ::odata::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
+		for (size_t i = 0; i < property_name.size(); ++i) \
 		{ \
 			collection_value->add_collection_value(odata_primitive_value::make_primitive_value(property_name[i])); \
 		} \
-		pcomplex->set_value(U(#edm_name), collection_value); \
+		pcomplex->set_value(_XPLATSTR(#edm_name), collection_value); \
 	}
 
 #define DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(property_name, edm_name, type) \
 public: \
-	type* get_##property_name() { return property_name.get(); } const \
+	type* get_##property_name() const { return property_name.get(); } \
 	void set_##property_name(type property_value) \
 	{\
-		property_name = std::make_shared<type>(property_value); \
+		property_name = ::odata::make_shared<type>(property_value); \
 	} \
 protected: \
-    std::shared_ptr<type> property_name; \
+	std::shared_ptr<type> property_name; \
 	void get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
 	void set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity);
 
@@ -583,66 +699,66 @@ protected: \
 	void myclass::get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
 		std::shared_ptr<::odata::core::odata_value> property_value; \
-		if (!pentity->get_property_value(U(#edm_name), property_value) || !property_value) \
+		if (!pentity->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
 		{ \
-			return ; \
+			return; \
 		} \
 		auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value); \
 		if (primitive_value) \
 		{ \
-			property_name = std::make_shared<type>(primitive_value->as<type>()); \
+			property_name = ::odata::make_shared<type>(primitive_value->as<type>()); \
 		} \
 	} \
 	void myclass::set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
-	    if (!pentity || !property_name) \
-	    { \
-		    return ; \
-        } \
-		pentity->set_value(U(#edm_name), *property_name); \
+		if (!pentity || !property_name) \
+		{ \
+			return; \
+		} \
+		pentity->set_value(_XPLATSTR(#edm_name), *property_name); \
 	}
 
 #define DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(property_name, edm_name, type) \
 public: \
-	type* get_##property_name() { return property_name.get(); } const \
-	void set_##property_name(type property_value)  \
-    { \
-		property_name = std::make_shared<type>(property_value);  \
+	type* get_##property_name() const { return property_name.get(); } \
+	void set_##property_name(type property_value) \
+	{ \
+		property_name = ::odata::make_shared<type>(property_value); \
 	} \
 protected: \
-    std::shared_ptr<type> property_name; \
+	std::shared_ptr<type> property_name; \
 	void get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); \
-	void set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); 
+	void set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex);
 
 #define IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(myclass, property_name, edm_name, type) \
 	void myclass::get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
 	{ \
 		std::shared_ptr<::odata::core::odata_value> property_value; \
-		if (!pcomplex->get_property_value(U(#edm_name), property_value) || !property_value) \
+		if (!pcomplex->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
 		{ \
-			return ; \
+			return; \
 		} \
 		auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value); \
 		if (primitive_value) \
 		{ \
-			property_name = std::make_shared<type>(primitive_value->as<type>()); \
+			property_name = ::odata::make_shared<type>(primitive_value->as<type>()); \
 		} \
 	} \
 	void myclass::set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
 	{ \
-	    if (!pcomplex || !property_name) \
-	    { \
-		    return ; \
-        } \
-		pcomplex->set_value(U(#edm_name), *property_name); \
+		if (!pcomplex || !property_name) \
+		{ \
+			return; \
+		} \
+		pcomplex->set_value(_XPLATSTR(#edm_name), *property_name); \
 	}
 
 #define DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(property_name, edm_name, type) \
 public: \
-	type* get_##property_name() { return property_name.get(); } const \
+	type* get_##property_name() const { return property_name.get(); } \
 	void set_##property_name(const std::shared_ptr<type>& property_value) { property_name = property_value; } \
 protected: \
-    std::shared_ptr<type> property_name; \
+	std::shared_ptr<type> property_name; \
 	void get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
 	void set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity);
 
@@ -650,9 +766,9 @@ protected: \
 	void myclass::get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
 		std::shared_ptr<::odata::core::odata_value> property_value; \
-		if (!pentity->get_property_value(U(#edm_name), property_value) || !property_value) \
+		if (!pentity->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
 		{ \
-			return ; \
+			return; \
 		} \
 		if (property_value->get_value_type()->get_type_kind() == ::odata::edm::edm_type_kind_t::Complex) \
 		{ \
@@ -661,19 +777,19 @@ protected: \
 	} \
 	void myclass::set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
-	    if (!pentity || !property_name) \
-	    { \
-		    return ; \
-        } \
-		pentity->set_value(U(#edm_name), property_name->to_value()); \
+		if (!pentity || !property_name) \
+		{ \
+			return; \
+		} \
+		pentity->set_value(_XPLATSTR(#edm_name), property_name->to_value()); \
 	}
 
 #define DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(property_name, edm_name, type) \
 public: \
-	type* get_##property_name() { return property_name.get(); } const \
+	type* get_##property_name() const { return property_name.get(); } \
 	void set_##property_name(const std::shared_ptr<type>& property_value) { property_name = property_value; } \
 protected: \
-    std::shared_ptr<type> property_name; \
+	std::shared_ptr<type> property_name; \
 	void get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); \
 	void set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex);
 
@@ -681,9 +797,9 @@ protected: \
 	void myclass::get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
 	{ \
 		std::shared_ptr<::odata::core::odata_value> property_value; \
-		if (!pcomplex->get_property_value(U(#edm_name), property_value) || !property_value) \
+		if (!pcomplex->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
 		{ \
-			return ; \
+			return; \
 		} \
 		if (property_value->get_value_type()->get_type_kind() == ::odata::edm::edm_type_kind_t::Complex) \
 		{ \
@@ -692,12 +808,19 @@ protected: \
 	} \
 	void myclass::set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
 	{ \
-	    if (!pcomplex || !property_name) \
-	    { \
-		    return ; \
-        } \
-		pcomplex->set_value(U(#edm_name), property_name->to_value()); \
+		if (!pcomplex || !property_name) \
+		{ \
+			return; \
+		} \
+		pcomplex->set_value(_XPLATSTR(#edm_name), property_name->to_value()); \
 	}
+
+// because we have to support derived complex type, so complex object in entity are all set with pointer type
+#define DECLARE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(property_name, edm_name, type) \
+	DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(property_name, edm_name, type)
+
+#define IMPLEMENT_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(myclass, property_name, edm_name, type) \
+	IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(myclass, property_name, edm_name, type)
 
 #define DECLARE_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(property_name, edm_name, type) \
 	DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(property_name, edm_name, type)
@@ -705,394 +828,875 @@ protected: \
 #define IMPLEMENT_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(myclass, property_name, edm_name, type) \
 	IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(myclass, property_name, edm_name, type)
 
+#define DECLARE_OPEN_PROPERTY_DICTIONARY_IN_ENTITY_MAPPING() \
+public: \
+	std::unordered_map<::odata::string_t, shared_ptr<::odata::string_t>> const& get_open_properties() const \
+	{ \
+		return open_property_dictionary; \
+	} \
+	void set_open_properties(std::unordered_map<::odata::string_t, shared_ptr<::odata::string_t>> const& properties) \
+	{ \
+		open_property_dictionary = properties; \
+	} \
+	shared_ptr<::odata::string_t> const get_open_property_from_dictionary(const ::odata::string_t& property_name) const; \
+	void set_open_property_to_dictionary(const ::odata::string_t& property_name, const ::odata::string_t& property_value) \
+	{\
+		open_property_dictionary[property_name] = ::odata::make_shared<::odata::string_t>(property_value); \
+	} \
+	size_t delete_open_property_from_dictionary(const ::odata::string_t& property_name) \
+	{ \
+		return open_property_dictionary.erase(property_name); \
+	} \
+protected: \
+	std::unordered_map<::odata::string_t, shared_ptr<::odata::string_t>> open_property_dictionary; \
+	void get_open_properties_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
+	void set_open_properties_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity);
+
+#define IMPLEMENT_OPEN_PROPERTY_DICTIONARY_IN_ENTITY_MAPPING(myclass) \
+shared_ptr<::odata::string_t> const myclass::get_open_property_from_dictionary(const ::odata::string_t& property_name) const \
+{ \
+	auto iter = open_property_dictionary.find(property_name); \
+	return iter != open_property_dictionary.end() ? iter->second : nullptr; \
+} \
+void myclass::get_open_properties_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
+{ \
+	if (pentity->is_open()) \
+	{ \
+		for (auto const &open_property_value : pentity->open_properties()) \
+		{ \
+			if (!open_property_value.second || pentity->has_property(open_property_value.first)) \
+			{ \
+				continue; \
+			} \
+			auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(open_property_value.second); \
+			if (primitive_value) \
+			{ \
+				open_property_dictionary[open_property_value.first] = ::odata::make_shared<::odata::string_t>(primitive_value->as<::odata::string_t>()); \
+			} \
+		} \
+	} \
+} \
+void myclass::set_open_properties_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
+{ \
+	if (pentity->is_open()) \
+	{ \
+		for (auto const &open_property_value : open_property_dictionary) \
+		{ \
+			if (!open_property_value.second || pentity->has_property(open_property_value.first)) \
+			{ \
+				continue; \
+			} \
+			pentity->set_open_value(open_property_value.first, *open_property_value.second); \
+		} \
+	} \
+} \
+
+#define DECLARE_OPEN_PROPERTY_DICTIONARY_IN_COMPLEX_MAPPING() \
+public: \
+	std::unordered_map<::odata::string_t, shared_ptr<::odata::string_t>> const& get_open_properties() const \
+	{ \
+		return open_property_dictionary; \
+	} \
+	void set_open_properties(std::unordered_map<::odata::string_t, shared_ptr<::odata::string_t>> const& properties) \
+	{ \
+		open_property_dictionary = properties; \
+	} \
+	shared_ptr<::odata::string_t> const get_open_property_from_dictionary(const ::odata::string_t& property_name) const; \
+	void set_open_property_to_dictionary(const ::odata::string_t& property_name, const ::odata::string_t& property_value) \
+	{ \
+		open_property_dictionary[property_name] = ::odata::make_shared<::odata::string_t>(property_value); \
+	} \
+	size_t delete_open_property_from_dictionary(const ::odata::string_t& property_name) \
+	{ \
+		return open_property_dictionary.erase(property_name); \
+	} \
+protected: \
+	std::unordered_map<::odata::string_t, shared_ptr<::odata::string_t>> open_property_dictionary; \
+	void get_open_properties_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); \
+	void set_open_properties_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex);
+
+#define IMPLEMENT_OPEN_PROPERTY_DICTIONARY_IN_COMPLEX_MAPPING(myclass) \
+shared_ptr<::odata::string_t> const myclass::get_open_property_from_dictionary(const ::odata::string_t& property_name) const \
+{ \
+	auto iter = open_property_dictionary.find(property_name); \
+	return iter != open_property_dictionary.end() ? iter->second : nullptr; \
+} \
+void myclass::get_open_properties_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
+{ \
+	if (pcomplex->is_open()) \
+	{ \
+		for (auto const &open_property_value : pcomplex->open_properties()) \
+		{ \
+			if (!open_property_value.second || pcomplex->has_property(open_property_value.first)) \
+			{ \
+				continue; \
+			} \
+			auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(open_property_value.second); \
+			if (primitive_value) \
+			{ \
+				open_property_dictionary[open_property_value.first] = ::odata::make_shared<::odata::string_t>(primitive_value->as<::odata::string_t>()); \
+			} \
+		} \
+	} \
+} \
+void myclass::set_open_properties_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
+{ \
+	if (pcomplex->is_open()) \
+	{ \
+		for (auto const &open_property_value : open_property_dictionary) \
+		{ \
+			if (!open_property_value.second || pcomplex->has_property(open_property_value.first)) \
+			{ \
+				continue; \
+			} \
+			pcomplex->set_open_value(open_property_value.first, *open_property_value.second); \
+		} \
+	} \
+}
+
 #define DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(property_name, edm_name, type) \
 public: \
-	const std::vector<std::shared_ptr<type>>& get_##property_name() { return property_name; } const \
+	const std::vector<std::shared_ptr<type>>& get_##property_name() const { return property_name; } \
 	void set_##property_name(const std::vector<std::shared_ptr<type>>& property_values) { property_name = property_values; } \
-	void add_to_##property_name(const std::shared_ptr<type>& property_value) { property_name.push_back(property_value); } \
-	::pplx::task<void> load_##property_name(const std::shared_ptr<odata_query_builder>& builder = nullptr); \
+	void add_to_##property_name(const std::shared_ptr<type>& property_value) { property_name.emplace_back(property_value); } \
+	::pplx::task<std::pair<std::vector<std::shared_ptr<type>>, ::odata::client::http_result>> load_##property_name(const std::shared_ptr<odata_query_builder>& builder = nullptr); \
 protected: \
 	std::vector<std::shared_ptr<type>> property_name; \
-	void get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); 
+	void get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
+	void set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity);
 
 #define IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(myclass, property_name, edm_name, type) \
 	void myclass::get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
-		std::shared_ptr<::odata::core::odata_value> property_value;  \
-		if (!pentity->get_property_value(U(#edm_name), property_value) || !property_value) \
+		std::shared_ptr<::odata::core::odata_value> property_value; \
+		if (!pentity->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
 		{ \
-			return ; \
+			return; \
 		} \
 		auto property_collection_value = static_pointer_cast<::odata::core::odata_collection_value>(property_value); \
 		if (!property_collection_value) \
 		{ \
-			return ; \
+			return; \
 		} \
-		for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); iter++) \
+		for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); ++iter) \
 		{ \
 			auto entity_value = std::dynamic_pointer_cast<::odata::core::odata_entity_value>(*iter); \
 			if (!entity_value) \
-	        { \
-			    continue ; \
+			{ \
+				continue; \
 			} \
 			std::shared_ptr<type> p_entity = create_instance_from_entity<type>(entity_value, m_service_context); \
-			property_name.push_back(std::dynamic_pointer_cast<type>(p_entity)); \
+			property_name.emplace_back(std::dynamic_pointer_cast<type>(p_entity)); \
 		} \
 	} \
-	::pplx::task<void> myclass::load_##property_name(const std::shared_ptr<odata_query_builder>& builder) \
+	::pplx::task<std::pair<std::vector<std::shared_ptr<type>>, ::odata::client::http_result>> myclass::load_##property_name(const std::shared_ptr<odata_query_builder>& builder) \
 	{ \
-	    if (m_service_context)\
+		if (m_service_context)\
 		{\
-		    ::utility::string_t path = m_service_context->get_relative_path(m_edit_link) + U("/") + U(#edm_name);\
+			::odata::string_t path = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/") + _XPLATSTR(#edm_name);\
 			auto query = m_service_context->create_query<odata_entityset_query_executor<type>, odata_query_builder>(path);\
 			if (builder) { query->set_query_builder(builder); } \
 			return query->execute_query().then( \
-			    [this] (const std::vector<std::shared_ptr<type>>& ret_values) -> void \
-			    { \
-	                property_name = ret_values; \
-		        }); \
-		}\
-		return ::pplx::task_from_result(); \
+				[this] (const std::pair<std::vector<std::shared_ptr<type>>, ::odata::client::http_result>& ret_values) -> std::pair<std::vector<std::shared_ptr<type>>, ::odata::client::http_result> \
+				{ \
+					property_name = ret_values.first; \
+					return ret_values; \
+				}); \
+		} \
+		return ::pplx::task_from_result(std::make_pair(std::vector<std::shared_ptr<type>>(), ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1)))); \
+	} \
+	void myclass::set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
+	{ \
+		if (!pentity || !pentity->get_value_type()) \
+		{ \
+			return; \
+		} \
+		auto entity_type = std::dynamic_pointer_cast<::odata::edm::edm_entity_type>(pentity->get_value_type()); \
+		if (!entity_type) \
+		{ \
+			return; \
+		} \
+		auto edm_property = entity_type->find_property(_XPLATSTR(#edm_name)); \
+		if (!edm_property) \
+		{ \
+			return; \
+		} \
+		auto property_type = edm_property->get_property_type(); \
+		auto navigation_value_type = std::dynamic_pointer_cast<::odata::edm::edm_navigation_type>(property_type); \
+		if (!navigation_value_type) \
+		{ \
+			return; \
+		} \
+		if (!navigation_value_type->is_contained()) \
+		{ \
+			::odata::string_t const BindName = _XPLATSTR(#edm_name) + odata::core::odata_json_constants::PAYLOAD_ANNOTATION_BIND; \
+			auto PrimitiveType = ::odata::make_shared<::odata::edm::edm_named_type>(BindName, entity_type->get_namespace(), odata::edm::edm_type_kind_t::Primitive); \
+			auto collection_value_type = ::odata::make_shared<::odata::edm::edm_collection_type>(BindName, PrimitiveType); \
+			if (!collection_value_type) \
+			{ \
+				return; \
+			} \
+			std::shared_ptr<::odata::core::odata_collection_value> collection_value = ::odata::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
+			for (size_t i = 0; i < property_name.size(); ++i) \
+			{ \
+				if (property_name[i]) collection_value->add_collection_value(std::dynamic_pointer_cast<::odata::core::odata_value>(odata::core::odata_primitive_value::make_primitive_value(m_service_context->get_relative_path(property_name[i]->get_edit_link())))); \
+			} \
+			pentity->set_value(BindName, collection_value); \
+			return; \
+		} \
+		auto navigation_type = std::dynamic_pointer_cast<::odata::edm::edm_named_type>(navigation_value_type->get_navigation_type()); \
+		if (!navigation_type) \
+		{ \
+			return; \
+		} \
+		auto collection_value_type = std::dynamic_pointer_cast<::odata::edm::edm_collection_type>(navigation_type); \
+		if (!collection_value_type) \
+		{ \
+			return; \
+		} \
+		std::shared_ptr<::odata::core::odata_collection_value> collection_value = ::odata::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
+		for (size_t i = 0; i < property_name.size(); ++i) \
+		{ \
+			if (property_name[i]) collection_value->add_collection_value(std::dynamic_pointer_cast<::odata::core::odata_value>(property_name[i]->to_value())); \
+		} \
+		pentity->set_value(_XPLATSTR(#edm_name), collection_value); \
+	}
+
+#define DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_COMPLEX_MAPPING(property_name, edm_name, type) \
+public: \
+	const std::vector<std::shared_ptr<type>>& get_##property_name() const { return property_name; } \
+	void set_##property_name(const std::vector<std::shared_ptr<type>>& property_values) { property_name = property_values; } \
+	void add_to_##property_name(const std::shared_ptr<type>& property_value) { property_name.emplace_back(property_value); } \
+	::pplx::task<std::pair<std::vector<std::shared_ptr<type>>, ::odata::client::http_result>> load_##property_name(const std::shared_ptr<odata_query_builder>& builder = nullptr); \
+protected: \
+	std::vector<std::shared_ptr<type>> property_name; \
+	void get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); \
+	void set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex);
+
+#define IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_COMPLEX_MAPPING(myclass, property_name, edm_name, type) \
+	void myclass::get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
+	{ \
+		std::shared_ptr<::odata::core::odata_value> property_value; \
+		if (!pcomplex->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
+		{ \
+			return; \
+		} \
+		auto property_collection_value = static_pointer_cast<::odata::core::odata_collection_value>(property_value); \
+		if (!property_collection_value) \
+		{ \
+			return; \
+		} \
+		for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); ++iter) \
+		{ \
+			auto entity_value = std::dynamic_pointer_cast<::odata::core::odata_entity_value>(*iter); \
+			if (!entity_value) \
+			{ \
+				continue; \
+			} \
+			std::shared_ptr<type> p_entity = create_instance_from_entity<type>(entity_value, m_service_context); \
+			property_name.emplace_back(std::dynamic_pointer_cast<type>(p_entity)); \
+		 } \
+	} \
+	::pplx::task<std::pair<std::vector<std::shared_ptr<type>>, ::odata::client::http_result>> myclass::load_##property_name(const std::shared_ptr<odata_query_builder>& builder) \
+	{ \
+		if (m_service_context)\
+		{\
+			::odata::string_t path = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/") + _XPLATSTR(#edm_name);\
+			auto query = m_service_context->create_query<odata_entityset_query_executor<type>, odata_query_builder>(path);\
+			if (builder) { query->set_query_builder(builder); } \
+			return query->execute_query().then( \
+				[this] (const std::pair<std::vector<std::shared_ptr<type>>, ::odata::client::http_result>& ret_values) -> std::pair<std::vector<std::shared_ptr<type>>, ::odata::client::http_result> \
+				{ \
+					property_name = ret_values.first; \
+					return ret_values; \
+				}); \
+		} \
+		return ::pplx::task_from_result(std::make_pair(std::vector<std::shared_ptr<type>>(), ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1)))); \
+	} \
+	void myclass::set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
+	{ \
+		if (!pcomplex || !pcomplex->get_value_type()) \
+		{ \
+			return; \
+		} \
+		auto complex_type = std::dynamic_pointer_cast<::odata::edm::edm_complex_type>(pcomplex->get_value_type()); \
+		if (!complex_type) \
+		{ \
+			return; \
+		} \
+		auto edm_property = complex_type->find_property(_XPLATSTR(#edm_name)); \
+		if (!edm_property) \
+		{ \
+			return; \
+		} \
+		auto property_type = edm_property->get_property_type(); \
+		auto navigation_value_type = std::dynamic_pointer_cast<::odata::edm::edm_navigation_type>(property_type); \
+		if (!navigation_value_type) \
+		{ \
+			return; \
+		} \
+		if (!navigation_value_type->is_contained()) \
+		{ \
+			::odata::string_t const BindName = _XPLATSTR(#edm_name) + odata::core::odata_json_constants::PAYLOAD_ANNOTATION_BIND; \
+			auto PrimitiveType = ::odata::make_shared<::odata::edm::edm_named_type>(BindName, complex_type->get_namespace(), odata::edm::edm_type_kind_t::Primitive); \
+			auto collection_value_type = ::odata::make_shared<::odata::edm::edm_collection_type>(BindName, PrimitiveType); \
+			if (!collection_value_type) \
+			{ \
+				return; \
+			} \
+			std::shared_ptr<::odata::core::odata_collection_value> collection_value = ::odata::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
+			for (size_t i = 0; i < property_name.size(); ++i) \
+			{ \
+				if (property_name[i]) collection_value->add_collection_value(std::dynamic_pointer_cast<::odata::core::odata_value>(odata::core::odata_primitive_value::make_primitive_value(m_service_context->get_relative_path(property_name[i]->get_edit_link())))); \
+			} \
+			pcomplex->set_value(BindName, collection_value); \
+			return; \
+		} \
+		auto navigation_type = std::dynamic_pointer_cast<::odata::edm::edm_named_type>(navigation_value_type->get_navigation_type()); \
+		if (!navigation_type) \
+		{ \
+			return; \
+		} \
+		auto collection_value_type = std::dynamic_pointer_cast<::odata::edm::edm_collection_type>(navigation_type); \
+		if (!collection_value_type) \
+		{ \
+			return; \
+		} \
+		std::shared_ptr<::odata::core::odata_collection_value> collection_value = ::odata::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
+		for (size_t i = 0; i < property_name.size(); ++i) \
+		{ \
+			if (property_name[i]) collection_value->add_collection_value(std::dynamic_pointer_cast<odata_complex_value>(property_name[i]->to_value())); \
+		} \
+		pcomplex->set_value(_XPLATSTR(#edm_name), collection_value); \
 	}
 
 #define DECLARE_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(property_name, edm_name, type) \
 public: \
-	const std::vector<std::shared_ptr<type>>& get_##property_name() { return property_name; } const\
+	const std::vector<std::shared_ptr<type>>& get_##property_name() const { return property_name; } \
 	void set_##property_name(std::vector<std::shared_ptr<type>> property_values) { property_name = std::move(property_values); } \
-	void add_to_##property_name(const std::shared_ptr<type>& property_value) { property_name.push_back(property_value); } \
+	void add_to_##property_name(const std::shared_ptr<type>& property_value) { property_name.emplace_back(property_value); } \
 protected: \
 	std::vector<std::shared_ptr<type>> property_name; \
 	void get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
-	void set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); 
+	void set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity);
 
 #define IMPLEMENT_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(myclass, property_name, edm_name, type) \
 	void myclass::get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
-		std::shared_ptr<::odata::core::odata_value> property_value;  \
-		if (!pentity->get_property_value(U(#edm_name), property_value) || !property_value) \
+		std::shared_ptr<::odata::core::odata_value> property_value; \
+		if (!pentity->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
 		{ \
-			return ; \
+			return; \
 		} \
 		auto property_collection_value = static_pointer_cast<::odata::core::odata_collection_value>(property_value); \
 		if (!property_collection_value) \
 		{ \
-			return ; \
+			return; \
 		} \
-		for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); iter++) \
+		for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); ++iter) \
 		{ \
 			auto complex_value = std::dynamic_pointer_cast<::odata::core::odata_complex_value>(*iter); \
 			if (!complex_value) \
-	        { \
-			    continue ; \
+			{ \
+				continue; \
 			} \
-			property_name.push_back(create_instance_from_complex<type>(complex_value, m_service_context)); \
+			property_name.emplace_back(create_instance_from_complex<type>(complex_value, m_service_context)); \
 		} \
 	} \
 	void myclass::set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
 		if (!pentity || !pentity->get_value_type()) \
 		{ \
-			return ; \
+			return; \
 		} \
-	    auto entity_type = std::dynamic_pointer_cast<::odata::edm::edm_entity_type>(pentity->get_value_type()); \
-		if (!entity_type) \
-		{ \
-			return ; \
-		} \
-		auto edm_property = entity_type->find_property(U(#edm_name)); \
-		if (!edm_property) \
-		{ \
-			return ; \
-		} \
-		auto property_type = edm_property->get_property_type(); \
-		auto collection_value_type = std::dynamic_pointer_cast<::odata::edm::edm_collection_type>(property_type); \
-		if (!collection_value_type) \
-		{ \
-			return ; \
-		} \
-		std::shared_ptr<::odata::core::odata_collection_value> collection_value = std::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
-		for (size_t i = 0; i < property_name.size(); i++) \
-		{ \
-		    if (property_name[i]) collection_value->add_collection_value(std::dynamic_pointer_cast<::odata::core::odata_value>(property_name[i]->to_value())); \
-		} \
-		pentity->set_value(U(#edm_name), collection_value); \
-	}
-
-#define DECLARE_ENUM_PROPERTY_IN_ENTITY_MAPPING(property_name, edm_name, type) \
-public: \
-	const type& get_##property_name() { return property_name; } const \
-	void set_##property_name(const type& property_value) { property_name = property_value; } \
-protected: \
-	type property_name; \
-	void get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
-	void set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); 
-
-#define IMPLEMENT_ENUM_PROPERTY_IN_ENTITY_MAPPING(myclass, property_name, edm_name, type) \
-	void myclass::get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
-	{ \
-		if (!pentity) \
-		{ \
-			return ; \
-		} \
-        std::shared_ptr<::odata::core::odata_value> property_value; \
-		if (!pentity->get_property_value(U(#edm_name), property_value) || !property_value) \
-	    { \
-			return ; \
-		} \
-		auto enum_value = std::dynamic_pointer_cast<::odata::core::odata_enum_value>(property_value); \
-	    if (enum_value) \
-	    { \
-		    property_name = enum_type_resolver::get_enum_type_from_string(enum_value->to_string(), type()); \
-        } \
-	} \
-	void myclass::set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
-	{ \
-		if (!pentity)  \
-	    {  \
-		    return ;  \
-        }  \
 		auto entity_type = std::dynamic_pointer_cast<::odata::edm::edm_entity_type>(pentity->get_value_type()); \
 		if (!entity_type) \
 		{ \
-			return ; \
+			return; \
 		} \
-		auto edm_property = entity_type->find_property(U(#edm_name)); \
+		auto edm_property = entity_type->find_property(_XPLATSTR(#edm_name)); \
 		if (!edm_property) \
 		{ \
-			return ; \
-		} \
-		auto property_type = edm_property->get_property_type(); \
-		auto enum_value = std::make_shared<::odata::core::odata_enum_value>(property_type, enum_type_resolver::get_string_from_enum_type(property_name)); \
-		pentity->set_value(U(#edm_name), enum_value);  \
-	}
-
-#define DECLARE_ENUM_PROPERTY_IN_COMPLEX_MAPPING(property_name, edm_name, type) \
-public: \
-	const type& get_##property_name() { return property_name; } const \
-	void set_##property_name(const type& property_value) { property_name = property_value; } \
-protected: \
-	type property_name; \
-	void get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); \
-	void set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); 
-
-#define IMPLEMENT_ENUM_PROPERTY_IN_COMPLEX_MAPPING(myclass, property_name, edm_name, type) \
-	void myclass::get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
-	{ \
-		if (!pcomplex) \
-		{ \
-			return ; \
-		} \
-        std::shared_ptr<::odata::core::odata_value> property_value; \
-		if (!pcomplex->get_property_value(U(#edm_name), property_value) || !property_value) \
-	    { \
-			return ; \
-		} \
-		auto enum_value = std::dynamic_pointer_cast<::odata::core::odata_enum_value>(property_value); \
-	    if (enum_value) \
-	    { \
-		    property_name = enum_type_resolver::get_enum_type_from_string(enum_value->to_string(), type()); \
-        } \
-	} \
-	void myclass::set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
-	{ \
-		if (!pcomplex)  \
-	    {  \
-		    return ;  \
-        }  \
-		auto complex_type = std::dynamic_pointer_cast<::odata::edm::edm_complex_type>(pcomplex->get_value_type()); \
-		if (!complex_type) \
-		{ \
-			return ; \
-		} \
-		auto edm_property = complex_type->find_property(U(#edm_name)); \
-		if (!edm_property) \
-		{ \
-			return ; \
-		} \
-		auto property_type = edm_property->get_property_type(); \
-		auto enum_value = std::make_shared<::odata::core::odata_enum_value>(property_type, enum_type_resolver::get_string_from_enum_type(property_name)); \
-		pcomplex->set_value(U(#edm_name), enum_value);  \
-	}
-
-#define DECLARE_COLLECTION_ENUM_PROPERTY_IN_ENTITY_MAPPING(property_name, edm_name, type) \
-public: \
-	const std::vector<type>& get_##property_name() { return property_name; } const \
-	void set_##property_name(const std::vector<type>& property_values) { property_name = property_values; } \
-	void add_to_##property_name(type property_value) { property_name.push_back(property_value); } \
-protected: \
-	std::vector<type> property_name; \
-	void get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
-	void set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); 
-
-#define IMPLEMENT_COLLECTION_ENUM_PROPERTY_IN_ENTITY_MAPPING(myclass, property_name, edm_name, type) \
-	void myclass::get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
-	{ \
-		std::shared_ptr<::odata::core::odata_value> property_value; \
-		if (!pentity->get_property_value(U(#edm_name), property_value) || !property_value) \
-		{ \
-			return ; \
-		} \
-		auto property_collection_value = static_pointer_cast<::odata::core::odata_collection_value>(property_value); \
-		if (!property_collection_value) \
-		{ \
-			return ; \
-		} \
-		for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); iter++) \
-		{ \
-		    auto enum_value = std::dynamic_pointer_cast<::odata::core::odata_enum_value>(*iter); \
-			if (!enum_value) \
-	        { \
-			    continue ; \
-			} \
-			property_name.push_back(enum_type_resolver::get_enum_type_from_string(enum_value->to_string(), type())); \
-		} \
-	} \
-	void myclass::set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
-	{ \
-		if (!pentity || !pentity->get_value_type()) \
-		{ \
-			return ; \
-		} \
-	    auto entity_type = std::dynamic_pointer_cast<::odata::edm::edm_entity_type>(pentity->get_value_type()); \
-		if (!entity_type) \
-		{ \
-			return ; \
-		} \
-		auto edm_property = entity_type->find_property(U(#edm_name)); \
-		if (!edm_property) \
-		{ \
-			return ; \
+			return; \
 		} \
 		auto property_type = edm_property->get_property_type(); \
 		auto collection_value_type = std::dynamic_pointer_cast<::odata::edm::edm_collection_type>(property_type); \
 		if (!collection_value_type) \
 		{ \
-			return ; \
+			return; \
 		} \
-		std::shared_ptr<::odata::core::odata_collection_value> collection_value = std::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
-		for (size_t i = 0; i < property_name.size(); i++) \
+		std::shared_ptr<::odata::core::odata_collection_value> collection_value = ::odata::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
+		for (size_t i = 0; i < property_name.size(); ++i) \
 		{ \
-		    collection_value->add_collection_value(std::make_shared<::odata::core::odata_enum_value>(collection_value_type->get_element_type(), enum_type_resolver::get_string_from_enum_type(property_name[i]))); \
+			if (property_name[i]) collection_value->add_collection_value(std::dynamic_pointer_cast<::odata::core::odata_value>(property_name[i]->to_value())); \
 		} \
-		pentity->set_value(U(#edm_name), collection_value); \
+		pentity->set_value(_XPLATSTR(#edm_name), collection_value); \
 	}
 
-#define DECLARE_COLLECTION_ENUM_PROPERTY_IN_COMPLEX_MAPPING(property_name, edm_name, type) \
+#define DECLARE_COLLECTION_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(property_name, edm_name, type) \
 public: \
-	const std::vector<type>& get_##property_name() { return property_name; } const \
-	void set_##property_name(const std::vector<type>& property_values) { property_name = property_values; } \
-	void add_to_##property_name(type property_value) { property_name.push_back(property_value); } \
+	const std::vector<std::shared_ptr<type>>& get_##property_name() const { return property_name; } \
+	void set_##property_name(std::vector<std::shared_ptr<type>> property_values) { property_name = std::move(property_values); } \
+	void add_to_##property_name(const std::shared_ptr<type>& property_value) { property_name.emplace_back(property_value); } \
 protected: \
-	std::vector<type> property_name; \
+	std::vector<std::shared_ptr<type>> property_name; \
 	void get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); \
-	void set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); 
+	void set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex);
 
-#define IMPLEMENT_COLLECTION_ENUM_PROPERTY_IN_COMPLEX_MAPPING(myclass, property_name, edm_name, type) \
+#define IMPLEMENT_COLLECTION_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(myclass, property_name, edm_name, type) \
 	void myclass::get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
 	{ \
 		std::shared_ptr<::odata::core::odata_value> property_value; \
-		if (!pcomplex->get_property_value(U(#edm_name), property_value) || !property_value) \
+		if (!pcomplex->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
 		{ \
-			return ; \
+			return; \
 		} \
 		auto property_collection_value = static_pointer_cast<::odata::core::odata_collection_value>(property_value); \
 		if (!property_collection_value) \
 		{ \
-			return ; \
+			return; \
 		} \
-		for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); iter++) \
+		for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); ++iter) \
 		{ \
-		    auto enum_value = std::dynamic_pointer_cast<::odata::core::odata_enum_value>(*iter); \
-			if (!enum_value) \
-	        { \
-			    continue ; \
+			auto complex_value = std::dynamic_pointer_cast<::odata::core::odata_complex_value>(*iter); \
+			if (!complex_value) \
+			{ \
+				continue; \
 			} \
-			property_name.push_back(enum_type_resolver::get_enum_type_from_string(enum_value->to_string(), type())); \
+			property_name.emplace_back(create_instance_from_complex<type>(complex_value, m_service_context)); \
 		} \
 	} \
 	void myclass::set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
 	{ \
 		if (!pcomplex || !pcomplex->get_value_type()) \
 		{ \
-			return ; \
+			return; \
 		} \
-	    auto complex_type = std::dynamic_pointer_cast<::odata::edm::edm_complex_type>(pcomplex->get_value_type()); \
-		if (!complex_type) \
+		auto entity_type = std::dynamic_pointer_cast<::odata::edm::edm_entity_type>(pcomplex->get_value_type()); \
+		if (!entity_type) \
 		{ \
-			return ; \
+			return; \
 		} \
-		auto edm_property = complex_type->find_property(U(#edm_name)); \
+		auto edm_property = entity_type->find_property(_XPLATSTR(#edm_name)); \
 		if (!edm_property) \
 		{ \
-			return ; \
+			return; \
 		} \
 		auto property_type = edm_property->get_property_type(); \
 		auto collection_value_type = std::dynamic_pointer_cast<::odata::edm::edm_collection_type>(property_type); \
 		if (!collection_value_type) \
 		{ \
-			return ; \
+			return; \
 		} \
-		std::shared_ptr<::odata::core::odata_collection_value> collection_value = std::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
-		for (size_t i = 0; i < property_name.size(); i++) \
+		std::shared_ptr<::odata::core::odata_collection_value> collection_value = ::odata::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
+		for (size_t i = 0; i < property_name.size(); ++i) \
 		{ \
-		    collection_value->add_collection_value(std::make_shared<::odata::core::odata_enum_value>(collection_value_type->get_element_type(), enum_type_resolver::get_string_from_enum_type(property_name[i]))); \
+			if (property_name[i]) collection_value->add_collection_value(std::dynamic_pointer_cast<::odata::core::odata_value>(property_name[i]->to_value())); \
 		} \
-		pcomplex->set_value(U(#edm_name), collection_value); \
+		pcomplex->set_value(_XPLATSTR(#edm_name), collection_value); \
+	}
+
+#define DECLARE_COLLECTION_ENTITY_PROPERTY_IN_ENTITY_MAPPING(property_name, edm_name, type) \
+public: \
+	const std::vector<std::shared_ptr<type>>& get_##property_name() const { return property_name; } \
+	void set_##property_name(std::vector<std::shared_ptr<type>> property_values) { property_name = std::move(property_values); } \
+	void add_to_##property_name(const std::shared_ptr<type>& property_value) { property_name.emplace_back(property_value); } \
+protected: \
+	std::vector<std::shared_ptr<type>> property_name; \
+	void get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
+	void set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity);
+
+#define IMPLEMENT_COLLECTION_ENTITY_PROPERTY_IN_ENTITY_MAPPING(myclass, property_name, edm_name, type) \
+	void myclass::get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
+	{ \
+		std::shared_ptr<::odata::core::odata_value> property_value; \
+		if (!pentity->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
+		{ \
+			return; \
+		} \
+		auto property_collection_value = static_pointer_cast<::odata::core::odata_collection_value>(property_value); \
+		if (!property_collection_value) \
+		{ \
+			return; \
+		} \
+		for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); ++iter) \
+		{ \
+			auto entity_value = std::dynamic_pointer_cast<::odata::core::odata_entity_value>(*iter); \
+			if (!entity_value) \
+			{ \
+				continue; \
+			} \
+			property_name.emplace_back(create_instance_from_entity<type>(entity_value, m_service_context)); \
+		} \
+	} \
+	void myclass::set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
+	{ \
+		if (!pentity || !pentity->get_value_type()) \
+		{ \
+			return; \
+		} \
+		auto entity_type = std::dynamic_pointer_cast<::odata::edm::edm_entity_type>(pentity->get_value_type()); \
+		if (!entity_type) \
+		{ \
+			return; \
+		} \
+		auto edm_property = entity_type->find_property(_XPLATSTR(#edm_name)); \
+		if (!edm_property) \
+		{ \
+			return; \
+		} \
+		auto property_type = edm_property->get_property_type(); \
+		auto collection_value_type = std::dynamic_pointer_cast<::odata::edm::edm_collection_type>(property_type); \
+		if (!collection_value_type) \
+		{ \
+			return; \
+		} \
+		std::shared_ptr<::odata::core::odata_collection_value> collection_value = ::odata::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
+		for (size_t i = 0; i < property_name.size(); ++i) \
+		{ \
+			if (property_name[i]) collection_value->add_collection_value(std::dynamic_pointer_cast<::odata::core::odata_value>(property_name[i]->to_value())); \
+		} \
+		pentity->set_value(_XPLATSTR(#edm_name), collection_value); \
+	}
+
+#define DECLARE_COLLECTION_ENTITY_PROPERTY_IN_COMPLEX_MAPPING(property_name, edm_name, type) \
+public: \
+	const std::vector<std::shared_ptr<type>>& get_##property_name() const { return property_name; } \
+	void set_##property_name(std::vector<std::shared_ptr<type>> property_values) { property_name = std::move(property_values); } \
+	void add_to_##property_name(const std::shared_ptr<type>& property_value) { property_name.emplace_back(property_value); } \
+protected: \
+	std::vector<std::shared_ptr<type>> property_name; \
+	void get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); \
+	void set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex);
+
+#define IMPLEMENT_COLLECTION_ENTITY_PROPERTY_IN_COMPLEX_MAPPING(myclass, property_name, edm_name, type) \
+	void myclass::get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
+	{ \
+		std::shared_ptr<::odata::core::odata_value> property_value; \
+		if (!pcomplex->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
+		{ \
+			return; \
+		} \
+		auto property_collection_value = static_pointer_cast<::odata::core::odata_collection_value>(property_value); \
+		if (!property_collection_value) \
+		{ \
+			return; \
+		} \
+		for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); ++iter) \
+		{ \
+			auto entity_value = std::dynamic_pointer_cast<::odata::core::odata_entity_value>(*iter); \
+			if (!entity_value) \
+			{ \
+				continue; \
+			} \
+			property_name.emplace_back(create_instance_from_entity<type>(entity_value, m_service_context)); \
+		} \
+	} \
+	void myclass::set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
+	{ \
+		if (!pcomplex || !pcomplex->get_value_type()) \
+		{ \
+			return; \
+		} \
+		auto complex_type = std::dynamic_pointer_cast<::odata::edm::edm_complex_type>(pcomplex->get_value_type()); \
+		if (!complex_type) \
+		{ \
+			return; \
+		} \
+		auto edm_property = complex_type->find_property(_XPLATSTR(#edm_name)); \
+		if (!edm_property) \
+		{ \
+			return; \
+		} \
+		auto property_type = edm_property->get_property_type(); \
+		auto collection_value_type = std::dynamic_pointer_cast<::odata::edm::edm_collection_type>(property_type); \
+		if (!collection_value_type) \
+		{ \
+			return; \
+		} \
+		std::shared_ptr<::odata::core::odata_collection_value> collection_value = ::odata::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
+		for (size_t i = 0; i < property_name.size(); ++i) \
+		{ \
+			if (property_name[i]) collection_value->add_collection_value(std::dynamic_pointer_cast<::odata::core::odata_value>(property_name[i]->to_value())); \
+		} \
+		pcomplex->set_value(_XPLATSTR(#edm_name), collection_value); \
+	}
+
+#define DECLARE_ENUM_PROPERTY_IN_ENTITY_MAPPING(property_name, edm_name, type) \
+public: \
+	const type& get_##property_name() const { return property_name; } \
+	void set_##property_name(const type& property_value) { property_name = property_value; } \
+protected: \
+	type property_name; \
+	void get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
+	void set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity);
+
+#define IMPLEMENT_ENUM_PROPERTY_IN_ENTITY_MAPPING(myclass, property_name, edm_name, type) \
+	void myclass::get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
+	{ \
+		if (!pentity) \
+		{ \
+			return; \
+		} \
+		std::shared_ptr<::odata::core::odata_value> property_value; \
+		if (!pentity->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
+		{ \
+			return; \
+		} \
+		auto enum_value = std::dynamic_pointer_cast<::odata::core::odata_enum_value>(property_value); \
+		if (enum_value) \
+		{ \
+			property_name = enum_type_resolver::get_enum_type_from_string(enum_value->to_string(), type()); \
+		} \
+	} \
+	void myclass::set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
+	{ \
+		if (!pentity) \
+		{ \
+			return; \
+		} \
+		auto entity_type = std::dynamic_pointer_cast<::odata::edm::edm_entity_type>(pentity->get_value_type()); \
+		if (!entity_type) \
+		{ \
+			return; \
+		} \
+		auto edm_property = entity_type->find_property(_XPLATSTR(#edm_name)); \
+		if (!edm_property) \
+		{ \
+			return; \
+		} \
+		auto property_type = edm_property->get_property_type(); \
+		auto enum_value = ::odata::make_shared<::odata::core::odata_enum_value>(property_type, enum_type_resolver::get_string_from_enum_type(property_name)); \
+		pentity->set_value(_XPLATSTR(#edm_name), enum_value); \
+	}
+
+#define DECLARE_ENUM_PROPERTY_IN_COMPLEX_MAPPING(property_name, edm_name, type) \
+public: \
+	const type& get_##property_name() const { return property_name; } \
+	void set_##property_name(const type& property_value) { property_name = property_value; } \
+protected: \
+	type property_name; \
+	void get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); \
+	void set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex);
+
+#define IMPLEMENT_ENUM_PROPERTY_IN_COMPLEX_MAPPING(myclass, property_name, edm_name, type) \
+	void myclass::get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
+	{ \
+		if (!pcomplex) \
+		{ \
+			return; \
+		} \
+		std::shared_ptr<::odata::core::odata_value> property_value; \
+		if (!pcomplex->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
+		{ \
+			return; \
+		} \
+		auto enum_value = std::dynamic_pointer_cast<::odata::core::odata_enum_value>(property_value); \
+		if (enum_value) \
+		{ \
+			property_name = enum_type_resolver::get_enum_type_from_string(enum_value->to_string(), type()); \
+		} \
+	} \
+	void myclass::set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
+	{ \
+		if (!pcomplex) \
+		{ \
+			return; \
+		} \
+		auto complex_type = std::dynamic_pointer_cast<::odata::edm::edm_complex_type>(pcomplex->get_value_type()); \
+		if (!complex_type) \
+		{ \
+			return; \
+		} \
+		auto edm_property = complex_type->find_property(_XPLATSTR(#edm_name)); \
+		if (!edm_property) \
+		{ \
+			return; \
+		} \
+		auto property_type = edm_property->get_property_type(); \
+		auto enum_value = ::odata::make_shared<::odata::core::odata_enum_value>(property_type, enum_type_resolver::get_string_from_enum_type(property_name)); \
+		pcomplex->set_value(_XPLATSTR(#edm_name), enum_value); \
+	}
+
+#define DECLARE_COLLECTION_ENUM_PROPERTY_IN_ENTITY_MAPPING(property_name, edm_name, type) \
+public: \
+	const std::vector<type>& get_##property_name() const { return property_name; } \
+	void set_##property_name(const std::vector<type>& property_values) { property_name = property_values; } \
+	void add_to_##property_name(type property_value) { property_name.emplace_back(property_value); } \
+protected: \
+	std::vector<type> property_name; \
+	void get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
+	void set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity);
+
+#define IMPLEMENT_COLLECTION_ENUM_PROPERTY_IN_ENTITY_MAPPING(myclass, property_name, edm_name, type) \
+	void myclass::get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
+	{ \
+		std::shared_ptr<::odata::core::odata_value> property_value; \
+		if (!pentity->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
+		{ \
+			return; \
+		} \
+		auto property_collection_value = static_pointer_cast<::odata::core::odata_collection_value>(property_value); \
+		if (!property_collection_value) \
+		{ \
+			return; \
+		} \
+		for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); ++iter) \
+		{ \
+			auto enum_value = std::dynamic_pointer_cast<::odata::core::odata_enum_value>(*iter); \
+			if (!enum_value) \
+			{ \
+				continue; \
+			} \
+			property_name.emplace_back(enum_type_resolver::get_enum_type_from_string(enum_value->to_string(), type())); \
+		} \
+	} \
+	void myclass::set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
+	{ \
+		if (!pentity || !pentity->get_value_type()) \
+		{ \
+			return; \
+		} \
+		auto entity_type = std::dynamic_pointer_cast<::odata::edm::edm_entity_type>(pentity->get_value_type()); \
+		if (!entity_type) \
+		{ \
+			return; \
+		} \
+		auto edm_property = entity_type->find_property(_XPLATSTR(#edm_name)); \
+		if (!edm_property) \
+		{ \
+			return; \
+		} \
+		auto property_type = edm_property->get_property_type(); \
+		auto collection_value_type = std::dynamic_pointer_cast<::odata::edm::edm_collection_type>(property_type); \
+		if (!collection_value_type) \
+		{ \
+			return; \
+		} \
+		std::shared_ptr<::odata::core::odata_collection_value> collection_value = ::odata::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
+		for (size_t i = 0; i < property_name.size(); ++i) \
+		{ \
+			collection_value->add_collection_value(::odata::make_shared<::odata::core::odata_enum_value>(collection_value_type->get_element_type(), enum_type_resolver::get_string_from_enum_type(property_name[i]))); \
+		} \
+		pentity->set_value(_XPLATSTR(#edm_name), collection_value); \
+	}
+
+#define DECLARE_COLLECTION_ENUM_PROPERTY_IN_COMPLEX_MAPPING(property_name, edm_name, type) \
+public: \
+	const std::vector<type>& get_##property_name() const { return property_name; } \
+	void set_##property_name(const std::vector<type>& property_values) { property_name = property_values; } \
+	void add_to_##property_name(type property_value) { property_name.emplace_back(property_value); } \
+protected: \
+	std::vector<type> property_name; \
+	void get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex); \
+	void set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex);
+
+#define IMPLEMENT_COLLECTION_ENUM_PROPERTY_IN_COMPLEX_MAPPING(myclass, property_name, edm_name, type) \
+	void myclass::get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
+	{ \
+		std::shared_ptr<::odata::core::odata_value> property_value; \
+		if (!pcomplex->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
+		{ \
+			return; \
+		} \
+		auto property_collection_value = static_pointer_cast<::odata::core::odata_collection_value>(property_value); \
+		if (!property_collection_value) \
+		{ \
+			return; \
+		} \
+		for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); ++iter) \
+		{ \
+			auto enum_value = std::dynamic_pointer_cast<::odata::core::odata_enum_value>(*iter); \
+			if (!enum_value) \
+			{ \
+				continue; \
+			} \
+			property_name.emplace_back(enum_type_resolver::get_enum_type_from_string(enum_value->to_string(), type())); \
+		} \
+	} \
+	void myclass::set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
+	{ \
+		if (!pcomplex || !pcomplex->get_value_type()) \
+		{ \
+			return; \
+		} \
+		auto complex_type = std::dynamic_pointer_cast<::odata::edm::edm_complex_type>(pcomplex->get_value_type()); \
+		if (!complex_type) \
+		{ \
+			return; \
+		} \
+		auto edm_property = complex_type->find_property(_XPLATSTR(#edm_name)); \
+		if (!edm_property) \
+		{ \
+			return; \
+		} \
+		auto property_type = edm_property->get_property_type(); \
+		auto collection_value_type = std::dynamic_pointer_cast<::odata::edm::edm_collection_type>(property_type); \
+		if (!collection_value_type) \
+		{ \
+			return; \
+		} \
+		std::shared_ptr<::odata::core::odata_collection_value> collection_value = ::odata::make_shared<::odata::core::odata_collection_value>(collection_value_type); \
+		for (size_t i = 0; i < property_name.size(); ++i) \
+		{ \
+			collection_value->add_collection_value(::odata::make_shared<::odata::core::odata_enum_value>(collection_value_type->get_element_type(), enum_type_resolver::get_string_from_enum_type(property_name[i]))); \
+		} \
+		pcomplex->set_value(_XPLATSTR(#edm_name), collection_value); \
 	}
 
 #define DECLARE_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(property_name, edm_name, type) \
 public: \
-	type* get_##property_name() { return property_name.get(); } const \
+	type* get_##property_name() const { return property_name.get(); } \
 	void set_##property_name(type property_value) \
 	{ \
-		property_name = std::make_shared<type>(property_value); \
+		property_name = ::odata::make_shared<type>(property_value); \
 	} \
 protected: \
 	std::shared_ptr<type> property_name; \
 	void get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); \
-	void set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity); 
+	void set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity);
 
 #define IMPLEMENT_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(myclass, property_name, edm_name, type) \
 	void myclass::get_##property_name##_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
 		std::shared_ptr<::odata::core::odata_value> property_value; \
-		if (!pentity->get_property_value(U(#edm_name), property_value) || !property_value) \
+		if (!pentity->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
 		{ \
-			return ; \
+			return; \
 		} \
 		auto enum_value = std::dynamic_pointer_cast<::odata::core::odata_enum_value>(property_value); \
 		if (enum_value) \
 		{ \
-		    property_name = std::make_shared<type>(enum_type_resolver::get_enum_type_from_string(enum_value->to_string(), type())); \
+			property_name = ::odata::make_shared<type>(enum_type_resolver::get_enum_type_from_string(enum_value->to_string(), type())); \
 		} \
 	} \
 	void myclass::set_##property_name##_to_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity) \
 	{ \
 		if (!pentity || !property_name) \
-	    { \
-		    return ; \
-        }  \
+		{ \
+			return; \
+		} \
 		auto entity_type = std::dynamic_pointer_cast<::odata::edm::edm_entity_type>(pentity->get_value_type()); \
 		if (!entity_type) \
 		{ \
-			return ; \
+			return; \
 		} \
-		auto edm_property = entity_type->find_property(U(#edm_name)); \
+		auto edm_property = entity_type->find_property(_XPLATSTR(#edm_name)); \
 		if (!edm_property) \
 		{ \
-			return ; \
+			return; \
 		} \
 		auto property_type = edm_property->get_property_type(); \
-		auto enum_value = std::make_shared<::odata::core::odata_enum_value>(property_type, enum_type_resolver::get_string_from_enum_type(*property_name)); \
-		pentity->set_value(U(#edm_name), enum_value); \
+		auto enum_value = ::odata::make_shared<::odata::core::odata_enum_value>(property_type, enum_type_resolver::get_string_from_enum_type(*property_name)); \
+		pentity->set_value(_XPLATSTR(#edm_name), enum_value); \
 	}
 
 #define DECLARE_NULLABLE_ENUM_PROPERTY_IN_COMPLEX_MAPPING(property_name, edm_name, type) \
 public: \
-	type* get_##property_name() { return property_name.get(); } const \
+	type* get_##property_name() const { return property_name.get(); } \
 	void set_##property_name(type property_value) \
-	{  \
-		property_name = std::make_shared<type>(property_value); \
+	{ \
+		property_name = ::odata::make_shared<type>(property_value); \
 	} \
 protected: \
 	std::shared_ptr<type> property_name; \
@@ -1103,157 +1707,157 @@ protected: \
 	void myclass::get_##property_name##_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
 	{ \
 		std::shared_ptr<::odata::core::odata_value> property_value; \
-		if (!pcomplex->get_property_value(U(#edm_name), property_value) || !property_value) \
+		if (!pcomplex->get_property_value(_XPLATSTR(#edm_name), property_value) || !property_value) \
 		{ \
-			return ; \
+			return; \
 		} \
 		auto enum_value = std::dynamic_pointer_cast<::odata::core::odata_enum_value>(property_value); \
 		if (enum_value) \
 		{ \
-			property_name = std::make_shared<type>(enum_type_resolver::get_enum_type_from_string(enum_value->to_string(), type())); \
+			property_name = ::odata::make_shared<type>(enum_type_resolver::get_enum_type_from_string(enum_value->to_string(), type())); \
 		} \
 	} \
 	void myclass::set_##property_name##_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) \
 	{ \
 		if (!pcomplex || !property_name) \
-	    { \
-		    return ; \
-        }  \
+		{ \
+			return; \
+		} \
 		auto complex_type = std::dynamic_pointer_cast<::odata::edm::edm_complex_type>(pcomplex->get_value_type()); \
 		if (!complex_type) \
 		{ \
-			return ; \
+			return; \
 		} \
-		auto edm_property = complex_type->find_property(U(#edm_name)); \
+		auto edm_property = complex_type->find_property(_XPLATSTR(#edm_name)); \
 		if (!edm_property) \
 		{ \
-			return ; \
+			return; \
 		} \
 		auto property_type = edm_property->get_property_type(); \
-		auto enum_value = std::make_shared<::odata::core::odata_enum_value>(property_type, enum_type_resolver::get_string_from_enum_type(*property_name)); \
-		pcomplex->set_value(U(#edm_name), enum_value); \
+		auto enum_value = ::odata::make_shared<::odata::core::odata_enum_value>(property_type, enum_type_resolver::get_string_from_enum_type(*property_name)); \
+		pcomplex->set_value(_XPLATSTR(#edm_name), enum_value); \
 	}
 
 #define DECLARE_FUNCTION_ENUM_TYPE_FROM_STRING(enum_type) \
-	static enum_type get_enum_type_from_string(const ::utility::string_t& enum_string, enum_type default_enum_value);
+	static enum_type get_enum_type_from_string(const ::odata::string_t& enum_string, enum_type default_enum_value);
 
 #define DECLARE_FUNCTION_STRING_FROM_ENUM_TYPE(enum_type) \
-	static ::utility::string_t get_string_from_enum_type(const enum_type& enum_value);
+	static ::odata::string_t get_string_from_enum_type(const enum_type& enum_value);
 
 #define DECLARE_GET_ENUM_TYPE_NAMESPACE(enum_type, name_space) \
-	static ::utility::string_t get_enum_type_namespace(const enum_type& enum_value); \
+	static ::odata::string_t get_enum_type_namespace(const enum_type& enum_value);
 
 #define IMPLEMENT_GET_ENUM_TYPE_NAMESPACE(enum_type, name_space) \
-	::utility::string_t enum_type_resolver::get_enum_type_namespace(const enum_type& enum_value) \
+	::odata::string_t enum_type_resolver::get_enum_type_namespace(const enum_type& /*enum_value*/) \
 	{ \
-		return U(#name_space); \
+		return _XPLATSTR(#name_space); \
 	}
 
 #define BGEIN_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(enum_type) \
-	enum_type enum_type_resolver::get_enum_type_from_string(const ::utility::string_t& enum_string, enum_type default_enum_value) \
+	enum_type enum_type_resolver::get_enum_type_from_string(const ::odata::string_t& enum_string, enum_type default_enum_value) \
 	{ \
-	    enum_type ret = default_enum_value;
+		enum_type ret = default_enum_value;
 
 #define ON_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(enum_value_string, enum_type) \
-	if (enum_string == U(#enum_value_string)) \
+	if (enum_string == _XPLATSTR(#enum_value_string)) \
 	{ \
 		ret = enum_type; \
 	}
 
 #define END_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(enum_type) \
-	    return ret; \
-    }
+		return ret; \
+	}
 
 #define BGEIN_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(enum_type) \
-	::utility::string_t enum_type_resolver::get_string_from_enum_type(const enum_type& enum_value) \
+	::odata::string_t enum_type_resolver::get_string_from_enum_type(const enum_type& enum_value) \
 	{ \
-	    ::utility::string_t ret;
+		::odata::string_t ret;
 
 #define ON_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(enum_type, enum_value_string) \
 	if (enum_value == enum_type) \
 	{ \
-	    ret = U(#enum_value_string); \
+		ret = _XPLATSTR(#enum_value_string); \
 	}
 
 #define END_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(enum_type) \
-	    return ret; \
-    }
+		return ret; \
+	}
 
 #define IMPLEMENT_EMPTY_DERIVED_TYPE_CREATOR_MAP(myclass) \
-    std::unordered_map<::utility::string_t, CREATE_CALL_FOR_ENTITY> myclass::_derived_entity_creator_map;
+	std::unordered_map<::odata::string_t, CREATE_CALL_FOR_ENTITY> myclass::_derived_entity_creator_map;
 
 #define BEGIN_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(myclass) \
-    create_map_for_entity_type::value_type myclass::_init_creator_map_values[] = {
+	create_map_for_entity_type::value_type myclass::_init_creator_map_values[] = {
 
 #define ON_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(keyname, funcname) \
-    create_map_for_entity_type::value_type(U(#keyname), (CREATE_CALL_FOR_ENTITY)&create_##funcname),
+	create_map_for_entity_type::value_type(_XPLATSTR(#keyname), (CREATE_CALL_FOR_ENTITY)&create_##funcname),
 
 #define END_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(myclass) \
-    }; \
-    std::unordered_map<::utility::string_t, CREATE_CALL_FOR_ENTITY> myclass::_derived_entity_creator_map(_init_creator_map_values, _init_creator_map_values + sizeof(_init_creator_map_values) / sizeof(create_map_for_entity_type::value_type));
+	}; \
+	std::unordered_map<::odata::string_t, CREATE_CALL_FOR_ENTITY> myclass::_derived_entity_creator_map(_init_creator_map_values, _init_creator_map_values + sizeof(_init_creator_map_values) / sizeof(create_map_for_entity_type::value_type));
 
 #define DECLARE_DERIVED_ENTITY_CREATOR_FUNC(derivedclassname, funcname) \
-    static std::shared_ptr<type_base> create_##funcname(const std::shared_ptr<::odata::codegen::odata_service_context>& service_context) \
-    { \
-        return std::make_shared<derivedclassname>(service_context); \
-    }
+	static std::shared_ptr<type_base> create_##funcname(const std::shared_ptr<::odata::codegen::odata_service_context>& service_context) \
+	{ \
+		return ::odata::make_shared<derivedclassname>(service_context); \
+	}
 
 #define IMPLEMENT_COMPLEX_DERIVED_TYPE_CREATOR_MAP(myclass) \
-    std::unordered_map<::utility::string_t, CREATE_CALL_FOR_COMPLEX> myclass::_derived_complex_creator_map;
+	std::unordered_map<::odata::string_t, CREATE_CALL_FOR_COMPLEX> myclass::_derived_complex_creator_map;
 
 #define BEGIN_IMPLEMENT_COMPLEX_DERIVED_TYPE_CREATOR_MAP(myclass) \
-    create_map_for_complex_type::value_type myclass::_init_creator_map_values[] = {
+	create_map_for_complex_type::value_type myclass::_init_creator_map_values[] = {
 
 #define ON_IMPLEMENT_COMPLEX_DERIVED_TYPE_CREATOR_MAP(keyname, funcname) \
-    create_map_for_complex_type::value_type(U(#keyname), (CREATE_CALL_FOR_COMPLEX)&create_##funcname),
+	create_map_for_complex_type::value_type(_XPLATSTR(#keyname), (CREATE_CALL_FOR_COMPLEX)&create_##funcname),
 
 #define END_IMPLEMENT_COMPLEX_DERIVED_TYPE_CREATOR_MAP(myclass) \
-    }; \
-    std::unordered_map<::utility::string_t, CREATE_CALL_FOR_COMPLEX> myclass::_derived_complex_creator_map(_init_creator_map_values, _init_creator_map_values + sizeof(_init_creator_map_values) / sizeof(create_map_for_entity_type::value_type));
+	}; \
+	std::unordered_map<::odata::string_t, CREATE_CALL_FOR_COMPLEX> myclass::_derived_complex_creator_map(_init_creator_map_values, _init_creator_map_values + sizeof(_init_creator_map_values) / sizeof(create_map_for_entity_type::value_type));
 
 #define DECLARE_DERIVED_COMPLEX_CREATOR_FUNC(derivedclassname, funcname) \
-    static std::shared_ptr<type_base> create_##funcname(const std::shared_ptr<::odata::codegen::odata_service_context>& service_context) \
-    { \
-        return std::make_shared<derivedclassname>(service_context); \
-    }
+	static std::shared_ptr<type_base> create_##funcname(const std::shared_ptr<::odata::codegen::odata_service_context>& service_context) \
+	{ \
+		return ::odata::make_shared<derivedclassname>(service_context); \
+	}
 
 #define DECLARE_GET_KEY_PROPERTY_STRING_NO_PARAM(baseclass) \
 public: \
-	::utility::string_t get_key_property_string(bool with_key_name = false) \
+	::odata::string_t get_key_property_string(bool with_key_name = false) \
 	{ \
 		return baseclass::get_key_property_string(with_key_name); \
 	}
 
 #define DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(baseclass, Name_1, key_1) \
 public: \
-	::utility::string_t get_key_property_string(bool with_key_name = false) \
+	::odata::string_t get_key_property_string(bool with_key_name = false) \
 	{ \
-	    ::utility::stringstream_t ostr; \
-		::utility::string_t key_string = baseclass::get_key_property_string(with_key_name); \
+		::utility::stringstream_t ostr; \
+		::odata::string_t key_string = baseclass::get_key_property_string(with_key_name); \
 		if (key_string.empty()) \
 		{ \
-		    if (with_key_name) \
-			    ostr << U(#Name_1) << U("=") << ::utility::conversions::print_string(key_1); \
+			if (with_key_name) \
+				ostr << _XPLATSTR(#Name_1) << _XPLATSTR("=") << ::utility::conversions::print_string(key_1); \
 			else \
-		        ostr << ::utility::conversions::print_string(key_1); \
+				ostr << ::utility::conversions::print_string(key_1); \
 			key_string = ostr.str(); \
 		} \
 		else \
 		{ \
-		    key_string = baseclass::get_key_property_string(true); \
-			ostr << U(#Name_1) << U("=") << ::utility::conversions::print_string(key_1); \
-			key_string += U(",") + ostr.str(); \
+			key_string = baseclass::get_key_property_string(true); \
+			ostr << _XPLATSTR(#Name_1) << _XPLATSTR("=") << ::utility::conversions::print_string(key_1); \
+			key_string += _XPLATSTR(",") + ostr.str(); \
 		} \
 		return key_string; \
 	}
 
 #define DECLARE_GET_KEY_PROPERTY_STRING_TWO_PARAM(baseclass, Name_1, key_1, Name_2, key_2) \
 public: \
-	::utility::string_t get_key_property_string(bool with_key_name = false) \
+	::odata::string_t get_key_property_string(bool /*with_key_name*/ = false) \
 	{ \
-	    ::utility::stringstream_t ostr; \
-		ostr << U(#Name_1) << U("=") << ::utility::conversions::print_string(key_1) << U(",") << U(#Name_2) << U("=") + ::utility::conversions::print_string(key_2); \
-		::utility::string_t key_string = baseclass::get_key_property_string(true); \
+		::utility::stringstream_t ostr; \
+		ostr << _XPLATSTR(#Name_1) << _XPLATSTR("=") << ::utility::conversions::print_string(key_1) << _XPLATSTR(",") << _XPLATSTR(#Name_2) << _XPLATSTR("=") + ::utility::conversions::print_string(key_2); \
+		::odata::string_t key_string = baseclass::get_key_property_string(true); \
 		if (key_string.empty()) \
 		{ \
 			key_string = ostr.str(); \
@@ -1267,11 +1871,11 @@ public: \
 
 #define DECLARE_GET_KEY_PROPERTY_STRING_THREE_PARAM(baseclass, Name_1, key_1, Name_2, key_2, Name_3, key_3) \
 public: \
-	::utility::string_t get_key_property_string(bool with_key_name = false) \
+	::odata::string_t get_key_property_string(bool /*with_key_name*/ = false) \
 	{ \
-	    ::utility::stringstream_t ostr; \
-		ostr << U(#Name_1) << U("=") << ::utility::conversions::print_string(key_1) << U(",") << U(#Name_2) << U("=") << ::utility::conversions::print_string(key_2) << U(",") << U(#Name_3) << U("=") << ::utility::conversions::print_string(key_3);\
-		::utility::string_t key_string = baseclass::get_key_property_string(true); \
+		::utility::stringstream_t ostr; \
+		ostr << _XPLATSTR(#Name_1) << _XPLATSTR("=") << ::utility::conversions::print_string(key_1) << _XPLATSTR(",") << _XPLATSTR(#Name_2) << _XPLATSTR("=") << ::utility::conversions::print_string(key_2) << _XPLATSTR(",") << _XPLATSTR(#Name_3) << _XPLATSTR("=") << ::utility::conversions::print_string(key_3);\
+		::odata::string_t key_string = baseclass::get_key_property_string(true); \
 		if (key_string.empty()) \
 		{ \
 			key_string = ostr.str(); \
@@ -1285,11 +1889,11 @@ public: \
 
 #define DECLARE_GET_KEY_PROPERTY_STRING_FOUR_PARAM(baseclass, Name_1, key_1, Name_2, key_2, Name_3, key_3, Name_4, key_4) \
 public: \
-	::utility::string_t get_key_property_string(bool with_key_name = false) \
+	::odata::string_t get_key_property_string(bool /*with_key_name*/ = false) \
 	{ \
-	    ::utility::stringstream_t ostr; \
-		ostr << U(#Name_1) << U("=") << ::utility::conversions::print_string(key_1) << U(",") << U(#Name_2) << U("=") << ::utility::conversions::print_string(key_2) << U(",") << U(#Name_3) << U("=") << ::utility::conversions::print_string(key_3) << U(",") << U(#Name_4) << U("=") << ::utility::conversions::print_string(key_4);\
-		::utility::string_t key_string = baseclass::get_key_property_string(true); \
+		::utility::stringstream_t ostr; \
+		ostr << _XPLATSTR(#Name_1) << _XPLATSTR("=") << ::utility::conversions::print_string(key_1) << _XPLATSTR(",") << _XPLATSTR(#Name_2) << _XPLATSTR("=") << ::utility::conversions::print_string(key_2) << _XPLATSTR(",") << _XPLATSTR(#Name_3) << _XPLATSTR("=") << ::utility::conversions::print_string(key_3) << _XPLATSTR(",") << _XPLATSTR(#Name_4) << _XPLATSTR("=") << ::utility::conversions::print_string(key_4);\
+		::odata::string_t key_string = baseclass::get_key_property_string(true); \
 		if (key_string.empty()) \
 		{ \
 			key_string = ostr.str(); \
@@ -1308,7 +1912,7 @@ public: \
 #define IMPLEMENT_OPERATION_IMPORT_P0(myclass, funcname, executor, isfunction) \
 ::pplx::task<typename executor::return_type> myclass::funcname() \
 { \
-    ::utility::string_t function_query_url = U(#funcname); \
+	::odata::string_t function_query_url = _XPLATSTR(#funcname); \
 	std::vector<std::shared_ptr<odata_parameter>> parameters; \
 	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
 }
@@ -1320,9 +1924,9 @@ public: \
 #define IMPLEMENT_OPERATION_IMPORT_P1(myclass, funcname, executor, isfunction, key1, type1, value1) \
 ::pplx::task<typename executor::return_type> myclass::funcname(type1 value1) \
 { \
-    ::utility::string_t function_query_url = U(#funcname); \
+	::odata::string_t function_query_url = _XPLATSTR(#funcname); \
 	std::vector<std::shared_ptr<odata_parameter>> parameters; \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
 	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
 }
 
@@ -1333,11 +1937,11 @@ public: \
 #define IMPLEMENT_OPERATION_IMPORT_P2(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2) \
 ::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2) \
 { \
-    ::utility::string_t function_query_url = U(#funcname); \
+	::odata::string_t function_query_url = _XPLATSTR(#funcname); \
 	std::vector<std::shared_ptr<odata_parameter>> parameters; \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key1), format_function_parameter(value1))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key2), format_function_parameter(value2))); \
-	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction);  \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2), format_function_parameter(value2))); \
+	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
 }
 
 #define DECLARE_OPERATION_IMPORT_P3(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3) \
@@ -1345,14 +1949,14 @@ public: \
 ::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3);
 
 #define IMPLEMENT_OPERATION_IMPORT_P3(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3) \
-::pplx::task<typename EXECUTOR::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3) \
 { \
-    ::utility::string_t function_query_url = U(#funcname); \
+	::odata::string_t function_query_url = _XPLATSTR(#funcname); \
 	std::vector<std::shared_ptr<odata_parameter>> parameters; \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key1), format_function_parameter(value1))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key2), format_function_parameter(value2))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key3), format_function_parameter(value3))); \
-	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction);  \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2), format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3), format_function_parameter(value3))); \
+	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
 }
 
 #define DECLARE_OPERATION_IMPORT_P4(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4) \
@@ -1360,15 +1964,15 @@ public: \
 ::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3, type4 value4);
 
 #define IMPLEMENT_OPERATION_IMPORT_P4(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4) \
-::pplx::task<typename EXECUTOR::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4) \
 { \
-    ::utility::string_t function_query_url = U(#funcname); \
+	::odata::string_t function_query_url = _XPLATSTR(#funcname); \
 	std::vector<std::shared_ptr<odata_parameter>> parameters; \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key1), format_function_parameter(value1))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key2), format_function_parameter(value2))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key3), format_function_parameter(value3))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key4), format_function_parameter(value4))); \
-	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction);  \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2), format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3), format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4), format_function_parameter(value4))); \
+	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
 }
 
 #define DECLARE_OPERATION_IMPORT_P5(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5) \
@@ -1376,16 +1980,163 @@ public: \
 ::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5);
 
 #define IMPLEMENT_OPERATION_IMPORT_P5(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5) \
-::pplx::task<typename EXECUTOR::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5) \
 { \
-    ::utility::string_t function_query_url = U(#funcname); \
+	::odata::string_t function_query_url = _XPLATSTR(#funcname); \
 	std::vector<std::shared_ptr<odata_parameter>> parameters; \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key1), format_function_parameter(value1))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key2), format_function_parameter(value2))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key3), format_function_parameter(value3))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key4), format_function_parameter(value4))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key5), format_function_parameter(value5))); \
-	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction);  \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2), format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3), format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4), format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key5), format_function_parameter(value5))); \
+	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
+}
+
+#define DECLARE_OPERATION_IMPORT_P6(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6) \
+public: \
+::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6);
+
+#define IMPLEMENT_OPERATION_IMPORT_P6(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6) \
+{ \
+	::odata::string_t function_query_url = _XPLATSTR(#funcname); \
+	std::vector<std::shared_ptr<odata_parameter>> parameters; \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2), format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3), format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4), format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key5), format_function_parameter(value5))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key6), format_function_parameter(value6))); \
+	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
+}
+
+#define DECLARE_OPERATION_IMPORT_P7(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7) \
+public: \
+::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7);
+
+#define IMPLEMENT_OPERATION_IMPORT_P7(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7) \
+{ \
+	::odata::string_t function_query_url = _XPLATSTR(#funcname); \
+	std::vector<std::shared_ptr<odata_parameter>> parameters; \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2), format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3), format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4), format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key5), format_function_parameter(value5))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key6), format_function_parameter(value6))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key7), format_function_parameter(value7))); \
+	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
+}
+
+#define DECLARE_OPERATION_IMPORT_P8(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8) \
+public: \
+::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8);
+
+#define IMPLEMENT_OPERATION_IMPORT_P8(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8) \
+{ \
+	::odata::string_t function_query_url = _XPLATSTR(#funcname); \
+	std::vector<std::shared_ptr<odata_parameter>> parameters; \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2), format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3), format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4), format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key5), format_function_parameter(value5))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key6), format_function_parameter(value6))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key7), format_function_parameter(value7))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key8), format_function_parameter(value8))); \
+	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
+}
+
+#define DECLARE_OPERATION_IMPORT_P9(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9) \
+public: \
+::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8, type9 value9);
+
+#define IMPLEMENT_OPERATION_IMPORT_P9(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8, type9 value9) \
+{ \
+	::odata::string_t function_query_url = _XPLATSTR(#funcname); \
+	std::vector<std::shared_ptr<odata_parameter>> parameters; \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2), format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3), format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4), format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key5), format_function_parameter(value5))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key6), format_function_parameter(value6))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key7), format_function_parameter(value7))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key8), format_function_parameter(value8))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key9), format_function_parameter(value9))); \
+	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
+}
+
+#define DECLARE_OPERATION_IMPORT_P10(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10) \
+public: \
+::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8, type9 value9, type10 value10);
+
+#define IMPLEMENT_OPERATION_IMPORT_P10(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8, type9 value9, type10 value10) \
+{ \
+	::odata::string_t function_query_url = _XPLATSTR(#funcname); \
+	std::vector<std::shared_ptr<odata_parameter>> parameters; \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1),  format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2),  format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3),  format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4),  format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key5),  format_function_parameter(value5))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key6),  format_function_parameter(value6))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key7),  format_function_parameter(value7))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key8),  format_function_parameter(value8))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key9),  format_function_parameter(value9))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key10), format_function_parameter(value10))); \
+	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
+}
+
+#define DECLARE_OPERATION_IMPORT_P11(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11) \
+public: \
+::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8, type9 value9, type10 value10, type11 value11);
+
+#define IMPLEMENT_OPERATION_IMPORT_P11(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8, type9 value9, type10 value10, type11 value11) \
+{ \
+	::odata::string_t function_query_url = _XPLATSTR(#funcname); \
+	std::vector<std::shared_ptr<odata_parameter>> parameters; \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1),  format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2),  format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3),  format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4),  format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key5),  format_function_parameter(value5))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key6),  format_function_parameter(value6))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key7),  format_function_parameter(value7))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key8),  format_function_parameter(value8))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key9),  format_function_parameter(value9))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key10), format_function_parameter(value10))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key11), format_function_parameter(value11))); \
+	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
+}
+
+#define DECLARE_OPERATION_IMPORT_P12(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12) \
+public: \
+::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8, type9 value9, type10 value10, type11 value11, type12 value12);
+
+#define IMPLEMENT_OPERATION_IMPORT_P12(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8, type9 value9, type10 value10, type11 value11, type12 value12) \
+{ \
+	::odata::string_t function_query_url = _XPLATSTR(#funcname); \
+	std::vector<std::shared_ptr<odata_parameter>> parameters; \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1),  format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2),  format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3),  format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4),  format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key5),  format_function_parameter(value5))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key6),  format_function_parameter(value6))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key7),  format_function_parameter(value7))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key8),  format_function_parameter(value8))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key9),  format_function_parameter(value9))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key10), format_function_parameter(value10))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key11), format_function_parameter(value11))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key12), format_function_parameter(value12))); \
+	return create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
 }
 
 #define DECLARE_OPERATION_P0(myclass, funcname, executor, isfunction) \
@@ -1395,10 +2146,10 @@ public: \
 #define IMPLEMENT_OPERATION_P0(myclass, funcname, executor, isfunction) \
 ::pplx::task<typename executor::return_type> myclass::funcname() \
 { \
-	::utility::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + U("/"); \
+	::odata::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/"); \
 	function_query_url += m_namespace; \
-	function_query_url += U("."); \
-	function_query_url += U(#funcname); \
+	function_query_url += _XPLATSTR("."); \
+	function_query_url += _XPLATSTR(#funcname); \
 	std::vector<std::shared_ptr<odata_parameter>> parameters; \
 	return m_service_context->create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
 }
@@ -1410,12 +2161,12 @@ public: \
 #define IMPLEMENT_OPERATION_P1(myclass, funcname, executor, isfunction, key1, type1, value1) \
 ::pplx::task<typename executor::return_type> myclass::funcname(type1 value1) \
 { \
-	::utility::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + U("/"); \
+	::odata::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/"); \
 	function_query_url += m_namespace; \
-	function_query_url += U("."); \
-	function_query_url += U(#funcname); \
+	function_query_url += _XPLATSTR("."); \
+	function_query_url += _XPLATSTR(#funcname); \
 	std::vector<std::shared_ptr<odata_parameter>> parameters; \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
 	return m_service_context->create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
 }
 
@@ -1424,15 +2175,15 @@ public: \
 ::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2);
 
 #define IMPLEMENT_OPERATION_P2(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2) \
-                ::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2) \
+		::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2) \
 { \
-	::utility::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + U("/"); \
+	::odata::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/"); \
 	function_query_url += m_namespace; \
-	function_query_url += U("."); \
-	function_query_url += U(#funcname); \
+	function_query_url += _XPLATSTR("."); \
+	function_query_url += _XPLATSTR(#funcname); \
 	std::vector<std::shared_ptr<odata_parameter>> parameters; \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key1), format_function_parameter(value1))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key2), format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2), format_function_parameter(value2))); \
 	return m_service_context->create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
 }
 
@@ -1443,14 +2194,14 @@ public: \
 #define IMPLEMENT_OPERATION_P3(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3) \
 ::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3) \
 { \
-	::utility::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + U("/"); \
+	::odata::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/"); \
 	function_query_url += m_namespace; \
-	function_query_url += U("."); \
-	function_query_url += U(#funcname); \
+	function_query_url += _XPLATSTR("."); \
+	function_query_url += _XPLATSTR(#funcname); \
 	std::vector<std::shared_ptr<odata_parameter>> parameters; \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key1), format_function_parameter(value1))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key2), format_function_parameter(value2))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key3), format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2), format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3), format_function_parameter(value3))); \
 	return m_service_context->create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
 }
 
@@ -1461,15 +2212,15 @@ public: \
 #define IMPLEMENT_OPERATION_P4(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4) \
 ::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4) \
 { \
-	::utility::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + U("/"); \
+	::odata::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/"); \
 	function_query_url += m_namespace; \
-	function_query_url += U("."); \
-	function_query_url += U(#funcname); \
+	function_query_url += _XPLATSTR("."); \
+	function_query_url += _XPLATSTR(#funcname); \
 	std::vector<std::shared_ptr<odata_parameter>> parameters; \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key1), format_function_parameter(value1))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key2), format_function_parameter(value2))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key3), format_function_parameter(value3))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key4), format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2), format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3), format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4), format_function_parameter(value4))); \
 	return m_service_context->create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
 }
 
@@ -1480,16 +2231,184 @@ public: \
 #define IMPLEMENT_OPERATION_P5(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5) \
 ::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5) \
 { \
-	::utility::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + U("/"); \
+	::odata::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/"); \
 	function_query_url += m_namespace; \
-	function_query_url += U("."); \
-	function_query_url += U(#funcname); \
+	function_query_url += _XPLATSTR("."); \
+	function_query_url += _XPLATSTR(#funcname); \
 	std::vector<std::shared_ptr<odata_parameter>> parameters; \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key1), format_function_parameter(value1))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key2), format_function_parameter(value2))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key3), format_function_parameter(value3))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key4), format_function_parameter(value4))); \
-	parameters.push_back(std::make_shared<odata_parameter>(U(#key5), format_function_parameter(value5))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2), format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3), format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4), format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key5), format_function_parameter(value5))); \
+	return m_service_context->create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
+}
+
+#define DECLARE_OPERATION_P6(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6) \
+public: \
+::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6);
+
+#define IMPLEMENT_OPERATION_P6(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6) \
+{ \
+	::odata::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/"); \
+	function_query_url += m_namespace; \
+	function_query_url += _XPLATSTR("."); \
+	function_query_url += _XPLATSTR(#funcname); \
+	std::vector<std::shared_ptr<odata_parameter>> parameters; \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2), format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3), format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4), format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key5), format_function_parameter(value5))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key6), format_function_parameter(value6))); \
+	return m_service_context->create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
+}
+
+#define DECLARE_OPERATION_P7(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7) \
+public: \
+::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7);
+
+#define IMPLEMENT_OPERATION_P7(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7) \
+{ \
+	::odata::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/"); \
+	function_query_url += m_namespace; \
+	function_query_url += _XPLATSTR("."); \
+	function_query_url += _XPLATSTR(#funcname); \
+	std::vector<std::shared_ptr<odata_parameter>> parameters; \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2), format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3), format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4), format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key5), format_function_parameter(value5))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key6), format_function_parameter(value6))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key7), format_function_parameter(value7))); \
+	return m_service_context->create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
+}
+
+#define DECLARE_OPERATION_P8(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8) \
+public: \
+::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8);
+
+#define IMPLEMENT_OPERATION_P8(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8) \
+{ \
+	::odata::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/"); \
+	function_query_url += m_namespace; \
+	function_query_url += _XPLATSTR("."); \
+	function_query_url += _XPLATSTR(#funcname); \
+	std::vector<std::shared_ptr<odata_parameter>> parameters; \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2), format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3), format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4), format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key5), format_function_parameter(value5))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key6), format_function_parameter(value6))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key7), format_function_parameter(value7))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key8), format_function_parameter(value8))); \
+	return m_service_context->create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
+}
+
+#define DECLARE_OPERATION_P9(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9) \
+public: \
+::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8, type9 value9);
+
+#define IMPLEMENT_OPERATION_P9(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8, type9 value9) \
+{ \
+	::odata::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/"); \
+	function_query_url += m_namespace; \
+	function_query_url += _XPLATSTR("."); \
+	function_query_url += _XPLATSTR(#funcname); \
+	std::vector<std::shared_ptr<odata_parameter>> parameters; \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1), format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2), format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3), format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4), format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key5), format_function_parameter(value5))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key6), format_function_parameter(value6))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key7), format_function_parameter(value7))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key8), format_function_parameter(value8))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key9), format_function_parameter(value9))); \
+	return m_service_context->create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
+}
+
+#define DECLARE_OPERATION_P10(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10) \
+public: \
+::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8, type9 value9, type10 value10);
+
+#define IMPLEMENT_OPERATION_P10(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8, type9 value9, type10 value10) \
+{ \
+	::odata::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/"); \
+	function_query_url += m_namespace; \
+	function_query_url += _XPLATSTR("."); \
+	function_query_url += _XPLATSTR(#funcname); \
+	std::vector<std::shared_ptr<odata_parameter>> parameters; \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1),  format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2),  format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3),  format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4),  format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key5),  format_function_parameter(value5))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key6),  format_function_parameter(value6))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key7),  format_function_parameter(value7))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key8),  format_function_parameter(value8))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key9),  format_function_parameter(value9))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key10), format_function_parameter(value10))); \
+	return m_service_context->create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
+}
+
+#define DECLARE_OPERATION_P11(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11) \
+public: \
+::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8, type9 value9, type10 value10, type11 value11);
+
+#define IMPLEMENT_OPERATION_P11(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8, type9 value9, type10 value10, type11 value11) \
+{ \
+	::odata::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/"); \
+	function_query_url += m_namespace; \
+	function_query_url += _XPLATSTR("."); \
+	function_query_url += _XPLATSTR(#funcname); \
+	std::vector<std::shared_ptr<odata_parameter>> parameters; \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1),  format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2),  format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3),  format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4),  format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key5),  format_function_parameter(value5))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key6),  format_function_parameter(value6))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key7),  format_function_parameter(value7))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key8),  format_function_parameter(value8))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key9),  format_function_parameter(value9))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key10), format_function_parameter(value10))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key11), format_function_parameter(value11))); \
+	return m_service_context->create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
+}
+
+#define DECLARE_OPERATION_P12(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12) \
+public: \
+::pplx::task<typename executor::return_type> funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8, type9 value9, type10 value10, type11 value11, type12 value12);
+
+#define IMPLEMENT_OPERATION_P12(myclass, funcname, executor, isfunction, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12) \
+::pplx::task<typename executor::return_type> myclass::funcname(type1 value1, type2 value2, type3 value3, type4 value4, type5 value5, type6 value6, type7 value7, type8 value8, type9 value9, type10 value10, type11 value11, type12 value12) \
+{ \
+	::odata::string_t function_query_url = m_service_context->get_relative_path(m_edit_link) + _XPLATSTR("/"); \
+	function_query_url += m_namespace; \
+	function_query_url += _XPLATSTR("."); \
+	function_query_url += _XPLATSTR(#funcname); \
+	std::vector<std::shared_ptr<odata_parameter>> parameters; \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key1),  format_function_parameter(value1))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key2),  format_function_parameter(value2))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key3),  format_function_parameter(value3))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key4),  format_function_parameter(value4))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key5),  format_function_parameter(value5))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key6),  format_function_parameter(value6))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key7),  format_function_parameter(value7))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key8),  format_function_parameter(value8))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key9),  format_function_parameter(value9))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key10), format_function_parameter(value10))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key11), format_function_parameter(value11))); \
+	parameters.emplace_back(::odata::make_shared<odata_parameter>(_XPLATSTR(#key12), format_function_parameter(value12))); \
 	return m_service_context->create_query<executor, odata_query_builder>(function_query_url)->execute_operation_query(parameters, isfunction); \
 }
 
@@ -1517,41 +2436,137 @@ public: \
 #define IMPLEMENT_FUNCTION_IMPORT_P3(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3) \
 	IMPLEMENT_OPERATION_IMPORT_P3(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3)
 
+#define DECLARE_FUNCTION_IMPORT_P4(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4) \
+	DECLARE_OPERATION_IMPORT_P4(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4)
+
 #define IMPLEMENT_FUNCTION_IMPORT_P4(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4) \
 	IMPLEMENT_OPERATION_IMPORT_P4(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4)
+
+#define DECLARE_FUNCTION_IMPORT_P5(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5) \
+	DECLARE_OPERATION_IMPORT_P5(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5)
 
 #define IMPLEMENT_FUNCTION_IMPORT_P5(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5) \
 	IMPLEMENT_OPERATION_IMPORT_P5(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5)
 
+#define DECLARE_FUNCTION_IMPORT_P6(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6) \
+	DECLARE_OPERATION_IMPORT_P6(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6)
+
+#define IMPLEMENT_FUNCTION_IMPORT_P6(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6) \
+	IMPLEMENT_OPERATION_IMPORT_P6(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6)
+
+#define DECLARE_FUNCTION_IMPORT_P7(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7) \
+	DECLARE_OPERATION_IMPORT_P7(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7)
+
+#define IMPLEMENT_FUNCTION_IMPORT_P7(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7) \
+	IMPLEMENT_OPERATION_IMPORT_P7(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7)
+
+#define DECLARE_FUNCTION_IMPORT_P8(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8) \
+	DECLARE_OPERATION_IMPORT_P8(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8)
+
+#define IMPLEMENT_FUNCTION_IMPORT_P8(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8) \
+	IMPLEMENT_OPERATION_IMPORT_P8(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8)
+
+#define DECLARE_FUNCTION_IMPORT_P9(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9) \
+	DECLARE_OPERATION_IMPORT_P9(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9)
+
+#define IMPLEMENT_FUNCTION_IMPORT_P9(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9) \
+	IMPLEMENT_OPERATION_IMPORT_P9(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9)
+
+#define DECLARE_FUNCTION_IMPORT_P10(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10) \
+	DECLARE_OPERATION_IMPORT_P10(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10)
+
+#define IMPLEMENT_FUNCTION_IMPORT_P10(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10) \
+	IMPLEMENT_OPERATION_IMPORT_P10(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10)
+
+#define DECLARE_FUNCTION_IMPORT_P11(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11) \
+	DECLARE_OPERATION_IMPORT_P11(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11)
+
+#define IMPLEMENT_FUNCTION_IMPORT_P11(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11) \
+	IMPLEMENT_OPERATION_IMPORT_P11(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11)
+
+#define DECLARE_FUNCTION_IMPORT_P12(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12) \
+	DECLARE_OPERATION_IMPORT_P12(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12)
+
+#define IMPLEMENT_FUNCTION_IMPORT_P12(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12) \
+	IMPLEMENT_OPERATION_IMPORT_P12(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12)
+
 #define DECLARE_FUNCTION_P0(myclass, funcname, executor) \
-    DECLARE_OPERATION_P0(myclass, funcname, executor, true)
+	DECLARE_OPERATION_P0(myclass, funcname, executor, true)
 
 #define IMPLEMENT_FUNCTION_P0(myclass, funcname, executor) \
-    IMPLEMENT_OPERATION_P0(myclass, funcname, executor, true)
+	IMPLEMENT_OPERATION_P0(myclass, funcname, executor, true)
 
 #define DECLARE_FUNCTION_P1(myclass, funcname, executor, key1, type1, value1) \
-    DECLARE_OPERATION_P1(myclass, funcname, executor, true, key1, type1, value1)
+	DECLARE_OPERATION_P1(myclass, funcname, executor, true, key1, type1, value1)
 
 #define IMPLEMENT_FUNCTION_P1(myclass, funcname, executor, key1, type1, value1) \
-    IMPLEMENT_OPERATION_P1(myclass, funcname, executor, true, key1, type1, value1)
+	IMPLEMENT_OPERATION_P1(myclass, funcname, executor, true, key1, type1, value1)
 
 #define DECLARE_FUNCTION_P2(myclass, funcname, executor, key1, type1, value1, key2, type2, value2) \
-    DECLARE_OPERATION_P2(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2)
+	DECLARE_OPERATION_P2(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2)
 
 #define IMPLEMENT_FUNCTION_P2(myclass, funcname, executor, key1, type1, value1, key2, type2, value2) \
-    IMPLEMENT_OPERATION_P2(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2)
+	IMPLEMENT_OPERATION_P2(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2)
 
 #define DECLARE_FUNCTION_P3(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3) \
-    DECLARE_OPERATION_P3(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3)
+	DECLARE_OPERATION_P3(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3)
 
 #define IMPLEMENT_FUNCTION_P3(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3) \
-   IMPLEMENT_OPERATION_P3(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3)
+	IMPLEMENT_OPERATION_P3(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3)
+
+#define DECLARE_FUNCTION_P4(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4) \
+	DECLARE_OPERATION_P4(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4)
 
 #define IMPLEMENT_FUNCTION_P4(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4) \
-   IMPLEMENT_OPERATION_P4(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4)
+	IMPLEMENT_OPERATION_P4(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4)
+
+#define DECLARE_FUNCTION_P5(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5) \
+	DECLARE_OPERATION_P5(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5)
 
 #define IMPLEMENT_FUNCTION_P5(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5) \
-   IMPLEMENT_OPERATION_P5(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5)
+	IMPLEMENT_OPERATION_P5(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5)
+
+#define DECLARE_FUNCTION_P6(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6) \
+	DECLARE_OPERATION_P6(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6)
+
+#define IMPLEMENT_FUNCTION_P6(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6) \
+	IMPLEMENT_OPERATION_P6(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6)
+
+#define DECLARE_FUNCTION_P7(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7) \
+	DECLARE_OPERATION_P7(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7)
+
+#define IMPLEMENT_FUNCTION_P7(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7) \
+	IMPLEMENT_OPERATION_P7(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7)
+
+#define DECLARE_FUNCTION_P8(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8) \
+	DECLARE_OPERATION_P8(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8)
+
+#define IMPLEMENT_FUNCTION_P8(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8) \
+	IMPLEMENT_OPERATION_P8(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8)
+
+#define DECLARE_FUNCTION_P9(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9) \
+	DECLARE_OPERATION_P9(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9)
+
+#define IMPLEMENT_FUNCTION_P9(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9) \
+	IMPLEMENT_OPERATION_P9(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9)
+
+#define DECLARE_FUNCTION_P10(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10) \
+	DECLARE_OPERATION_P10(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10)
+
+#define IMPLEMENT_FUNCTION_P10(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10) \
+	IMPLEMENT_OPERATION_P10(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10)
+
+#define DECLARE_FUNCTION_P11(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11) \
+	DECLARE_OPERATION_P11(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11)
+
+#define IMPLEMENT_FUNCTION_P11(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11) \
+	IMPLEMENT_OPERATION_P11(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11)
+
+#define DECLARE_FUNCTION_P12(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12) \
+	DECLARE_OPERATION_P12(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12)
+
+#define IMPLEMENT_FUNCTION_P12(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12) \
+	IMPLEMENT_OPERATION_P12(myclass, funcname, executor, true, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12)
 
 #define DECLARE_ACTION_IMPORT_P0(myclass, funcname, executor) \
 	DECLARE_OPERATION_IMPORT_P0(myclass, funcname, executor, false)
@@ -1574,49 +2589,139 @@ public: \
 #define DECLARE_ACTION_IMPORT_P3(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3) \
 	DECLARE_OPERATION_IMPORT_P3(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3)
 
+#define IMPLEMENT_ACTION_IMPORT_P3(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3) \
+	IMPLEMENT_OPERATION_IMPORT_P3(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3)
+
 #define DECLARE_ACTION_IMPORT_P4(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4) \
 	DECLARE_OPERATION_IMPORT_P4(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4)
+
+#define IMPLEMENT_ACTION_IMPORT_P4(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4) \
+	IMPLEMENT_OPERATION_IMPORT_P4(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4)
 
 #define DECLARE_ACTION_IMPORT_P5(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5) \
 	DECLARE_OPERATION_IMPORT_P5(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5)
 
-#define IMPLEMENT_ACTION_IMPORT_P3(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3) \
-	IMPLEMENT_OPERATION_IMPORT_P3(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3)
+#define IMPLEMENT_ACTION_IMPORT_P5(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5) \
+	IMPLEMENT_OPERATION_IMPORT_P5(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5)
+
+#define DECLARE_ACTION_IMPORT_P6(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6) \
+	DECLARE_OPERATION_IMPORT_P6(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6)
+
+#define IMPLEMENT_ACTION_IMPORT_P6(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6) \
+	IMPLEMENT_OPERATION_IMPORT_P6(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6)
+
+#define DECLARE_ACTION_IMPORT_P7(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7) \
+	DECLARE_OPERATION_IMPORT_P7(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7)
+
+#define IMPLEMENT_ACTION_IMPORT_P7(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7) \
+	IMPLEMENT_OPERATION_IMPORT_P7(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7)
+
+#define DECLARE_ACTION_IMPORT_P8(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8) \
+	DECLARE_OPERATION_IMPORT_P8(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8)
+
+#define IMPLEMENT_ACTION_IMPORT_P8(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8) \
+	IMPLEMENT_OPERATION_IMPORT_P8(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8)
+
+#define DECLARE_ACTION_IMPORT_P9(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9) \
+	DECLARE_OPERATION_IMPORT_P9(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9)
+
+#define IMPLEMENT_ACTION_IMPORT_P9(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9) \
+	IMPLEMENT_OPERATION_IMPORT_P9(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9)
+
+#define DECLARE_ACTION_IMPORT_P10(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10) \
+	DECLARE_OPERATION_IMPORT_P10(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10)
+
+#define IMPLEMENT_ACTION_IMPORT_P10(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10) \
+	IMPLEMENT_OPERATION_IMPORT_P10(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10)
+
+#define DECLARE_ACTION_IMPORT_P11(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11) \
+	DECLARE_OPERATION_IMPORT_P11(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11)
+
+#define IMPLEMENT_ACTION_IMPORT_P11(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11) \
+	IMPLEMENT_OPERATION_IMPORT_P11(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11)
+
+#define DECLARE_ACTION_IMPORT_P12(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12) \
+	DECLARE_OPERATION_IMPORT_P12(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12)
+
+#define IMPLEMENT_ACTION_IMPORT_P12(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12) \
+	IMPLEMENT_OPERATION_IMPORT_P12(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12)
 
 #define DECLARE_ACTION_P0(myclass, funcname, executor) \
-    DECLARE_OPERATION_P0(myclass, funcname, executor, false)
+	DECLARE_OPERATION_P0(myclass, funcname, executor, false)
 
 #define IMPLEMENT_ACTION_P0(myclass, funcname, executor) \
-    IMPLEMENT_OPERATION_P0(myclass, funcname, executor, false)
+	IMPLEMENT_OPERATION_P0(myclass, funcname, executor, false)
 
 #define DECLARE_ACTION_P1(myclass, funcname, executor, key1, type1, value1) \
-    DECLARE_OPERATION_P1(myclass, funcname, executor, false, key1, type1, value1)
+	DECLARE_OPERATION_P1(myclass, funcname, executor, false, key1, type1, value1)
 
 #define IMPLEMENT_ACTION_P1(myclass, funcname, executor, key1, type1, value1) \
-    IMPLEMENT_OPERATION_P1(myclass, funcname, executor, false, key1, type1, value1)
+	IMPLEMENT_OPERATION_P1(myclass, funcname, executor, false, key1, type1, value1)
 
 #define DECLARE_ACTION_P2(myclass, funcname, executor, key1, type1, value1, key2, type2, value2) \
-    DECLARE_OPERATION_P2(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2)
+	DECLARE_OPERATION_P2(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2)
 
 #define IMPLEMENT_ACTION_P2(myclass, funcname, executor, key1, type1, value1, key2, type2, value2) \
-    IMPLEMENT_OPERATION_P2(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2)
+	IMPLEMENT_OPERATION_P2(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2)
 
 #define DECLARE_ACTION_P3(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3) \
-    DECLARE_OPERATION_P3(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3)
+	DECLARE_OPERATION_P3(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3)
 
 #define IMPLEMENT_ACTION_P3(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3) \
-   IMPLEMENT_OPERATION_P3(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3)
+	IMPLEMENT_OPERATION_P3(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3)
 
 #define DECLARE_ACTION_P4(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4) \
-    DECLARE_OPERATION_P4(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4)
+	DECLARE_OPERATION_P4(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4)
 
 #define IMPLEMENT_ACTION_P4(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4) \
-   IMPLEMENT_OPERATION_P4(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4)
+	IMPLEMENT_OPERATION_P4(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4)
 
 #define DECLARE_ACTION_P5(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5) \
-    DECLARE_OPERATION_P5(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5)
+	DECLARE_OPERATION_P5(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5)
 
 #define IMPLEMENT_ACTION_P5(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5) \
-   IMPLEMENT_OPERATION_P5(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5)
+	IMPLEMENT_OPERATION_P5(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5)
+
+#define DECLARE_ACTION_P6(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6) \
+	DECLARE_OPERATION_P6(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6)
+
+#define IMPLEMENT_ACTION_P6(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6) \
+	IMPLEMENT_OPERATION_P6(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6)
+
+#define DECLARE_ACTION_P7(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7) \
+	DECLARE_OPERATION_P7(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7)
+
+#define IMPLEMENT_ACTION_P7(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7) \
+	IMPLEMENT_OPERATION_P7(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7)
+
+#define DECLARE_ACTION_P8(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8) \
+	DECLARE_OPERATION_P8(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8)
+
+#define IMPLEMENT_ACTION_P8(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8) \
+	IMPLEMENT_OPERATION_P8(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8)
+
+#define DECLARE_ACTION_P9(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9) \
+	DECLARE_OPERATION_P9(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9)
+
+#define IMPLEMENT_ACTION_P9(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9) \
+	IMPLEMENT_OPERATION_P9(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9)
+
+#define DECLARE_ACTION_P10(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10) \
+	DECLARE_OPERATION_P10(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10)
+
+#define IMPLEMENT_ACTION_P10(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10) \
+	IMPLEMENT_OPERATION_P10(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10)
+
+#define DECLARE_ACTION_P11(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11) \
+	DECLARE_OPERATION_P11(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11)
+
+#define IMPLEMENT_ACTION_P11(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11) \
+	IMPLEMENT_OPERATION_P11(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11)
+
+#define DECLARE_ACTION_P12(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12) \
+	DECLARE_OPERATION_P12(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12)
+
+#define IMPLEMENT_ACTION_P12(myclass, funcname, executor, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12) \
+	IMPLEMENT_OPERATION_P12(myclass, funcname, executor, false, key1, type1, value1, key2, type2, value2, key3, type3, value3, key4, type4, value4, key5, type5, value5, key6, type6, value6, key7, type7, value7, key8, type8, value8, key9, type9, value9, key10, type10, value10, key11, type11, value11, key12, type12, value12)
 
 }}

--- a/include/odata/codegen/code_generation_base.h
+++ b/include/odata/codegen/code_generation_base.h
@@ -9,64 +9,72 @@
 #include "cpprest/json.h"
 #include "odata/core/odata_core.h"
 
-namespace odata { namespace codegen { 
+namespace odata { namespace codegen {
 
 #define SAFE_DELETE(value) \
 	if (value) \
 	{ \
-	    delete value; \
+		delete value; \
 		value = nullptr; \
 	}
 
 class odata_service_context;
 
-class type_base 
+class type_base
 {
 public:
-	type_base(const std::shared_ptr<odata_service_context>& service_context) : m_service_context(service_context){}
-	virtual ~type_base(){}
+	type_base(const std::shared_ptr<odata_service_context>& service_context) : m_service_context(service_context) {}
+	virtual ~type_base() = default;
 
-	virtual void from_value(const std::shared_ptr<::odata::core::odata_entity_value>& pentity) {}
-	virtual void from_value(const std::shared_ptr<::odata::core::odata_complex_value>& pentity) {}
+	virtual void from_value(const std::shared_ptr<::odata::core::odata_entity_value>& /*pentity*/) {}
+	virtual void from_value(const std::shared_ptr<::odata::core::odata_complex_value>& /*pentity*/) {}
 
-	const ::utility::string_t& get_edit_link()
+	const ::odata::string_t& get_edit_link() const
 	{
 		return m_edit_link;
 	}
 
-	void set_edit_link(::utility::string_t edit_link)
+	void set_edit_link(::odata::string_t edit_link)
 	{
 		m_edit_link = std::move(edit_link);
 	}
 
-	::utility::string_t get_key_property_string(bool with_key_name = false)
+	::odata::string_t get_key_property_string(bool /*with_key_name*/ = false) const
 	{
-		return U("");
+		return _XPLATSTR("");
 	}
 
+	const std::shared_ptr<odata_service_context> get_service_context() const
+	{
+		return m_service_context;
+	}
+
+	web::http::http_headers const& get_model_response_header  ()                              const;
+	::odata::string_t              match_model_response_header(const ::odata::string_t &name) const;
+	bool                           has_model_response_header  (const ::odata::string_t &name) const;
+
 protected:
-	::utility::string_t m_edit_link;
+	::odata::string_t m_edit_link;
 	std::shared_ptr<odata_service_context> m_service_context;
 };
-
 
 typedef void (type_base::*PROP_MAP_CALL_IN_ENTITY)(const std::shared_ptr<::odata::core::odata_entity_value>&);
 typedef void (type_base::*PROP_MAP_CALL_IN_COMPLEX)(const std::shared_ptr<::odata::core::odata_complex_value>&);
 
 typedef std::shared_ptr<type_base> (*CREATE_CALL_FOR_ENTITY)(const std::shared_ptr<::odata::codegen::odata_service_context>&);
-typedef std::unordered_map<::utility::string_t, CREATE_CALL_FOR_ENTITY> create_map_for_entity_type; 
+typedef std::unordered_map<::odata::string_t, CREATE_CALL_FOR_ENTITY> create_map_for_entity_type;
 
 typedef std::shared_ptr<type_base> (*CREATE_CALL_FOR_COMPLEX)(const std::shared_ptr<::odata::codegen::odata_service_context>&);
-typedef std::unordered_map<::utility::string_t, CREATE_CALL_FOR_COMPLEX> create_map_for_complex_type; 
+typedef std::unordered_map<::odata::string_t, CREATE_CALL_FOR_COMPLEX> create_map_for_complex_type;
 
-struct PROPMAP_ENTRY_IN_ENTITY 
-{  
-    PROP_MAP_CALL_IN_ENTITY pfn;
-};  
+struct PROPMAP_ENTRY_IN_ENTITY
+{
+	PROP_MAP_CALL_IN_ENTITY pfn;
+};
 
 struct PROPMAP_ENTRY_IN_COMPLEX
-{  
-    PROP_MAP_CALL_IN_COMPLEX pfn;
-}; 
+{
+	PROP_MAP_CALL_IN_COMPLEX pfn;
+};
 
 }}

--- a/include/odata/codegen/code_generation_helper.h
+++ b/include/odata/codegen/code_generation_helper.h
@@ -9,40 +9,40 @@
 #include "odata/common/utility.h"
 #include "odata/codegen/code_generation_base.h"
 
-namespace odata { namespace codegen { 
+namespace odata { namespace codegen {
 
 template<typename T>
 std::shared_ptr<T> create_instance_from_entity(const std::shared_ptr<::odata::core::odata_entity_value>& entity_value, const std::shared_ptr<odata_service_context>& service_context)
 {
 	std::shared_ptr<T> ret = nullptr;
 
-	if (!entity_value) 
+	if (!entity_value)
 	{
-		return ret; 
+		return ret;
 	}
 
-	::utility::string_t real_type_name = entity_value->get_value_type()->get_name(); 
-	::utility::string_t expected_type_name = T::get_type_name(); 
-	if (expected_type_name != real_type_name) 
-	{ 
+	::odata::string_t real_type_name = entity_value->get_value_type()->get_name();
+	::odata::string_t expected_type_name = T::get_type_name();
+	if (expected_type_name != real_type_name)
+	{
 		auto create_pfn = T::_derived_entity_creator_map[real_type_name];
-		if (!create_pfn) 
+		if (!create_pfn)
 		{
 			return ret;
 		}
-		std::shared_ptr<type_base> p_derived = (*create_pfn)(service_context); 
-		if (!p_derived) 
+		std::shared_ptr<type_base> p_derived = (*create_pfn)(service_context);
+		if (!p_derived)
 		{
 			return ret;
 		}
 		p_derived->from_value(entity_value);
-		ret = std::dynamic_pointer_cast<T>(p_derived); 
-	} 
-	else 
-	{ 
-        ret = std::make_shared<T>(service_context); 
-		ret->from_value(entity_value); 
-	} 
+		ret = std::dynamic_pointer_cast<T>(p_derived);
+	}
+	else
+	{
+		ret = ::odata::make_shared<T>(service_context);
+		ret->from_value(entity_value);
+	}
 
 	return ret;
 }
@@ -52,33 +52,33 @@ std::shared_ptr<T> create_instance_from_complex(const std::shared_ptr<::odata::c
 {
 	std::shared_ptr<T> ret = nullptr;
 
-	if (!complex_value) 
+	if (!complex_value)
 	{
-		return ret; 
+		return ret;
 	}
 
-	::utility::string_t real_type_name = complex_value->get_value_type()->get_name(); 
-	::utility::string_t expected_type_name = T::get_type_name(); 
-	if (expected_type_name != real_type_name) 
-	{ 
+	::odata::string_t real_type_name = complex_value->get_value_type()->get_name();
+	::odata::string_t expected_type_name = T::get_type_name();
+	if (expected_type_name != real_type_name)
+	{
 		auto create_pfn = T::_derived_complex_creator_map[real_type_name];
-		if (!create_pfn) 
+		if (!create_pfn)
 		{
 			return ret;
 		}
-		std::shared_ptr<type_base> p_derived = (*create_pfn)(service_context); 
-		if (!p_derived) 
+		std::shared_ptr<type_base> p_derived = (*create_pfn)(service_context);
+		if (!p_derived)
 		{
 			return ret;
 		}
 		p_derived->from_value(complex_value);
-		ret = std::dynamic_pointer_cast<T>(p_derived); 
-	} 
-	else 
-	{ 
-        ret = std::make_shared<T>(service_context); 
-		ret->from_value(complex_value); 
-	} 
+		ret = std::dynamic_pointer_cast<T>(p_derived);
+	}
+	else
+	{
+		ret = ::odata::make_shared<T>(service_context);
+		ret->from_value(complex_value);
+	}
 
 	return ret;
 }

--- a/include/odata/codegen/odata_complex_query_executor.h
+++ b/include/odata/codegen/odata_complex_query_executor.h
@@ -25,53 +25,52 @@ public:
 	{
 	}
 
-	typedef typename std::vector<std::shared_ptr<ElementType>> return_type;
+	typedef typename std::pair<std::vector<std::shared_ptr<ElementType>>, ::odata::client::http_result> return_type;
 
-	::pplx::task<return_type> execute_query(const ::utility::string_t& query_expression)
+	::pplx::task<return_type> execute_query(const ::odata::string_t& query_expression)
 	{
 		if (!m_client_context || !m_client_context->get_client())
 		{
-			return ::pplx::task_from_result(return_type());
+			return ::pplx::task_from_result(std::make_pair(return_type::first_type(), ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 		}
 
-		auto model = m_client_context->get_edm_model();
-		auto root_url = m_client_context->get_root_url();
-		auto client_context = m_client_context;
+		auto &model = m_client_context->get_edm_model();
+		auto &root_url = m_client_context->get_root_url();
+		auto &client_context = m_client_context;
 
 		return m_client_context->get_client()->get_data_from_server(query_expression).then(
-            [this, model, root_url, client_context] (const std::vector<std::shared_ptr<odata::core::odata_value>>& values) -> return_type
+			[this, model, root_url, client_context] (const std::pair<std::vector<std::shared_ptr<odata::core::odata_value>>, ::odata::client::http_result>& values) -> return_type
 			{
-				return_type vec;
+				return_type::first_type vec;
 
-				for(auto iter = values.cbegin(); iter != values.cend(); iter++)
+				for(auto iter = values.first.cbegin(); iter != values.first.cend(); ++iter)
 				{
-					vec.push_back(create_instance_from_complex<ElementType>(std::dynamic_pointer_cast<::odata::core::odata_complex_value>(*iter), client_context));
+					vec.emplace_back(create_instance_from_complex<ElementType>(std::dynamic_pointer_cast<::odata::core::odata_complex_value>(*iter), client_context));
 				}
-			
-				return std::move(vec); 
+
+				return std::make_pair(std::move(vec), values.second);
 			});
 	}
 
-
-	::pplx::task<return_type> execute_operation_query(const ::utility::string_t& query_expression, const std::vector<std::shared_ptr<::odata::core::odata_parameter>>& parameters, bool is_function)
+	::pplx::task<return_type> execute_operation_query(const ::odata::string_t& query_expression, const std::vector<std::shared_ptr<::odata::core::odata_parameter>>& parameters, bool is_function)
 	{
 		if (!m_client_context || !m_client_context->get_client())
 		{
-			return ::pplx::task_from_result(return_type());
+			return ::pplx::task_from_result(std::make_pair(return_type::first_type(), ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 		}
 
-		auto client_context = m_client_context;
+		auto &client_context = m_client_context;
 		std::vector<std::shared_ptr<::odata::core::odata_value>> ret_values;
-		m_client_context->get_client()->send_data_to_server(query_expression, parameters, ret_values, is_function ? HTTP_GET : HTTP_POST).get();
+		auto status_code = m_client_context->get_client()->send_data_to_server(query_expression, parameters, ret_values, is_function ? HTTP_GET : HTTP_POST).get().second;
 
-		return_type vec;
+		return_type::first_type vec;
 
-		for(auto iter = ret_values.cbegin(); iter != ret_values.cend(); iter++)
+		for(auto iter = ret_values.cbegin(); iter != ret_values.cend(); ++iter)
 		{
-			vec.push_back(create_instance_from_complex<ElementType>(std::dynamic_pointer_cast<::odata::core::odata_complex_value>(*iter), client_context));
+			vec.emplace_back(create_instance_from_complex<ElementType>(std::dynamic_pointer_cast<::odata::core::odata_complex_value>(*iter), client_context));
 		}
-			
-		return ::pplx::task_from_result(std::move(vec)); 
+
+		return ::pplx::task_from_result(std::make_pair(std::move(vec), std::move(status_code)));
 	}
 
 protected:

--- a/include/odata/codegen/odata_entityset_query_executor.h
+++ b/include/odata/codegen/odata_entityset_query_executor.h
@@ -25,78 +25,78 @@ public:
 	{
 	}
 
-	typedef typename std::vector<std::shared_ptr<ElementType>> return_type;
+	typedef typename std::pair<std::vector<std::shared_ptr<ElementType>>, ::odata::client::http_result> return_type;
 
-	::pplx::task<return_type> execute_query(const ::utility::string_t& query_expression)
-	{
-		if (!m_client_context || !m_client_context->get_client() || !m_client_context->get_client())
-		{
-			return ::pplx::task_from_result(return_type());
-		}
-
-		auto client_context = m_client_context;
-
-		return m_client_context->get_client()->get_data_from_server(query_expression).then(
-            [this, client_context] (const std::vector<std::shared_ptr<odata::core::odata_value>>& values) -> return_type
-			{
-				return_type vec;
-
-				for(auto iter = values.cbegin(); iter != values.cend(); iter++)
-				{
-					vec.push_back(create_instance_from_entity<ElementType>(std::dynamic_pointer_cast<::odata::core::odata_entity_value>(*iter), client_context));
-				}
-			
-				return std::move(vec); 
-			});
-	}
-
-	::pplx::task<return_type> execute_paged_query(::utility::string_t& next_link_url)
-	{
-		if (next_link_url.empty() || !m_client_context || !m_client_context->get_client())
-		{
-			return ::pplx::task_from_result(return_type());
-		}
-
-		auto client_context = m_client_context;
-
-		return m_client_context->get_client()->get_paged_data_from_server(next_link_url).then(
-			[this, client_context, &next_link_url] (const std::shared_ptr<::odata::core::odata_payload>& payload) -> return_type
-		    {
-				next_link_url = payload->get_next_link();
-
-				return_type vec;
-
-				for(auto iter = payload->get_values().cbegin(); iter != payload->get_values().cend(); iter++)
-				{
-					vec.push_back(create_instance_from_entity<ElementType>(std::dynamic_pointer_cast<::odata::core::odata_entity_value>(*iter), client_context));
-				}
-			
-				return std::move(vec); 
-		    });
-	}
-
-	::pplx::task<return_type> execute_operation_query(const ::utility::string_t& query_expression, const std::vector<std::shared_ptr<::odata::core::odata_parameter>>& parameters, bool is_function)
+	::pplx::task<return_type> execute_query(const ::odata::string_t& query_expression)
 	{
 		if (!m_client_context || !m_client_context->get_client())
 		{
-			return ::pplx::task_from_result(return_type());
+			return ::pplx::task_from_result(std::make_pair(return_type::first_type(), ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 		}
 
-		auto client_context = m_client_context;
+		auto &client_context = m_client_context;
+
+		return m_client_context->get_client()->get_data_from_server(query_expression).then(
+			[this, client_context] (const std::pair<std::vector<std::shared_ptr<odata::core::odata_value>>, ::odata::client::http_result>& values) -> return_type
+			{
+				return_type::first_type vec;
+
+				for(auto iter = values.first.cbegin(); iter != values.first.cend(); ++iter)
+				{
+					vec.emplace_back(create_instance_from_entity<ElementType>(std::dynamic_pointer_cast<::odata::core::odata_entity_value>(*iter), client_context));
+				}
+
+				return std::make_pair(std::move(vec), values.second);
+			});
+	}
+
+	::pplx::task<return_type> execute_paged_query(::odata::string_t& next_link_url)
+	{
+		if (next_link_url.empty() || !m_client_context || !m_client_context->get_client())
+		{
+			return ::pplx::task_from_result(std::make_pair(return_type::first_type(), ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
+		}
+
+		auto &client_context = m_client_context;
+
+		return m_client_context->get_client()->get_paged_data_from_server(next_link_url).then(
+			[this, client_context, &next_link_url] (const std::pair<std::shared_ptr<::odata::core::odata_payload>, ::odata::client::http_result>& payload) -> return_type
+			{
+				next_link_url = payload.first->get_next_link();
+
+				return_type::first_type vec;
+
+				for(auto iter = payload.first->get_values().cbegin(); iter != payload.first->get_values().cend(); ++iter)
+				{
+					vec.emplace_back(create_instance_from_entity<ElementType>(std::dynamic_pointer_cast<::odata::core::odata_entity_value>(*iter), client_context));
+				}
+
+				return std::make_pair(std::move(vec), payload.second);
+			});
+	}
+
+	::pplx::task<return_type> execute_operation_query(const ::odata::string_t& query_expression, const std::vector<std::shared_ptr<::odata::core::odata_parameter>>& parameters, bool is_function)
+	{
+		if (!m_client_context || !m_client_context->get_client())
+		{
+			return ::pplx::task_from_result(std::make_pair(return_type::first_type(), ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
+		}
+
+		auto &client_context = m_client_context;
 
 		std::vector<std::shared_ptr<::odata::core::odata_value>> ret_values;
-		m_client_context->get_client()->send_data_to_server(query_expression, parameters, ret_values, is_function ? HTTP_GET : HTTP_POST).get();
+		auto status_code = m_client_context->get_client()->send_data_to_server(query_expression, parameters, ret_values, is_function ? HTTP_GET : HTTP_POST).get().second;
 
-		return_type vec;
+		return_type::first_type vec;
 
-		for(auto iter = ret_values.cbegin(); iter != ret_values.cend(); iter++)
+		for(auto iter = ret_values.cbegin(); iter != ret_values.cend(); ++iter)
 		{
-			vec.push_back(create_instance_from_entity<ElementType>(std::dynamic_pointer_cast<::odata::core::odata_entity_value>(*iter), client_context));
+			vec.emplace_back(create_instance_from_entity<ElementType>(std::dynamic_pointer_cast<::odata::core::odata_entity_value>(*iter), client_context));
 		}
 
-		return ::pplx::task_from_result(std::move(vec)); 
+		return ::pplx::task_from_result(std::make_pair(std::move(vec), std::move(status_code)));
 	}
-	
+
 protected:
 	std::shared_ptr<::odata::codegen::odata_service_context> m_client_context;
 };

--- a/include/odata/codegen/odata_function_param_formatter.h
+++ b/include/odata/codegen/odata_function_param_formatter.h
@@ -20,13 +20,13 @@ std::shared_ptr<::odata::core::odata_value> format_function_class_parameter(T t)
 }
 
 template<typename T>
-std::shared_ptr<::odata::core::odata_value> format_function_parameter(const T& t, std::false_type fa, std::true_type tr)
+std::shared_ptr<::odata::core::odata_value> format_function_parameter(const T& t, std::false_type /*fa*/, std::true_type /*tr*/)
 {
 	return format_function_class_parameter(t);
 }
 
 template<typename T>
-std::shared_ptr<::odata::core::odata_value> format_function_parameter(const T& t, std::false_type fa, std::false_type fa2nd)
+std::shared_ptr<::odata::core::odata_value> format_function_parameter(const T& t, std::false_type /*fa*/, std::false_type /*fa2nd*/)
 {
 	return format_function_primitive_parameter(t);
 }
@@ -34,22 +34,18 @@ std::shared_ptr<::odata::core::odata_value> format_function_parameter(const T& t
 template<typename T>
 std::shared_ptr<::odata::core::odata_value> format_function_parameter(const T& t, std::false_type fa)
 {
-	// a primitive or a class 
+	// a primitive or a class
 	return format_function_parameter(t, fa, integral_constant<bool, std::is_base_of<::odata::codegen::type_base, T>::value>());
 }
 
 template<typename T>
 std::shared_ptr<::odata::core::odata_value> format_function_enum_parameter(const T& t)
 {
-	::utility::stringstream_t ostr;
-
-	ostr << enum_type_resolver::get_string_from_enum_type(t);
-
-	return std::make_shared<::odata::core::odata_enum_value>(std::make_shared<::odata::edm::edm_enum_type>(U(""), U(""), U(""), false), ostr.str());
+	return ::odata::make_shared<::odata::core::odata_enum_value>(::odata::make_shared<::odata::edm::edm_enum_type>(_XPLATSTR(""), _XPLATSTR(""), _XPLATSTR(""), false), enum_type_resolver::get_string_from_enum_type(t));
 }
 
 template<typename T>
-std::shared_ptr<::odata::core::odata_value> format_function_parameter(const T& t, std::true_type tr)
+std::shared_ptr<::odata::core::odata_value> format_function_parameter(const T& t, std::true_type /*tr*/)
 {
 	return format_function_enum_parameter(t);
 }
@@ -72,7 +68,7 @@ std::shared_ptr<::odata::core::odata_value> format_function_parameter(const std:
 template<typename T>
 std::shared_ptr<::odata::core::odata_value> format_function_parameter(const std::vector<T>& t)
 {
-	auto collection = std::make_shared<::odata::core::odata_collection_value>(std::make_shared<::odata::edm::edm_collection_type>(U("action parameter")));
+	auto collection = ::odata::make_shared<::odata::core::odata_collection_value>(::odata::make_shared<::odata::edm::edm_collection_type>(_XPLATSTR("action parameter")));
 
 	for (auto iter = t.cbegin(); iter != t.cend(); ++iter)
 	{

--- a/include/odata/codegen/odata_primitive_query_executor.h
+++ b/include/odata/codegen/odata_primitive_query_executor.h
@@ -25,54 +25,54 @@ public:
 	{
 	}
 
-	typedef typename std::vector<ElementType> return_type;
+	typedef typename std::pair<std::vector<ElementType>, ::odata::client::http_result> return_type;
 
-	::pplx::task<return_type> execute_query(const ::utility::string_t& query_expression)
+	::pplx::task<return_type> execute_query(const ::odata::string_t& query_expression)
 	{
 		if (!m_client_context || !m_client_context->get_client())
 		{
-			return ::pplx::task_from_result(std::vector<ElementType>());
+			return ::pplx::task_from_result(std::make_pair(return_type::first_type(), ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 		}
 
 		return m_client_context->get_client()->get_data_from_server(query_expression).then(
-            [this] (const std::vector<std::shared_ptr<odata::core::odata_value>>& values) -> std::vector<ElementType>
+			[this] (const std::pair<std::vector<std::shared_ptr<odata::core::odata_value>>, ::odata::client::http_result>& values) -> return_type
 			{
-				std::vector<ElementType> vec;
+				return_type::first_type vec;
 
-				for(auto iter = values.cbegin(); iter != values.cend(); iter++)
+				for(auto iter = values.first.cbegin(); iter != values.first.cend(); ++iter)
 				{
 					auto primitive_value = std::dynamic_pointer_cast<::odata::core::odata_primitive_value>(*iter);
 					if (primitive_value)
 					{
-						vec.push_back(primitive_value->as<ElementType>());
+						vec.emplace_back(primitive_value->as<ElementType>());
 					}
 				}
-			
-				return std::move(vec); 
+
+				return std::make_pair(std::move(vec), values.second);
 			});
 	}
 
-	::pplx::task<return_type> execute_operation_query(const ::utility::string_t& query_expression, const std::vector<std::shared_ptr<::odata::core::odata_parameter>>& parameters, bool is_function)
+	::pplx::task<return_type> execute_operation_query(const ::odata::string_t& query_expression, const std::vector<std::shared_ptr<::odata::core::odata_parameter>>& parameters, bool is_function)
 	{
 		if (!m_client_context || !m_client_context->get_client())
 		{
-			return ::pplx::task_from_result(return_type());
+			return ::pplx::task_from_result(std::make_pair(return_type::first_type(), ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 		}
 
 		std::vector<std::shared_ptr<::odata::core::odata_value>> ret_values;
-		m_client_context->get_client()->send_data_to_server(query_expression, parameters, ret_values, is_function ? HTTP_GET : HTTP_POST).get();
+		auto status_code = m_client_context->get_client()->send_data_to_server(query_expression, parameters, ret_values, is_function ? HTTP_GET : HTTP_POST).get().second;
 
-		std::vector<ElementType> vec;
-		for(auto iter = ret_values.cbegin(); iter != ret_values.cend(); iter++)
+		return_type::first_type vec;
+		for(auto iter = ret_values.cbegin(); iter != ret_values.cend(); ++iter)
 		{
 			auto primitive_value = std::dynamic_pointer_cast<::odata::core::odata_primitive_value>(*iter);
 			if (primitive_value)
 			{
-				vec.push_back(primitive_value->as<ElementType>());
+				vec.emplace_back(primitive_value->as<ElementType>());
 			}
 		}
-			
-		return ::pplx::task_from_result(std::move(vec)); 
+
+		return ::pplx::task_from_result(std::make_pair(std::move(vec), std::move(status_code)));
 	}
 
 protected:

--- a/include/odata/codegen/odata_query_builder.h
+++ b/include/odata/codegen/odata_query_builder.h
@@ -15,7 +15,7 @@ namespace odata { namespace codegen {
 class odata_query_builder : public std::enable_shared_from_this<odata_query_builder>
 {
 public:
-	odata_query_builder(const ::utility::string_t& entity_set_name) 
+	odata_query_builder(const ::odata::string_t& entity_set_name)
 	{
 		m_root_query_path.reset(odata_query_path::creat_query_path(entity_set_name, true));
 	}
@@ -23,7 +23,7 @@ public:
 	std::shared_ptr<odata_query_builder> top(int count)
 	{
 		m_root_query_path->top(count);
-	
+
 		return this->shared_from_this();
 	}
 
@@ -34,35 +34,35 @@ public:
 		return this->shared_from_this();
 	}
 
-	std::shared_ptr<odata_query_builder> key(const ::utility::string_t& key)
+	std::shared_ptr<odata_query_builder> key(const ::odata::string_t& key)
 	{
 		m_root_query_path->key(key);
 
 		return this->shared_from_this();
 	}
 
-	std::shared_ptr<odata_query_builder> orderby(const ::utility::string_t& orderby_clause)
+	std::shared_ptr<odata_query_builder> orderby(const ::odata::string_t& orderby_clause)
 	{
 		m_root_query_path->orderby(orderby_clause);
 
 		return this->shared_from_this();
 	}
 
-	std::shared_ptr<odata_query_builder> filter(const ::utility::string_t& filter_clause)
+	std::shared_ptr<odata_query_builder> filter(const ::odata::string_t& filter_clause)
 	{
 		m_root_query_path->filter(filter_clause);
 
 		return this->shared_from_this();
 	}
 
-	std::shared_ptr<odata_query_builder> select(const ::utility::string_t& select_clause)
+	std::shared_ptr<odata_query_builder> select(const ::odata::string_t& select_clause)
 	{
 		m_root_query_path->select(select_clause);
 
 		return this->shared_from_this();
 	}
 
-	std::shared_ptr<odata_query_builder> expand(const ::utility::string_t& expand_path)
+	std::shared_ptr<odata_query_builder> expand(const ::odata::string_t& expand_path)
 	{
 		m_root_query_path->expand(expand_path);
 
@@ -76,14 +76,21 @@ public:
 		return this->shared_from_this();
 	}
 
-	::utility::string_t get_query_expression()
+		std::shared_ptr<odata_query_builder> search(const ::odata::string_t& search_clause)
+	{
+		m_root_query_path->search(search_clause);
+
+		return this->shared_from_this();
+	}
+
+	::odata::string_t get_query_expression()
 	{
 		if (m_root_query_path)
 		{
 			return std::move(::web::http::uri::encode_uri((m_root_query_path->evaluate_query_path())));
 		}
 
-		return U("");
+		return _XPLATSTR("");
 	}
 
 private:

--- a/include/odata/codegen/odata_query_option.h
+++ b/include/odata/codegen/odata_query_option.h
@@ -9,7 +9,7 @@
 #include "odata/common/utility.h"
 #include "odata/core/odata_core.h"
 
-namespace odata { namespace codegen { 
+namespace odata { namespace codegen {
 
 enum ODATA_QUERY_OPTION_TYPE
 {
@@ -20,12 +20,13 @@ enum ODATA_QUERY_OPTION_TYPE
 	ORDER_BY,
 	SELECT_QUERY,
 	EXPAND_QUERY,
+	SEARCH_QUERY,
 };
 
 class odata_query_option
 {
 public:
-	odata_query_option(ODATA_QUERY_OPTION_TYPE query_option_type, ::utility::string_t query_option_clause)
+	odata_query_option(ODATA_QUERY_OPTION_TYPE query_option_type, ::odata::string_t query_option_clause)
 		: m_query_option_type(query_option_type), m_query_option_clause(std::move(query_option_clause))
 	{
 	}
@@ -35,19 +36,19 @@ public:
 		return m_query_option_type;
 	}
 
-	const ::utility::string_t& get_query_option_clause() const
+	const ::odata::string_t& get_query_option_clause() const
 	{
 		return m_query_option_clause;
 	}
 
-	void set_query_option_clause(::utility::string_t query_option_clause)
+	void set_query_option_clause(::odata::string_t query_option_clause)
 	{
 		m_query_option_clause = std::move(query_option_clause);
 	}
 
 private:
-	ODATA_QUERY_OPTION_TYPE    m_query_option_type;
-	::utility::string_t m_query_option_clause;
+	ODATA_QUERY_OPTION_TYPE m_query_option_type;
+	::odata::string_t       m_query_option_clause;
 };
 
 class odata_query_option_comparator

--- a/include/odata/codegen/odata_query_path.h
+++ b/include/odata/codegen/odata_query_path.h
@@ -10,28 +10,28 @@
 #include "odata/codegen/odata_query_option.h"
 #include "odata/core/odata_core.h"
 
-namespace odata { namespace codegen { 
+namespace odata { namespace codegen {
 
 class odata_query_path
 {
 private:
-    odata_query_path(::utility::string_t path, bool is_root = false) 
-		: m_resource_path(std::move(path)), m_is_root(is_root), l_child_item(nullptr), l_sibling_item(nullptr)
+	odata_query_path(::odata::string_t path, bool is_root = false)
+	:	l_child_item(nullptr), l_sibling_item(nullptr), m_query_options(), m_resource_path(std::move(path)), m_is_root(is_root)
 	{
 	}
 
-	odata_query_path(const odata_query_path& path)
+	odata_query_path(const odata_query_path& /*path*/)
+	:	l_child_item(nullptr), l_sibling_item(nullptr), m_query_options(), m_resource_path(_XPLATSTR("")), m_is_root(false)
 	{
-
 	}
 
-	odata_query_path& operator = (const odata_query_path& path)
+	odata_query_path& operator = (const odata_query_path& /*path*/)
 	{
 		return *this;
 	}
 
 public:
-	static odata_query_path* creat_query_path(const ::utility::string_t& path, bool is_root = false)
+	static odata_query_path* creat_query_path(const ::odata::string_t& path, bool is_root = false)
 	{
 		return new odata_query_path(path, is_root);
 	}
@@ -41,102 +41,108 @@ public:
 		if (l_sibling_item)
 		{
 			delete l_sibling_item;
+			l_sibling_item = nullptr;
 		}
 
 		if (l_child_item)
 		{
 			delete l_child_item;
+			l_child_item = nullptr;
 		}
-
-		l_sibling_item = nullptr;
-		l_child_item = nullptr;
 	}
 
-	const ::utility::string_t& get_resource_path() const 
+	const ::odata::string_t& get_resource_path() const
 	{
 		return m_resource_path;
 	}
-       
-    odata_query_path* top(int count)
+
+	odata_query_path* top(int count)
 	{
-		::utility::string_t query_clause = U("$top=");
-		::utility::string_t string_count;
+		::odata::string_t query_clause = _XPLATSTR("$top=");
+		::odata::string_t string_count;
 		::odata::common::to_string(count, string_count);
 		query_clause += string_count;
 
-		m_query_options.push_back(odata_query_option(ODATA_QUERY_OPTION_TYPE::TOP_QUERY, query_clause));
+		m_query_options.emplace_back(ODATA_QUERY_OPTION_TYPE::TOP_QUERY, query_clause);
 
 		return this;
 	}
 
 	odata_query_path* skip(int count)
 	{
-		::utility::string_t query_clause = U("$skip=");
-		::utility::string_t string_count;
+		::odata::string_t query_clause = _XPLATSTR("$skip=");
+		::odata::string_t string_count;
 		::odata::common::to_string(count, string_count);
 		query_clause += string_count;
 
-		m_query_options.push_back(odata_query_option(ODATA_QUERY_OPTION_TYPE::SKIP_QUERY, query_clause));
+		m_query_options.emplace_back(ODATA_QUERY_OPTION_TYPE::SKIP_QUERY, query_clause);
 
 		return this;
 	}
 
-    odata_query_path* orderby(const ::utility::string_t& orderby_clause)
+	odata_query_path* orderby(const ::odata::string_t& orderby_clause)
 	{
-		m_query_options.push_back(odata_query_option(ODATA_QUERY_OPTION_TYPE::ORDER_BY, U("$orderby=") + orderby_clause));
+		m_query_options.emplace_back(ODATA_QUERY_OPTION_TYPE::ORDER_BY, _XPLATSTR("$orderby=") + orderby_clause);
 
 		return this;
 	}
 
-    odata_query_path* filter(const ::utility::string_t& filter_clause)
+	odata_query_path* filter(const ::odata::string_t& filter_clause)
 	{
-		m_query_options.push_back(odata_query_option(ODATA_QUERY_OPTION_TYPE::FILTER_QUERY, U("$filter=") + filter_clause));
+		m_query_options.emplace_back(ODATA_QUERY_OPTION_TYPE::FILTER_QUERY, _XPLATSTR("$filter=") + filter_clause);
 
 		return this;
 	}
 
-    odata_query_path* select(const ::utility::string_t& select_clause)
+	odata_query_path* select(const ::odata::string_t& select_clause)
 	{
-		m_query_options.push_back(odata_query_option(ODATA_QUERY_OPTION_TYPE::SELECT_QUERY, U("$select=") + select_clause));
+		m_query_options.emplace_back(ODATA_QUERY_OPTION_TYPE::SELECT_QUERY, _XPLATSTR("$select=") + select_clause);
 
 		return this;
 	}
 
-	odata_query_path* key(const ::utility::string_t& key)
+	odata_query_path* key(const ::odata::string_t& key)
 	{
-		m_resource_path += U("(") + key + U(")");
+		m_resource_path += _XPLATSTR("(") + key + _XPLATSTR(")");
 
 		return this;
 	}
 
-	odata_query_path* expand(const ::utility::string_t& expand_path)
+	odata_query_path* expand(const ::odata::string_t& expand_path)
 	{
 		expand(new odata_query_path(expand_path));
 
 		return this;
 	}
 
-    odata_query_path* expand(odata_query_path* expand_item)
+	odata_query_path* expand(odata_query_path* expand_item)
 	{
 		if (expand_item)
 		{
 			expand_item->l_sibling_item = this->l_child_item;
-			this->l_child_item = expand_item;
+			l_child_item = expand_item;
 		}
-		
+
 		return this;
 	}
 
-	ODATACPP_CLIENT_API ::utility::string_t evaluate_query_path();
+	odata_query_path* search(const ::odata::string_t& search_clause)
+	{
+		m_query_options.emplace_back(ODATA_QUERY_OPTION_TYPE::SEARCH_QUERY, _XPLATSTR("$search=") + search_clause);
+
+		return this;
+	}
+
+	ODATACPP_CLIENT_API ::odata::string_t evaluate_query_path();
 
 private:
-	::utility::string_t normalize_query_options();
+	::odata::string_t normalize_query_options();
 
-    odata_query_path* l_child_item;
-    odata_query_path* l_sibling_item;
+	odata_query_path* l_child_item;
+	odata_query_path* l_sibling_item;
 
 	std::vector<odata_query_option> m_query_options;
-    ::utility::string_t      m_resource_path;
+	::odata::string_t               m_resource_path;
 	bool                            m_is_root;
 };
 

--- a/include/odata/codegen/odata_query_path_composer.h
+++ b/include/odata/codegen/odata_query_path_composer.h
@@ -9,236 +9,461 @@
 #include "odata/common/utility.h"
 #include "odata/core/odata_core.h"
 
-namespace odata { namespace codegen { 
+namespace odata { namespace codegen {
 
-class atrribute
+class attribute
 {
 public:
-	atrribute(const ::utility::string_t& exp) : _exp(exp)
-	{}
-
-	atrribute& operator && (const atrribute& exp)
+	attribute(const ::odata::string_t& exp) : _exp(exp)
 	{
-		::utility::stringstream_t ostr;
+	}
 
-		ostr << _exp << U(" and ") << exp.evaluate();
+	attribute(::odata::string_t&& exp) : _exp(std::move(exp))
+	{
+	}
 
-		_exp = ostr.str();
+	attribute(const attribute& exp) : _exp(exp._exp)
+	{
+	}
+
+	attribute(attribute&& exp) : _exp(std::move(exp._exp))
+	{
+	}
+
+	attribute& operator = (const attribute& exp)
+	{
+		_exp = exp._exp;
+		return *this;
+	}
+
+	attribute& operator = (attribute&& exp)
+	{
+		_exp = std::move(exp._exp);
+		return *this;
+	}
+
+	attribute& operator () ()
+	{
+		_exp.insert(0, _XPLATSTR("("));
+		_exp += _XPLATSTR(")");
 
 		return *this;
 	}
 
-	atrribute& operator || (const atrribute& exp)
+	attribute& operator + (const attribute& exp)
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << _exp << U(" or ") << exp.evaluate();
-
-		_exp = ostr.str();
+		_exp += _XPLATSTR(" add ");
+		_exp += exp.evaluate();
 
 		return *this;
 	}
 
-	atrribute& operator !()
+	attribute& operator - (const attribute& exp)
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << U("not ") << _exp;
-
-		_exp = ostr.str();
+		_exp += _XPLATSTR(" sub ");
+		_exp += exp.evaluate();
 
 		return *this;
 	}
 
-	atrribute& operator |(const atrribute& exp)
+	attribute& operator * (const attribute& exp)
 	{
-		::utility::stringstream_t ostr;
+		_exp += _XPLATSTR(" mul ");
+		_exp += exp.evaluate();
 
-		ostr << _exp << U(",") << exp.evaluate();
+		return *this;
+	}
 
-		_exp = ostr.str();
+	attribute& operator / (const attribute& exp)
+	{
+		_exp += _XPLATSTR(" div ");
+		_exp += exp.evaluate();
+
+		return *this;
+	}
+
+	attribute& operator % (const attribute& exp)
+	{
+		_exp += _XPLATSTR(" mod ");
+		_exp += exp.evaluate();
+
+		return *this;
+	}
+
+	attribute& operator && (const attribute& exp)
+	{
+		_exp += _XPLATSTR(" and ");
+		_exp += exp.evaluate();
+
+		return *this;
+	}
+
+	attribute& operator || (const attribute& exp)
+	{
+		_exp += _XPLATSTR(" or ");
+		_exp += exp.evaluate();
+
+		return *this;
+	}
+
+	attribute& operator ! ()
+	{
+		_exp.insert(0, _XPLATSTR("not "));
+
+		return *this;
+	}
+
+	attribute& operator | (const attribute& exp)
+	{
+		_exp += _XPLATSTR(',');
+		_exp += exp.evaluate();
 
 		return *this;
 	}
 
 	template<typename T>
-	atrribute& operator == (const T& exp)
+	attribute& operator == (const T& exp)
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << _exp << U(" eq ") << exp;
-
-		_exp = ostr.str();
+		_exp += _XPLATSTR(" eq ");
+		_exp += exp;
 
 		return *this;
 	}
 
 	template<typename T>
-	atrribute& operator != (const T& exp)
+	attribute& operator != (const T& exp)
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << _exp << U(" ne ") << exp;
-
-		_exp = ostr.str();
+		_exp += _XPLATSTR(" ne ");
+		_exp += exp;
 
 		return *this;
 	}
 
 	template<typename T>
-	atrribute& operator >= (const T& exp)
+	attribute& operator >= (const T& exp)
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << _exp << U(" ge ") << exp;
-
-		_exp = ostr.str();
+		_exp += _XPLATSTR(" ge ");
+		_exp += exp;
 
 		return *this;
 	}
 
 	template<typename T>
-	atrribute& operator > (const T& exp)
+	attribute& operator > (const T& exp)
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << _exp << U(" gt ") << exp;
-
-		_exp = ostr.str();
+		_exp += _XPLATSTR(" gt ");
+		_exp += exp;
 
 		return *this;
 	}
 
 	template<typename T>
-	atrribute& operator <= (const T& exp)
+	attribute& operator <= (const T& exp)
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << _exp << U(" le ") << exp;
-
-		_exp = ostr.str();
+		_exp += _XPLATSTR(" le ");
+		_exp += exp;
 
 		return *this;
 	}
 
 	template<typename T>
-	atrribute& operator < (const T& exp)
+	attribute& operator < (const T& exp)
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << _exp << U(" lt ") << exp;
-
-		_exp = ostr.str();
+		_exp += _XPLATSTR(" lt ");
+		_exp += exp;
 
 		return *this;
 	}
 
-	atrribute& contains(const ::utility::string_t& exp)
+	attribute& contains(const ::odata::string_t& exp)
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << U("contains") << U("(") << _exp << U(",'") << exp << U("')");
-
-		_exp = ostr.str();
+		_exp.insert(0, _XPLATSTR("contains("));
+		_exp += _XPLATSTR(",'");
+		_exp += exp;
+		_exp += _XPLATSTR("')");
 
 		return *this;
 	}
 
-	atrribute& concat(const ::utility::string_t& exp)
+	attribute& concat(const ::odata::string_t& exp)
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << U("concat") << U("(") << _exp << U(",'") << exp << U("')");
-
-		_exp = ostr.str();
+		_exp.insert(0, _XPLATSTR("concat("));
+		_exp += _XPLATSTR(",'");
+		_exp += exp;
+		_exp += _XPLATSTR("')");
 
 		return *this;
 	}
 
-	atrribute& tolower()
+	attribute& tolower()
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << U("tolower") << U("(") << _exp << U("')");
-
-		_exp = ostr.str();
+		_exp.insert(0, _XPLATSTR("tolower("));
+		_exp += _XPLATSTR("')");
 
 		return *this;
 	}
 
-	atrribute& toupper()
+	attribute& toupper()
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << U("toupper") << U("(") << _exp << U("')");
-
-		_exp = ostr.str();
+		_exp.insert(0, _XPLATSTR("toupper("));
+		_exp += _XPLATSTR("')");
 
 		return *this;
 	}
 
-	atrribute& trim()
+	attribute& trim()
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << U("trim") << U("(") << _exp << U("')");
-
-		_exp = ostr.str();
+		_exp.insert(0, _XPLATSTR("trim("));
+		_exp += _XPLATSTR("')");
 
 		return *this;
 	}
 
-	atrribute& endswith(const ::utility::string_t& exp)
+	attribute& endswith(const ::odata::string_t& exp)
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << U("endswith") << U("(") << _exp << U(",'") << exp << U("')");
-
-		_exp = ostr.str();
+		_exp.insert(0, _XPLATSTR("endswith("));
+		_exp += _XPLATSTR(",'");
+		_exp += exp;
+		_exp += _XPLATSTR("')");
 
 		return *this;
 	}
 
-	atrribute& startswith(const ::utility::string_t& exp)
+	attribute& startswith(const ::odata::string_t& exp)
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << U("startswith") << U("(") << _exp << U(",'") << exp << U("')");
-
-		_exp = ostr.str();
+		_exp.insert(0, _XPLATSTR("startswith("));
+		_exp += _XPLATSTR(",'");
+		_exp += exp;
+		_exp += _XPLATSTR("')");
 
 		return *this;
 	}
 
-	atrribute& substring(int index)
+	attribute& substring(int index)
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << U("substring") << U("(") << _exp << U(",'") << index << U("')");
-
-		_exp = ostr.str();
+		_exp.insert(0, _XPLATSTR("substring("));
+		_exp += _XPLATSTR(",'");
+		_exp += utility::conversions::details::to_string_t(index);
+		_exp += _XPLATSTR("')");
 
 		return *this;
 	}
 
-	atrribute& substring(int index, int length)
+	attribute& substring(int index, int length)
 	{
-		::utility::stringstream_t ostr;
-
-		ostr << U("substring") << U("(") << _exp << U(",'") << index << U(",'") << length << U("')");
-
-		_exp = ostr.str();
+		_exp.insert(0, _XPLATSTR("substring("));
+		_exp += _XPLATSTR(",'");
+		_exp += utility::conversions::details::to_string_t(index);
+		_exp += _XPLATSTR("','");
+		_exp += utility::conversions::details::to_string_t(length);
+		_exp += _XPLATSTR("')");
 
 		return *this;
 	}
 
-	const ::utility::string_t& evaluate() const
+	attribute& substringof(const ::odata::string_t& exp)
+	{
+		_exp.insert(0, _XPLATSTR("substringof("));
+		_exp += _XPLATSTR(",'");
+		_exp += exp;
+		_exp += _XPLATSTR("')");
+
+		return *this;
+	}
+
+	attribute& length()
+	{
+		_exp.insert(0, _XPLATSTR("length("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& indexof(const ::odata::string_t& exp)
+	{
+		_exp.insert(0, _XPLATSTR("indexof("));
+		_exp += _XPLATSTR(",'");
+		_exp +=  exp;
+		_exp += _XPLATSTR("')");
+
+		return *this;
+	}
+
+	attribute& replace(const ::odata::string_t& expSrch, const ::odata::string_t& expRepl)
+	{
+		_exp.insert(0, _XPLATSTR("replace("));
+		_exp += _XPLATSTR(",'");
+		_exp += expSrch;
+		_exp += _XPLATSTR("','");
+		_exp += expRepl;
+		_exp += _XPLATSTR("')");
+
+		return *this;
+	}
+
+	attribute& year()
+	{
+		_exp.insert(0, _XPLATSTR("year("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& years()
+	{
+		_exp.insert(0, _XPLATSTR("years("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& month()
+	{
+		_exp.insert(0, _XPLATSTR("month("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& months()
+	{
+		_exp.insert(0, _XPLATSTR("months("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& day()
+	{
+		_exp.insert(0, _XPLATSTR("day("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& days()
+	{
+		_exp.insert(0, _XPLATSTR("days("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& hour()
+	{
+		_exp.insert(0, _XPLATSTR("hour("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& hours()
+	{
+		_exp.insert(0, _XPLATSTR("hours("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& minute()
+	{
+		_exp.insert(0, _XPLATSTR("minute("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& minutes()
+	{
+		_exp.insert(0, _XPLATSTR("minutes("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& second()
+	{
+		_exp.insert(0, _XPLATSTR("second("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& seconds()
+	{
+		_exp.insert(0, _XPLATSTR("seconds("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& round()
+	{
+		_exp.insert(0, _XPLATSTR("round("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& floor()
+	{
+		_exp.insert(0, _XPLATSTR("floor("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& ceiling()
+	{
+		_exp.insert(0, _XPLATSTR("ceiling("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& isof()
+	{
+		_exp.insert(0, _XPLATSTR("isof("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& isof(const ::odata::string_t& exp)
+	{
+		_exp.insert(0, _XPLATSTR("isof("));
+		_exp += _XPLATSTR(",");
+		_exp += exp;
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& cast()
+	{
+		_exp.insert(0, _XPLATSTR("cast("));
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	attribute& cast(const ::odata::string_t& exp)
+	{
+		_exp.insert(0, _XPLATSTR("cast("));
+		_exp += _XPLATSTR(",");
+		_exp += exp;
+		_exp += _XPLATSTR(")");
+
+		return *this;
+	}
+
+	const ::odata::string_t& evaluate() const
 	{
 		return _exp;
 	}
 
 private:
-	::utility::string_t _exp;
+	::odata::string_t _exp;
 };
 
 }}

--- a/include/odata/codegen/odata_service_context.h
+++ b/include/odata/codegen/odata_service_context.h
@@ -13,24 +13,23 @@
 #include "odata/core/odata_core.h"
 #include "odata/edm/edm_model_utility.h"
 
-namespace odata { namespace codegen { 
+namespace odata { namespace codegen {
 
 class odata_service_context : public std::enable_shared_from_this<odata_service_context>
 {
 public:
-	odata_service_context(const ::utility::string_t& baseAddress, ::odata::client::client_options options =  ::odata::client::client_options())
+	odata_service_context(const ::odata::string_t& baseAddress, ::odata::client::client_options options =  ::odata::client::client_options())
+		: m_client(::odata::make_shared<::odata::client::odata_client>(baseAddress, options)), m_model()
 	{
-		m_client = std::make_shared<::odata::client::odata_client>(baseAddress, options);
-		m_model = nullptr;
 	}
 
-    virtual ~odata_service_context(){}
+	virtual ~odata_service_context() = default;
 
-	const std::shared_ptr<::odata::edm::edm_model>& get_edm_model() 
+	const std::shared_ptr<::odata::edm::edm_model>& get_edm_model()
 	{
 		if (!m_model)
 		{
-			m_model = m_client->get_model().get();
+			m_model = m_client->get_model().get().first;
 		}
 
 		return m_model;
@@ -41,140 +40,170 @@ public:
 		return m_client;
 	}
 
-	const ::utility::string_t& get_root_url()
+	const ::odata::string_t& get_root_url() const
 	{
 		return m_client->get_service_root_url();
 	}
 
-	::utility::string_t get_relative_path(const ::utility::string_t& full_path)
+	::odata::string_t get_relative_path(const ::odata::string_t& full_path) const
 	{
 		return m_client->get_relative_path(full_path);
 	}
 
 	template<typename Executor, typename Builder>
-	std::shared_ptr<odata_service_query<Executor, Builder>> create_query(const ::utility::string_t& resource_path)
+	std::shared_ptr<odata_service_query<Executor, Builder>> create_query(const ::odata::string_t& resource_path)
 	{
-		return std::make_shared<odata_service_query<Executor, Builder>>(resource_path, shared_from_this());
+		return ::odata::make_shared<odata_service_query<Executor, Builder>>(resource_path, shared_from_this());
 	}
 
-    template<typename Type>
-	::pplx::task<::web::http::status_code> add_object(const ::utility::string_t& path, const std::shared_ptr<Type>& p_object)
+	template<typename Type>
+	::pplx::task<std::pair<nullptr_t, ::odata::client::http_result>> add_object(const ::odata::string_t& path, const std::shared_ptr<Type>& p_object)
 	{
-		auto model = m_client->get_model().get();
+		auto model = m_client->get_model().get().first;
 
 		if (m_client && model && p_object)
 		{
 			auto entity_value = std::dynamic_pointer_cast<::odata::core::odata_entity_value>(p_object->to_value());
 			if (!entity_value)
 			{
-				return ::pplx::task_from_result(::web::http::status_code(-1));
+				return ::pplx::task_from_result(std::make_pair(nullptr, ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 			}
 
 			entity_value->set_value(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_TYPE, Type::get_full_name());
 
 			return m_client->create_entity(path, entity_value).then(
-				[this, entity_value, p_object] (const ::web::http::status_code& ret_code) -> ::web::http::status_code
-			    {
-					::utility::string_t edit_link;
+				[this, entity_value, p_object] (const std::pair<nullptr_t, ::odata::client::http_result>& ret_code) -> std::pair<nullptr_t, ::odata::client::http_result>
+				{
+					::odata::string_t edit_link;
 					if (entity_value->try_get(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_EDITLINK, edit_link))
 					{
 						p_object->set_edit_link(edit_link);
 					}
 
 					return ret_code;
-			    });
+				});
 		}
 
-		return ::pplx::task_from_result(::web::http::status_code(-1));
+		return ::pplx::task_from_result(std::make_pair(nullptr, ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 	}
 
 	template<typename Type>
-	::pplx::task<::web::http::status_code> update_object(const std::shared_ptr<Type>& p_object, const ::utility::string_t &update_type = HTTP_PATCH)
+	::pplx::task<std::pair<nullptr_t, ::odata::client::http_result>> update_object(const std::shared_ptr<Type>& p_object, const ::odata::string_t &update_type = HTTP_PATCH)
 	{
 		if (m_client && p_object)
 		{
-			return m_client->send_data_to_server(get_relative_path(p_object->get_edit_link()), p_object->to_value(), update_type);
+			return m_client->send_data_to_server(::web::http::uri::encode_uri(get_relative_path(p_object->get_edit_link())), p_object->to_value(), update_type);
 		}
 
-		return ::pplx::task_from_result(::web::http::status_code(-1));
+		return ::pplx::task_from_result(std::make_pair(nullptr, ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 	}
 
 	template<typename Type>
-    ::pplx::task<::web::http::status_code> delete_object(const std::shared_ptr<Type>& p_object)
+	::pplx::task<std::pair<nullptr_t, ::odata::client::http_result>> update_object(const std::vector<std::shared_ptr<Type>>& objects, const ::odata::string_t &update_type = HTTP_PATCH)
+	{
+		if (m_client && !objects.empty())
+		{
+			auto entity_type = m_model->find_entity_type(objects.front()->get_type_name());
+			if (entity_type)
+			{
+				auto collection_type = ::odata::make_shared<::odata::edm::edm_collection_type>(_XPLATSTR(""), entity_type);
+				auto Collection      = ::odata::make_shared<::odata::core::odata_collection_value>(collection_type);
+				for (auto &p_object : objects)
+				{
+					Collection->add_collection_value(p_object->to_value());
+				}
+				::odata::string_t link = objects.front()->get_edit_link();
+				::odata::string_t key  = objects.front()->get_key_property_string();
+				size_t            keypos = link.rfind(key);
+				if ((keypos >= 0) && (keypos != ::odata::string_t::npos))
+				{
+					link.erase(keypos - 1);
+				}
+				return m_client->send_data_to_server(::web::http::uri::encode_uri(get_relative_path(link)), Collection, update_type);
+			}
+		}
+
+		return ::pplx::task_from_result(std::make_pair(nullptr, ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
+	}
+
+	template<typename Type>
+	::pplx::task<std::pair<nullptr_t, ::odata::client::http_result>> delete_object(const std::shared_ptr<Type>& p_object)
 	{
 		if (m_client && p_object)
 		{
-			return m_client->send_data_to_server(get_relative_path(p_object->get_edit_link()), HTTP_DELETE);
+			return m_client->send_data_to_server(::web::http::uri::encode_uri(get_relative_path(p_object->get_edit_link())), HTTP_DELETE);
 		}
 
-		return ::pplx::task_from_result(::web::http::status_code(-1));
+		return ::pplx::task_from_result(std::make_pair(nullptr, ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 	}
 
+	// @TODO: How can we make a multiple instance delete???
+
 	template<typename ParentType, typename Type>
-	::pplx::task<::web::http::status_code> add_related_object(const std::shared_ptr<ParentType>& p_parent, const ::utility::string_t& path,  const std::shared_ptr<Type>& p_object)
+	::pplx::task<std::pair<nullptr_t, ::odata::client::http_result>> add_related_object(const std::shared_ptr<ParentType>& p_parent, const ::odata::string_t& path, const std::shared_ptr<Type>& p_object)
 	{
-		auto model = get_edm_model();
-		if (!p_parent || !model || !p_object) 
+		auto &model = get_edm_model();
+		if (!p_parent || !model || !p_object)
 		{
-			return ::pplx::task_from_result(::web::http::status_code(-1));
+			return ::pplx::task_from_result(std::make_pair(nullptr, ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 		}
 
-		return add_object(get_relative_path(p_parent->get_edit_link() + U("/") + path), p_object);
+		return add_object(get_relative_path(p_parent->get_edit_link() + _XPLATSTR("/") + path), p_object);
 	}
 
 	template<typename ParentType, typename Type>
-	::pplx::task<::web::http::status_code> update_related_object(const std::shared_ptr<ParentType>& p_parent, const ::utility::string_t& path,  const std::shared_ptr<Type>& p_object)
+	::pplx::task<std::pair<nullptr_t, ::odata::client::http_result>> update_related_object(const std::shared_ptr<ParentType>& p_parent, const ::odata::string_t& path, const std::shared_ptr<Type>& p_object)
 	{
 		if (!p_parent)
 		{
-			return ::pplx::task_from_result(::web::http::status_code(-1));
+			return ::pplx::task_from_result(std::make_pair(nullptr, ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 		}
-		
-		auto full_navigation_path = p_parent->get_edit_link() + U("/") + path;
+
+		auto full_navigation_path = p_parent->get_edit_link() + _XPLATSTR("/") + path;
 		auto navigation_path = get_relative_path(full_navigation_path);
 
 		if (m_client && p_object)
 		{
-			return m_client->send_data_to_server(get_relative_path(navigation_path), p_object->to_value(), HTTP_PATCH).then
-				( [this, p_object, full_navigation_path] (::web::http::status_code ret_code) -> ::web::http::status_code
-			    {
+			return m_client->send_data_to_server(::web::http::uri::encode_uri(get_relative_path(navigation_path)), p_object->to_value(), HTTP_PATCH).then
+				( [this, p_object, full_navigation_path] (::odata::client::http_result ret_code) -> std::pair<nullptr_t, ::odata::client::http_result>
+				{
 					if (p_object)
 					{
 						p_object->set_edit_link(full_navigation_path);
 					}
 
-					return ret_code;
-			    });
+					return std::make_pair(nullptr, ret_code);
+				});
 		}
 
-		return ::pplx::task_from_result(::web::http::status_code(-1));
+		return ::pplx::task_from_result(std::make_pair(nullptr, ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 	}
 
 	template<typename ParentType, typename Type>
-	::pplx::task<::web::http::status_code> add_reference(const std::shared_ptr<ParentType>& p_parent, const ::utility::string_t& path, const std::shared_ptr<Type>& p_object)
+	::pplx::task<std::pair<nullptr_t, ::odata::client::http_result>> add_reference(const std::shared_ptr<ParentType>& p_parent, const ::odata::string_t& path, const std::shared_ptr<Type>& p_object)
 	{
 		if (m_client && p_parent && p_object)
 		{
-			return m_client->add_reference(get_relative_path(p_parent->get_edit_link() + U("/") + path), p_object->get_edit_link());
+			return m_client->add_reference(get_relative_path(p_parent->get_edit_link() + _XPLATSTR("/") + path), p_object->get_edit_link());
 		}
 
-		return ::pplx::task_from_result(::web::http::status_code(-1));
+		return ::pplx::task_from_result(std::make_pair(nullptr, ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 	}
 
 	template<typename ParentType, typename Type>
-	::pplx::task<::web::http::status_code> update_reference(const std::shared_ptr<ParentType>& p_parent, const ::utility::string_t& path, const std::shared_ptr<Type>& p_object)
+	::pplx::task<std::pair<nullptr_t, ::odata::client::http_result>> update_reference(const std::shared_ptr<ParentType>& p_parent, const ::odata::string_t& path, const std::shared_ptr<Type>& p_object)
 	{
 		if (m_client && p_parent && p_object)
 		{
-			return m_client->update_reference(get_relative_path(p_parent->get_edit_link() + U("/") + path), p_object->get_edit_link());
+			return m_client->update_reference(get_relative_path(p_parent->get_edit_link() + _XPLATSTR("/") + path), p_object->get_edit_link());
 		}
 
-		return ::pplx::task_from_result(::web::http::status_code(-1));
+		return ::pplx::task_from_result(std::make_pair(nullptr, ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 	}
 
 protected:
-	std::shared_ptr<::odata::client::odata_client>         m_client;
-	std::shared_ptr<::odata::edm::edm_model>               m_model;
+	std::shared_ptr<::odata::client::odata_client> m_client;
+	std::shared_ptr<::odata::edm::edm_model>       m_model;
 };
 
 }}

--- a/include/odata/codegen/odata_singleton_query_executor.h
+++ b/include/odata/codegen/odata_singleton_query_executor.h
@@ -25,50 +25,50 @@ public:
 	{
 	}
 
-	typedef typename std::shared_ptr<ElementType> return_type;
+	typedef typename std::pair<std::shared_ptr<ElementType>, ::odata::client::http_result> return_type;
 
-	::pplx::task<return_type> execute_query(const ::utility::string_t& query_expression)
+	::pplx::task<return_type> execute_query(const ::odata::string_t& query_expression)
 	{
 		if (!m_client_context || !m_client_context->get_client())
 		{
-			return ::pplx::task_from_result(std::shared_ptr<ElementType>(nullptr));
+			return ::pplx::task_from_result(std::make_pair(return_type::first_type(), ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 		}
 
-		auto model = m_client_context->get_edm_model();
-		auto root_url = m_client_context->get_root_url();
-		auto client_context = m_client_context;
+		auto &model = m_client_context->get_edm_model();
+		auto &root_url = m_client_context->get_root_url();
+		auto &client_context = m_client_context;
 
 		return m_client_context->get_client()->get_data_from_server(query_expression).then(
-            [this, model, root_url, client_context] (const std::vector<std::shared_ptr<odata::core::odata_value>>& values) -> std::shared_ptr<ElementType>
+			[this, model, root_url, client_context] (const std::pair<std::vector<std::shared_ptr<odata::core::odata_value>>, ::odata::client::http_result>& values) -> return_type
 			{
-				if (values.size() == 1)
+				if (values.first.size() == 1)
 				{
-					auto entity_value = std::dynamic_pointer_cast<::odata::core::odata_entity_value>(values[0]);
-					return create_instance_from_entity<ElementType>(entity_value, client_context);
+					auto entity_value = std::dynamic_pointer_cast<::odata::core::odata_entity_value>(values.first.front());
+					return std::make_pair(create_instance_from_entity<ElementType>(entity_value, client_context), values.second);
 				}
-        
-				return nullptr; 
+
+				return std::make_pair(return_type::first_type(), values.second);
 			});
 	}
 
-	::pplx::task<return_type> execute_operation_query(const ::utility::string_t& query_expression, const std::vector<std::shared_ptr<::odata::core::odata_parameter>>& parameters, bool is_function)
+	::pplx::task<return_type> execute_operation_query(const ::odata::string_t& query_expression, const std::vector<std::shared_ptr<::odata::core::odata_parameter>>& parameters, bool is_function)
 	{
 		if (!m_client_context || !m_client_context->get_client())
 		{
-			return ::pplx::task_from_result(return_type());
+			return ::pplx::task_from_result(std::make_pair(return_type::first_type(), ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 		}
 
-		auto client_context = m_client_context;
+		auto &client_context = m_client_context;
 
 		std::vector<std::shared_ptr<::odata::core::odata_value>> ret_values;
-		m_client_context->get_client()->send_data_to_server(query_expression, parameters, ret_values, is_function ? HTTP_GET : HTTP_POST).get();
+		auto status_code = m_client_context->get_client()->send_data_to_server(query_expression, parameters, ret_values, is_function ? HTTP_GET : HTTP_POST).get().second;
 
 		if (ret_values.size() == 1)
 		{
-			return ::pplx::task_from_result(create_instance_from_entity<ElementType>(std::dynamic_pointer_cast<::odata::core::odata_entity_value>(ret_values[0]), client_context));
+			return ::pplx::task_from_result(std::make_pair(create_instance_from_entity<ElementType>(std::dynamic_pointer_cast<::odata::core::odata_entity_value>(ret_values.front()), client_context), std::move(status_code)));
 		}
 
-		return ::pplx::task_from_result(return_type()); 
+		return ::pplx::task_from_result(std::make_pair(return_type::first_type(), std::move(status_code)));
 	}
 
 protected:

--- a/include/odata/codegen/odata_void_query_executor.h
+++ b/include/odata/codegen/odata_void_query_executor.h
@@ -24,19 +24,19 @@ public:
 	{
 	}
 
-	typedef int return_type;
+	typedef std::pair<int, ::odata::client::http_result> return_type;
 
-	::pplx::task<return_type> execute_operation_query(const ::utility::string_t& query_expression, const std::vector<std::shared_ptr<::odata::core::odata_parameter>>& parameters, bool is_function)
+	::pplx::task<return_type> execute_operation_query(const ::odata::string_t& query_expression, const std::vector<std::shared_ptr<::odata::core::odata_parameter>>& parameters, bool is_function)
 	{
 		if (!m_client_context || !m_client_context->get_client())
 		{
-			return ::pplx::task_from_result(-1);
+			return ::pplx::task_from_result(std::make_pair(-1, ::odata::client::http_result(::web::http::http_headers(), ::web::http::status_code(-1))));
 		}
 
 		std::vector<std::shared_ptr<::odata::core::odata_value>> ret_values;
-		m_client_context->get_client()->send_data_to_server(query_expression, parameters, ret_values, is_function ? HTTP_GET : HTTP_POST).get();
-			
-		return ::pplx::task_from_result(0); 
+		auto status_code = m_client_context->get_client()->send_data_to_server(query_expression, parameters, ret_values, is_function ? HTTP_GET : HTTP_POST).get().second;
+
+		return ::pplx::task_from_result(std::make_pair(0, std::move(status_code)));
 	}
 
 protected:

--- a/include/odata/common/platform.h
+++ b/include/odata/common/platform.h
@@ -9,15 +9,15 @@
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
 #include <ppltasks.h>
 namespace pplx = Concurrency;
-#else 
+#else
 #include "pplx/pplxtasks.h"
 #endif
 
 #ifdef _MSC_VER
-#pragma warning(disable:4146 4267 4521 4522 4566 4996)
+#pragma warning(disable: 4996)
 #endif
 
-#define U(x) _XPLATSTR(x)
+//#define U(x) _XPLATSTR(x)
 
 #ifndef ODATACPP_CLIENT_API
 #ifdef ODATACLIENT_EXPORTS

--- a/include/odata/common/utility.h
+++ b/include/odata/common/utility.h
@@ -256,31 +256,31 @@ class string_t
 		string_t& insert(size_type index, ::utility::string_t const &str, size_type index_str, size_type count = npos)   { auto s = s_.get(); s.insert(index, str, index_str, count);    s_ = std::move(s); return *this; }
 		const_iterator insert(const_iterator pos, value_type ch)
 		{
-			auto s    = s_.get();
-			auto iter = s.insert(s.begin() + (pos - s_.get().cbegin()), ch);
-			s_        = std::move(s);
-			return cbegin() + (iter - s.begin());
+			auto s = s_.get();
+			auto length = s.insert(s.begin() + (pos - s_.get().cbegin()), ch) - s.begin();
+			s_ = std::move(s);
+			return cbegin() + length;
 		}
 		const_iterator insert(const_iterator pos, size_type count, value_type ch)
 		{
 			auto s = s_.get();
-			auto iter = s.insert(s.begin() + (pos - s_.get().cbegin()), count, ch);
+			auto length = s.insert(s.begin() + (pos - s_.get().cbegin()), count, ch) - s.begin();
 			s_ = std::move(s);
-			return cbegin() + (iter - s.begin());
+			return cbegin() + length;
 		}
 		template<typename InputIt> const_iterator insert(const_iterator pos, InputIt first, InputIt last)
 		{
 			auto s = s_.get();
-			auto iter = s.insert(s.begin() + (pos - s_.get().cbegin()), first, last);
+			auto length = s.insert(s.begin() + (pos - s_.get().cbegin()), first, last) - s.begin();
 			s_ = std::move(s);
-			return cbegin() + (iter - s.begin());
+			return cbegin() + length;
 		}
 		const_iterator insert(const_iterator pos, std::initializer_list<value_type> ilist)
 		{
 			auto s = s_.get();
-			auto iter = s.insert(s.begin() + (pos - s_.get().cbegin()), ilist);
+			auto length = s.insert(s.begin() + (pos - s_.get().cbegin()), ilist) - s.begin();
 			s_ = std::move(s);
-			return cbegin() + (iter - s.begin());
+			return cbegin() + length;
 		}
 		template <typename T> string_t& insert(size_type pos, T const &t)                                                { auto s = s_.get(); s.insert(pos, t);                          s_ = std::move(s); return *this; }
 		template <typename T> string_t& insert(size_type index, T const &t, size_type index_str, size_type count = npos) { auto s = s_.get(); s.insert(index, t, index_str, count);      s_ = std::move(s); return *this; }
@@ -290,16 +290,16 @@ class string_t
 		const_iterator erase(const_iterator position)
 		{
 			auto s = s_.get();
-			auto iter = s.erase(s.begin() + (position - s_.get().cbegin()));
+			auto length = s.erase(s.begin() + (position - s_.get().cbegin())) - s.begin();
 			s_ = std::move(s);
-			return cbegin() + (iter - s.begin());
+			return cbegin() + length;
 		}
 		const_iterator erase(const_iterator first, const_iterator last)
 		{
 			auto s = s_.get();
-			auto iter = s.erase(s.begin() + (first - s_.get().cbegin()), s.begin() + (last - s_.get().cbegin()));
+			auto length = s.erase(s.begin() + (first - s_.get().cbegin()), s.begin() + (last - s_.get().cbegin())) - s.begin();
 			s_ = std::move(s);
-			return cbegin() + (iter - s.begin());
+			return cbegin() + length;
 		}
 
 		// push_back

--- a/include/odata/common/utility.h
+++ b/include/odata/common/utility.h
@@ -7,19 +7,20 @@
 #pragma once
 
 #include <string>
+#ifdef __cpp_lib_string_view
+	#include <string_view>
+#endif
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <functional>
 #include <memory>
-#include <vector>
 #include <utility>
 #include <exception>
 #include <algorithm>
 #include <unordered_map>
 #include <functional>
-#include <list>
-#include <thread> 
+#include <thread>
 #include <mutex>
 #include <iomanip>
 #include "cpprest/uri.h"
@@ -28,24 +29,682 @@
 #include "cpprest/http_client.h"
 #include "odata/common/platform.h"
 
+// Select std and boost replacements
+#define _USE_BOOST_FLYWEIGHT_STRING
+//#define _USE_BOOST_FLYWEIGHT_VECTOR
+#define _USE_SHARED_PTR_TWO_PHASE_ALLOCATION
+//#define _ODATA_TEST_INSTANCIATE_HASH_SPECIALISATIONS
+
+// If we want to use boost::flyweight<std::string> we create an additional wrapper around this to simulate the behavior of std::string as closely as possible.
+// The only exception here are functions that have iterators on the string to manipulate or return a reference to the hold string (non-const).
+#if defined(_USE_BOOST_FLYWEIGHT_STRING) || defined(_USE_BOOST_FLYWEIGHT_VECTOR) || !defined(_BOOST_FLYWEIGHT_HASH_OPTIMIZATION)
+	#include "boost/flyweight.hpp"
+	#include "boost/flyweight/no_tracking.hpp"
+	#include "boost/container_hash/hash.hpp"
+#endif
+
+// Extend std::hash to support boost::flyweight with optimum performance:
+// This causes to hash the address of the flyweight object instead of the object itself, resulting in optimum performance for the hash operation.
+// For an explanation see http://lists.boost.org/boost-users/2013/03/78007.php
+// and https://stackoverflow.com/questions/8695379/how-to-make-boost-unordered-map-to-support-flyweightstring
+// Hint: According to the standard extending the std-namespace in this case is exceptionally legal (for template specialization).
+//       Beware! Extending the std-namespace in other use cases is an absolute no-go!
+#ifndef _BOOST_FLYWEIGHT_HASH_OPTIMIZATION
+namespace std
+{
+	template <typename T> struct hash<::boost::flyweight<T, ::boost::flyweights::no_tracking>>
+	{
+		using value_type = ::boost::flyweight<T, ::boost::flyweights::no_tracking>;
+		size_t operator()(value_type const &Value) const
+		{
+			hash<void const*> hasher;
+			return hasher(&Value.get());
+		}
+	};
+}
+#define _BOOST_FLYWEIGHT_HASH_OPTIMIZATION
+#endif
+
+#ifdef _USE_BOOST_FLYWEIGHT_STRING
+namespace odata
+{
+
+	// ============================================================================================================
+	// Begin extension:
+	// Alternatively to ::utility::string_t we can use ::boost::flyweight<::utility::string_t> for storing strings.
+	// Depending on the data processed this gives us releave on the memory burden that plain strings will cause.
+	// This is mainly useful in case of many identical strings that otherwise clobber the memory.
+	// ============================================================================================================
+
+class string_t
+{
+	// @HINT: In order to make it fully functional we'd also need to add replacement classes for reference and iterator types!
+	//        However this might prove to be extremely unperformant. Every time the reference or iterator is being written to
+	//        we'd need to create a complete new flyweight string and swap it with the existing one. When looping over a string
+	//        this will yield unearthly, prohibitively bad performance!
+	//        So until someone comes up with a well founded reason to have those objects (can't imagine why) we'll not take
+	//        the effort to implement this complicated and utmost useless helper classes that are dangerous to use for unawares!
+	// @TODO: However there *is* a scenario when refactoring existing code, namely the use of mutating function of std::algorithm!
+	//        Refactor this into creating a temporary ::utility::string_t and mutating this one, assigning back to the flyweight
+	//        string if necessary. Alternatively one could also supply suitable overloads of all mutating algorithms if desirable.
+
+	public:
+
+		// Forward typedefs
+		typedef ::utility::string_t::traits_type            traits_type;
+		typedef ::utility::string_t::value_type             value_type;
+		typedef ::utility::string_t::allocator_type         allocator_type;
+		typedef ::utility::string_t::size_type              size_type;
+		typedef ::utility::string_t::difference_type        difference_type;
+		typedef ::utility::string_t::reference              reference;
+		typedef ::utility::string_t::const_reference        const_reference;
+		typedef ::utility::string_t::pointer                pointer;
+		typedef ::utility::string_t::const_pointer          const_pointer;
+		typedef ::utility::string_t::iterator               iterator;
+		typedef ::utility::string_t::const_iterator         const_iterator;
+		typedef ::utility::string_t::reverse_iterator       reverse_iterator;
+		typedef ::utility::string_t::const_reverse_iterator const_reverse_iterator;
+
+		// Member functions
+		// ================
+
+		// Constructors
+		string_t()                                                                                                                      : s_() {}
+		explicit string_t(allocator_type const &alloc) noexcept                                                                         : s_(alloc) {}
+		string_t(size_type count, value_type ch, allocator_type const &alloc = allocator_type())                                        : s_(count, ch, alloc) {}
+		string_t(string_t const &other, size_type pos, size_type count = npos, allocator_type const &alloc = allocator_type())          : s_(other.s_, pos, count, alloc) {}
+		string_t(::utility::string_t const &str, size_type pos, size_type count = npos, allocator_type const& alloc = allocator_type()) : s_(str, pos, count, alloc) {}
+		string_t(value_type const *cstr, size_type count, allocator_type const &alloc = allocator_type())                               : s_(cstr, count, alloc) {}
+		string_t(value_type const *cstr, allocator_type const &alloc = allocator_type())                                                : s_(cstr, alloc) {}
+		template<typename InputIt> string_t(InputIt first, InputIt last, allocator_type const &alloc = allocator_type())                : s_(first, last, alloc) {}
+		string_t(string_t const &other)                                                                                                 : s_(other.s_) {}
+		string_t(string_t const &other, allocator_type const &alloc)                                                                    : s_(other.s_, alloc) {}
+		string_t(::utility::string_t const &str)                                                                                        : s_(str) {}
+		string_t(::utility::string_t const &str, allocator_type const& alloc)                                                           : s_(str, alloc) {}
+		string_t(string_t &&other) noexcept                                                                                             : s_(std::move(other.s_)) {}
+		string_t(string_t &&other, allocator_type const &alloc)                                                                         : s_(std::move(other.s_), alloc) {}
+		string_t(::utility::string_t && str) noexcept                                                                                   : s_(std::move(str)) {}
+		string_t(::utility::string_t && str, allocator_type const& alloc)                                                               : s_(std::move(str), alloc) {}
+		string_t(std::initializer_list<value_type> ilist, allocator_type const &alloc = allocator_type())                               : s_(ilist, alloc) {}
+		template<typename T> explicit string_t(T const &t, allocator_type const &alloc = allocator_type())                              : s_(::utility::string_t(t), alloc) {}
+		template<typename T> string_t(T const &t, size_type pos, size_type n, allocator_type const &alloc = allocator_type())           : s_(::utility::string_t(t, pos, n), alloc) {}
+
+		// Destructor
+		~string_t() = default;
+
+		// operator=
+		string_t& operator=(string_t const &str)                     { s_ = str.s_;                     return *this; }
+		string_t& operator=(::utility::string_t const& str)          { s_ = str;                        return *this; }
+		string_t& operator=(string_t &&str) noexcept                 { s_ = std::move(str.s_);          return *this; }
+		string_t& operator=(::utility::string_t&& str) noexcept      { s_ = std::move(str);             return *this; }
+		string_t& operator=(value_type const *cstr)                  { s_ = cstr;                       return *this; }
+		string_t& operator=(value_type ch)                           { s_ = ::utility::string_t(1, ch); return *this; }
+		string_t& operator=(std::initializer_list<value_type> ilist) { s_ = ilist;                      return *this; }
+		template<typename T> string_t& operator=(T const &t)         { s_ = t;                          return *this; }
+
+		// Assign
+		string_t& assign(size_type count, value_type ch)                                          { s_ = ::utility::string_t(count, ch);          return *this; }
+		string_t& assign(string_t const& str)                                                     { s_ = str.s_;                                  return *this; }
+		string_t& assign(::utility::string_t const& str)                                          { s_ = str;                                     return *this; }
+		string_t& assign(string_t const& str, size_type pos, size_type count = npos)              { s_ = ::utility::string_t(str.s_, pos, count); return *this; }
+		string_t& assign(::utility::string_t const& str, size_type pos, size_type count = npos)   { s_ = ::utility::string_t(str, pos, count);    return *this; }
+		string_t& assign(string_t &&str) noexcept                                                 { s_ = std::move(str.s_);                       return *this; }
+		string_t& assign(::utility::string_t &&str) noexcept                                      { s_ = std::move(str);                          return *this; }
+		string_t& assign(value_type const *cstr, size_type count)                                 { s_ = ::utility::string_t(cstr, count);        return *this; }
+		string_t& assign(value_type const *cstr)                                                  { s_ = cstr;                                    return *this; }
+		template<typename InputIt> string_t& assign(InputIt first, InputIt last)                  { s_ = ::utility::string_t(first, last);        return *this; }
+		string_t& assign(std::initializer_list<value_type> ilist)                                 { s_ = ::utility::string_t(ilist);              return *this; }
+		template <typename T> string_t& assign(T const &t)                                        { s_ = ::utility::string_t(t);                  return *this; }
+		template <typename T> string_t& assign(T const &t, size_type pos, size_type count = npos) { s_ = ::utility::string_t(t, pos, count);      return *this; }
+
+		// get_allocator
+		allocator_type get_allocator() const { return s_.get().get_allocator(); }
+
+		// Element access
+		// ==============
+
+		// at
+		//reference at(size_type pos); // @HINT: Needs reference replacement!
+		const_reference at(size_type pos) const { return s_.get().at(pos); }
+
+		// operator[]
+		//reference operator[](size_type pos);  // @HINT: Needs reference replacement!
+		const_reference operator[](size_type pos) const { return s_.get()[pos]; }
+
+		// front
+		//value_type& front();  // @HINT: Needs reference replacement!
+		value_type const& front() const { return s_.get().front(); }
+
+		// back
+		//value_type& back();  // @HINT: Needs reference replacement!
+		value_type const& back() const { return s_.get().back(); }
+
+		// data
+		value_type const* data() const noexcept { return s_.get().data(); }
+
+		// c_str()
+		value_type const* c_str() const noexcept { return s_.get().c_str(); }
+
+		// operator basic_string_view
+		#ifdef __cpp_lib_string_view
+			operator std::basic_string_view<value_type, traits_type>() const noexcept { return std::basic_string_view<value_type, traits_type>(s_.get()); }
+		#endif
+
+		// Iterators
+		// =========
+
+		// (c)begin
+		//iterator begin() noexcept; // @HINT: Needs iterator replacement!
+		const_iterator begin()  const noexcept { return s_.get().begin();  }
+		const_iterator cbegin() const noexcept { return s_.get().cbegin(); }
+
+		// (c)end
+		//iterator end() noexcept; // @HINT: Needs iterator replacement!
+		const_iterator end()  const noexcept { return s_.get().end();  }
+		const_iterator cend() const noexcept { return s_.get().cend(); }
+
+		// (c)rbegin
+		//reverse_iterator rbegin() noexcept; // @HINT: Needs iterator replacement!
+		const_reverse_iterator rbegin()  const noexcept { return s_.get().rbegin();  }
+		const_reverse_iterator crbegin() const noexcept { return s_.get().crbegin(); }
+
+		// (c)rend
+		//reverse_iterator rend() noexcept; // @HINT: Needs iterator replacement!
+		const_reverse_iterator rend()  const noexcept { return s_.get().rend();  }
+		const_reverse_iterator crend() const noexcept { return s_.get().crend(); }
+
+		// Capacity
+		// ========
+
+		// empty
+		#ifdef __has_cpp_attribute
+			#if __has_cpp_attribute(nodiscard)
+				[[nodiscard]]
+			#endif
+		#endif
+		bool empty() const noexcept { return s_.get().empty(); }
+
+		// size/length
+		size_type size()   const noexcept { return s_.get().size();   }
+		size_type length() const noexcept { return s_.get().length(); }
+
+		// max_size
+		size_type max_size() const noexcept { return s_.get().max_size(); }
+
+		// reserve
+		void reserve(size_type /*new_cap*/ = 0) {} // Not safely/reasonably implementable, thus made it a no-op!
+
+		// capacity
+		size_type capacity() const noexcept { return s_.get().capacity(); }
+
+		// shrink_to_fit
+		void shrink_to_fit() {} // Not safely/reasonably implementable, thus made it a no-op!
+
+		// Operations
+		// ==========
+
+		// clear
+		void clear() noexcept { s_ = ::utility::string_t(); }
+
+		// insert
+		string_t& insert(size_type index, size_type count, value_type ch)                                                { auto s = s_.get(); s.insert(index, count, ch);                s_ = std::move(s); return *this; }
+		string_t& insert(size_type index, value_type const *cstr)                                                        { auto s = s_.get(); s.insert(index, cstr);                     s_ = std::move(s); return *this; }
+		string_t& insert(size_type index, value_type const * cstr, size_type count)                                      { auto s = s_.get(); s.insert(index, cstr, count);              s_ = std::move(s); return *this; }
+		string_t& insert(size_type index, string_t const &str)                                                           { auto s = s_.get(); s.insert(index, str.s_);                   s_ = std::move(s); return *this; }
+		string_t& insert(size_type index, ::utility::string_t const &str)                                                { auto s = s_.get(); s.insert(index, str);                      s_ = std::move(s); return *this; }
+		string_t& insert(size_type index, string_t const &str, size_type index_str, size_type count = npos)              { auto s = s_.get(); s.insert(index, str.s_, index_str, count); s_ = std::move(s); return *this; }
+		string_t& insert(size_type index, ::utility::string_t const &str, size_type index_str, size_type count = npos)   { auto s = s_.get(); s.insert(index, str, index_str, count);    s_ = std::move(s); return *this; }
+		const_iterator insert(const_iterator pos, value_type ch)
+		{
+			auto s    = s_.get();
+			auto iter = s.insert(s.begin() + (pos - s_.get().cbegin()), ch);
+			s_        = std::move(s);
+			return cbegin() + (iter - s.begin());
+		}
+		const_iterator insert(const_iterator pos, size_type count, value_type ch)
+		{
+			auto s = s_.get();
+			auto iter = s.insert(s.begin() + (pos - s_.get().cbegin()), count, ch);
+			s_ = std::move(s);
+			return cbegin() + (iter - s.begin());
+		}
+		template<typename InputIt> const_iterator insert(const_iterator pos, InputIt first, InputIt last)
+		{
+			auto s = s_.get();
+			auto iter = s.insert(s.begin() + (pos - s_.get().cbegin()), first, last);
+			s_ = std::move(s);
+			return cbegin() + (iter - s.begin());
+		}
+		const_iterator insert(const_iterator pos, std::initializer_list<value_type> ilist)
+		{
+			auto s = s_.get();
+			auto iter = s.insert(s.begin() + (pos - s_.get().cbegin()), ilist);
+			s_ = std::move(s);
+			return cbegin() + (iter - s.begin());
+		}
+		template <typename T> string_t& insert(size_type pos, T const &t)                                                { auto s = s_.get(); s.insert(pos, t);                          s_ = std::move(s); return *this; }
+		template <typename T> string_t& insert(size_type index, T const &t, size_type index_str, size_type count = npos) { auto s = s_.get(); s.insert(index, t, index_str, count);      s_ = std::move(s); return *this; }
+
+		// erase
+		string_t& erase(size_type index = 0, size_type count = npos) { auto s = s_.get(); s.erase(index, count); s_ = std::move(s); return *this; }
+		const_iterator erase(const_iterator position)
+		{
+			auto s = s_.get();
+			auto iter = s.erase(s.begin() + (position - s_.get().cbegin()));
+			s_ = std::move(s);
+			return cbegin() + (iter - s.begin());
+		}
+		const_iterator erase(const_iterator first, const_iterator last)
+		{
+			auto s = s_.get();
+			auto iter = s.erase(s.begin() + (first - s_.get().cbegin()), s.begin() + (last - s_.get().cbegin()));
+			s_ = std::move(s);
+			return cbegin() + (iter - s.begin());
+		}
+
+		// push_back
+		void push_back(value_type ch) { append(static_cast<size_type>(1U), ch); }
+
+		// pop_back
+		void pop_back() { auto s = s_.get(); s.pop_back(); s_ = std::move(s); }
+
+		// append
+		string_t& append(size_type count, value_type ch)                                          { auto s = s_.get(); s.append(count, ch);          s_ = std::move(s); return *this; }
+		string_t& append(string_t const &str)                                                     { auto s = s_.get(); s.append(str.s_);             s_ = std::move(s); return *this; }
+		string_t& append(::utility::string_t const &str)                                          { auto s = s_.get(); s.append(str);                s_ = std::move(s); return *this; }
+		string_t& append(string_t const &str, size_type pos, size_type count = npos)              { auto s = s_.get(); s.append(str.s_, pos, count); s_ = std::move(s); return *this; }
+		string_t& append(::utility::string_t const &str, size_type pos, size_type count = npos)   { auto s = s_.get(); s.append(str, pos, count);    s_ = std::move(s); return *this; }
+		string_t& append(value_type const *cstr, size_type count)                                 { auto s = s_.get(); s.append(cstr, count);        s_ = std::move(s); return *this; }
+		string_t& append(value_type const *cstr)                                                  { auto s = s_.get(); s.append(cstr);               s_ = std::move(s); return *this; }
+		template<typename InputIt> string_t& append(InputIt first, InputIt last)                  { auto s = s_.get(); s.append(first, last);        s_ = std::move(s); return *this; }
+		string_t& append(std::initializer_list<value_type> ilist)                                 { auto s = s_.get(); s.append(ilist);              s_ = std::move(s); return *this; }
+		template <typename T> string_t& append(T const &t)                                        { auto s = s_.get(); s.append(t);                  s_ = std::move(s); return *this; }
+		template <typename T> string_t& append(T const &t, size_type pos, size_type count = npos) { auto s = s_.get(); s.append(t, pos, count);      s_ = std::move(s); return *this; }
+
+		// operator+=
+		string_t& operator+=(string_t const &str)                     { return append(str);                            }
+		string_t& operator+=(::utility::string_t const &str)          { return append(str);                            }
+		string_t& operator+=(value_type ch)                           { return append(static_cast<size_type>(1U), ch); }
+		string_t& operator+=(value_type const *cstr)                  { return append(cstr);                           }
+		string_t& operator+=(std::initializer_list<value_type> ilist) { return append(ilist);                          }
+		template <typename T> string_t& operator+=(T const &t)        { return append(t);                              }
+
+		// compare
+		int compare(string_t const &str) const noexcept                                                                                { return s_.get().compare(str.s_); }
+		int compare(::utility::string_t const &str) const noexcept                                                                     { return s_.get().compare(str); }
+		int compare(size_type pos1, size_type count1, string_t const &str) const                                                       { return s_.get().compare(pos1, count1, str.s_); }
+		int compare(size_type pos1, size_type count1, ::utility::string_t const &str) const                                            { return s_.get().compare(pos1, count1, str); }
+		int compare(size_type pos1, size_type count1, string_t const &str, size_type pos2, size_type count2 = npos) const              { return s_.get().compare(pos1, count1, str.s_, pos2, count2); }
+		int compare(size_type pos1, size_type count1, ::utility::string_t const &str, size_type pos2, size_type count2 = npos) const   { return s_.get().compare(pos1, count1, str, pos2, count2); }
+		int compare(value_type const *cstr) const                                                                                      { return s_.get().compare(cstr); }
+		int compare(size_type pos1, size_type count1, value_type const *cstr) const                                                    { return s_.get().compare(pos1, count1, cstr); }
+		int compare(size_type pos1, size_type count1, value_type const *cstr, size_type count2) const                                  { return s_.get().compare(pos1, count1, cstr, count2); }
+		template <typename T> int compare(T const &t) const noexcept                                                                   { return s_.get().compare(t); }
+		template <typename T> int compare(size_type pos1, size_type count1, T const &t) const                                          { return s_.get().compare(pos1, count1, t); }
+		template <typename T> int compare(size_type pos1, size_type count1, T const &t, size_type pos2, size_type count2 = npos) const { return s_.get().compare(pos1, count1, t, pos2, count2); }
+
+		// starts_with
+		#ifdef __cpp_lib_string_view
+			bool starts_with(std::basic_string_view<value_type, traits_type> x) const noexcept { return s_.get().starts_with(x); }
+		#endif
+		#if __cplusplus > 201703L
+			bool starts_with(value_type x) const noexcept { return s_.get().starts_with(x); }
+			bool starts_with(value_type const* x) const   { return s_.get().starts_with(x); }
+		#endif
+
+		// ends_with
+		#ifdef __cpp_lib_string_view
+			bool ends_with(std::basic_string_view<value_type, traits_type> x) const noexcept { return s_.get().ends_with(x); }
+		#endif
+		#if __cplusplus > 201703L
+			bool ends_with(value_type x) const noexcept { return s_.get().ends_with(x); }
+			bool ends_with(value_type const *x) const   { return s_.get().ends_with(x); }
+		#endif
+
+		// replace
+		string_t& replace(size_type pos, size_type count, string_t const &str)                                                       { auto s = s_.get(); s.replace(pos, count, str.s_.get());               s_ = s; return *this; }
+		string_t& replace(size_type pos, size_type count, ::utility::string_t const &str)                                            { auto s = s_.get(); s.replace(pos, count, str);                        s_ = s; return *this; }
+		string_t& replace(const_iterator first, const_iterator last, string_t const &str)
+		{
+			auto s = s_.get();
+			auto iter = s.replace(s.begin() + (first - s_.get().cbegin()), s.begin() + (last - s_.get().cbegin()), str.s_.get());
+			s_ = std::move(s);
+			return *this;
+		}
+		string_t& replace(const_iterator first, const_iterator last, ::utility::string_t const &str)
+		{
+			auto s = s_.get();
+			auto iter = s.replace(s.begin() + (first - s_.get().cbegin()), s.begin() + (last - s_.get().cbegin()), str);
+			s_ = std::move(s);
+			return *this;
+		}
+		string_t& replace(size_type pos, size_type count, string_t const &str, size_type pos2, size_type count2 = npos)              { auto s = s_.get(); s.replace(pos, count, str.s_.get(), pos2, count2); s_ = s; return *this; }
+		string_t& replace(size_type pos, size_type count, ::utility::string_t const &str, size_type pos2, size_type count2 = npos)   { auto s = s_.get(); s.replace(pos, count, str, pos2, count2);          s_ = s; return *this; }
+		template<typename InputIt> string_t& replace(const_iterator first, const_iterator last, InputIt first2, InputIt last2)
+		{
+			auto s = s_.get();
+			auto iter = s.replace(s.begin() + (first - s_.get().cbegin()), s.begin() + (last - s_.get().cbegin()), first2, last2);
+			s_ = std::move(s);
+			return *this;
+		}
+		string_t& replace(size_type pos, size_type count, value_type const *cstr, size_type count2)                                  { auto s = s_.get(); s.replace(pos, count, cstr, count2);               s_ = s; return *this; }
+		string_t& replace(const_iterator first, const_iterator last, value_type const *cstr, size_type count2)
+		{
+			auto s = s_.get();
+			auto iter = s.replace(s.begin() + (first - s_.get().cbegin()), s.begin() + (last - s_.get().cbegin()), cstr, count2);
+			s_ = std::move(s);
+			return *this;
+		}
+		string_t& replace(size_type pos, size_type count, value_type const *cstr)                                                    { auto s = s_.get(); s.replace(pos, count, cstr);                       s_ = s; return *this; }
+		string_t& replace(const_iterator first, const_iterator last, value_type const *cstr)
+		{
+			auto s = s_.get();
+			auto iter = s.replace(s.begin() + (first - s_.get().cbegin()), s.begin() + (last - s_.get().cbegin()), cstr);
+			s_ = std::move(s);
+			return *this;
+		}
+		string_t& replace(size_type pos, size_type count, size_type count2, value_type ch)                                           { auto s = s_.get(); s.replace(pos, count, count2, ch);                 s_ = s; return *this; }
+		string_t& replace(const_iterator first, const_iterator last, size_type count2, value_type ch)
+		{
+			auto s = s_.get();
+			auto iter = s.replace(s.begin() + (first - s_.get().cbegin()), s.begin() + (last - s_.get().cbegin()), count2, ch);
+			s_ = std::move(s);
+			return *this;
+		}
+		string_t& replace(const_iterator first, const_iterator last, std::initializer_list<value_type> ilist)
+		{
+			auto s = s_.get();
+			auto iter = s.replace(s.begin() + (first - s_.get().cbegin()), s.begin() + (last - s_.get().cbegin()), ilist);
+			s_ = std::move(s);
+			return *this;
+		}
+		template <typename T> string_t& replace(size_type pos, size_type count, T const &t)                                          { auto s = s_.get(); s.replace(pos, count, t);                          s_ = s; return *this; }
+		template <typename T> string_t& replace(const_iterator first, const_iterator last, T const &t)
+		{
+			auto s = s_.get();
+			auto iter = s.replace(s.begin() + (first - s_.get().cbegin()), s.begin() + (last - s_.get().cbegin()), t);
+			s_ = std::move(s);
+			return *this;
+		}
+		template <typename T> string_t& replace(size_type pos, size_type count, T const &t, size_type pos2, size_type count2 = npos) { auto s = s_.get(); s.replace(pos, count, t, pos2, count2);            s_ = s; return *this; }
+
+		// substr
+		string_t substr(size_type pos = 0, size_type count = npos) const { return string_t(s_.get().substr(pos, count)); }
+
+		// copy
+		size_type copy(value_type *dest, size_type count, size_type pos = 0) const { return s_.get().copy(dest, count, pos); }
+
+		// resize
+		void resize(size_type count)                { if (s_.get().size() != count) { auto s = s_.get(); s.resize(count); s_ = std::move(s); } }
+		void resize(size_type count, value_type ch) { auto s = s_.get(); s.resize(count, ch); s_ = std::move(s); }
+
+		// swap
+		void swap(string_t &other) noexcept          { using namespace std; s_.swap(other.s_); }
+		void swap(::utility::string_t &str) noexcept { auto s = std::move(str); str = s_.get(); s_ = std::move(s); }
+
+		// Search
+		// ======
+
+		// find
+		size_type find(string_t const &str, size_type pos = 0) const noexcept              { return s_.get().find(str.s_, pos); }
+		size_type find(::utility::string_t const &str, size_type pos = 0) const noexcept   { return s_.get().find(str, pos); }
+		size_type find(value_type const *cstr, size_type pos, size_type count) const       { return s_.get().find(cstr, pos, count); }
+		size_type find(value_type const *cstr, size_type pos = 0) const                    { return s_.get().find(cstr, pos); }
+		size_type find(value_type ch, size_type pos = 0) const noexcept                    { return s_.get().find(ch, pos); }
+		template <typename T> size_type find(T const &t, size_type pos = 0) const noexcept { return s_.get().find(t, pos); }
+
+		// rfind
+		size_type rfind(string_t const &str, size_type pos = npos) const noexcept              { return s_.get().rfind(str.s_, pos); }
+		size_type rfind(::utility::string_t const &str, size_type pos = npos) const noexcept   { return s_.get().rfind(str, pos); }
+		size_type rfind(value_type const *cstr, size_type pos, size_type count) const          { return s_.get().rfind(cstr, pos, count); }
+		size_type rfind(value_type const *cstr, size_type pos = npos) const                    { return s_.get().rfind(cstr, pos); }
+		size_type rfind(value_type ch, size_type pos = npos) const noexcept                    { return s_.get().rfind(ch, pos); }
+		template <typename T> size_type rfind(T const &t, size_type pos = npos) const noexcept { return s_.get().rfind(t, pos); }
+
+		// find_first_of
+		size_type find_first_of(string_t const &str, size_type pos = 0) const noexcept              { return s_.get().find_first_of(str.s_, pos); }
+		size_type find_first_of(::utility::string_t const &str, size_type pos = 0) const noexcept   { return s_.get().find_first_of(str, pos); }
+		size_type find_first_of(value_type const *cstr, size_type pos, size_type count) const       { return s_.get().find_first_of(cstr, pos, count); }
+		size_type find_first_of(value_type const *cstr, size_type pos = 0) const                    { return s_.get().find_first_of(cstr, pos); }
+		size_type find_first_of(value_type ch, size_type pos = 0) const noexcept                    { return s_.get().find_first_of(ch, pos); }
+		template <typename T> size_type find_first_of(T const &t, size_type pos = 0) const noexcept { return s_.get().find_first_of(t, pos); }
+
+		// find_first_not_of
+		size_type find_first_not_of(string_t const &str, size_type pos = 0) const noexcept              { return s_.get().find_first_not_of(str.s_, pos); }
+		size_type find_first_not_of(::utility::string_t const &str, size_type pos = 0) const noexcept   { return s_.get().find_first_not_of(str, pos); }
+		size_type find_first_not_of(value_type const *cstr, size_type pos, size_type count) const       { return s_.get().find_first_not_of(cstr, pos, count); }
+		size_type find_first_not_of(value_type const *cstr, size_type pos = 0) const                    { return s_.get().find_first_not_of(cstr, pos); }
+		size_type find_first_not_of(value_type ch, size_type pos = 0) const noexcept                    { return s_.get().find_first_not_of(ch, pos); }
+		template <typename T> size_type find_first_not_of(T const &t, size_type pos = 0) const noexcept { return s_.get().find_first_not_of(t, pos); }
+
+		// find_last_of
+		size_type find_last_of(string_t const &str, size_type pos = npos) const noexcept              { return s_.get().find_last_of(str.s_, pos); }
+		size_type find_last_of(::utility::string_t const &str, size_type pos = npos) const noexcept   { return s_.get().find_last_of(str, pos); }
+		size_type find_last_of(value_type const *cstr, size_type pos, size_type count) const          { return s_.get().find_last_of(cstr, pos, count); }
+		size_type find_last_of(value_type const *cstr, size_type pos = npos) const                    { return s_.get().find_last_of(cstr, pos); }
+		size_type find_last_of(value_type ch, size_type pos = npos) const noexcept                    { return s_.get().find_last_of(ch, pos); }
+		template <typename T> size_type find_last_of(T const& t, size_type pos = npos) const noexcept { return s_.get().find_last_of(t, pos); }
+
+		// find_last_not_of
+		size_type find_last_not_of(string_t const &str, size_type pos = npos) const noexcept              { return s_.get().find_last_not_of(str.s_, pos); }
+		size_type find_last_not_of(::utility::string_t const &str, size_type pos = npos) const noexcept   { return s_.get().find_last_not_of(str, pos); }
+		size_type find_last_not_of(value_type const *cstr, size_type pos, size_type count) const          { return s_.get().find_last_not_of(cstr, pos, count); }
+		size_type find_last_not_of(value_type const *cstr, size_type pos = npos) const                    { return s_.get().find_last_not_of(cstr, pos); }
+		size_type find_last_not_of(value_type ch, size_type pos = npos) const noexcept                    { return s_.get().find_last_not_of(ch, pos); }
+		template <typename T> size_type find_last_not_of(T const &t, size_type pos = npos) const noexcept { return s_.get().find_last_not_of(t, pos); }
+
+		// Constants
+		// =========
+
+		// npos
+		static const size_type npos = ::utility::string_t::npos;
+
+		// Non-member functions
+		// ====================
+
+		// operator+
+		friend string_t operator+(string_t             const &lhs, string_t             const &rhs) { return string_t(lhs.s_.get()   + rhs.s_.get()); }
+		friend string_t operator+(::utility::string_t  const &lhs, string_t             const &rhs) { return string_t(lhs            + rhs.s_.get()); }
+		friend string_t operator+(string_t             const &lhs, ::utility::string_t  const &rhs) { return string_t(lhs.s_.get()   + rhs); }
+		friend string_t operator+(string_t             const &lhs, string_t::value_type const *rhs) { return string_t(lhs.s_.get()   + rhs); }
+		friend string_t operator+(string_t             const &lhs, string_t::value_type        rhs) { return string_t(lhs.s_.get()   + rhs); }
+		friend string_t operator+(string_t::value_type const *lhs, string_t             const &rhs) { return string_t(lhs            + rhs.s_.get()); }
+		friend string_t operator+(string_t::value_type        lhs, string_t             const &rhs) { return string_t(lhs            + rhs.s_.get()); }
+		friend string_t operator+(string_t                  &&lhs, string_t                  &&rhs) { return string_t(lhs.s_.get()   + rhs.s_.get()); }
+		friend string_t operator+(::utility::string_t       &&lhs, string_t                  &&rhs) { return string_t(std::move(lhs) + rhs.s_.get()); }
+		friend string_t operator+(string_t                  &&lhs, ::utility::string_t       &&rhs) { return string_t(lhs.s_.get()   + std::move(rhs)); }
+		friend string_t operator+(string_t                  &&lhs, string_t             const &rhs) { return string_t(lhs.s_.get()   + rhs.s_.get()); }
+		friend string_t operator+(::utility::string_t       &&lhs, string_t             const &rhs) { return string_t(std::move(lhs) + rhs.s_.get()); }
+		friend string_t operator+(string_t                  &&lhs, ::utility::string_t  const &rhs) { return string_t(lhs.s_.get()   + rhs); }
+		friend string_t operator+(string_t                  &&lhs, string_t::value_type const *rhs) { return string_t(lhs.s_.get()   + rhs); }
+		friend string_t operator+(string_t                  &&lhs, string_t::value_type        rhs) { return string_t(lhs.s_.get()   + rhs); }
+		friend string_t operator+(string_t             const &lhs, string_t                  &&rhs) { return string_t(lhs.s_.get()   + rhs.s_.get()); }
+		friend string_t operator+(::utility::string_t  const &lhs, string_t                  &&rhs) { return string_t(lhs            + rhs.s_.get()); }
+		friend string_t operator+(string_t             const &lhs, ::utility::string_t       &&rhs) { return string_t(lhs.s_.get()   + std::move(rhs)); }
+		friend string_t operator+(string_t::value_type const *lhs, string_t                  &&rhs) { return string_t(lhs            + rhs.s_.get()); }
+		friend string_t operator+(string_t::value_type        lhs, string_t                  &&rhs) { return string_t(lhs            + rhs.s_.get()); }
+
+		// operator==, !=, <, <=, >, >=
+		friend bool operator==(string_t             const &lhs, string_t             const &rhs) { return lhs.s_.get() == rhs.s_.get(); }
+		friend bool operator!=(string_t             const &lhs, string_t             const &rhs) { return lhs.s_.get() != rhs.s_.get(); }
+		friend bool operator< (string_t             const &lhs, string_t             const &rhs) { return lhs.s_.get() <  rhs.s_.get(); }
+		friend bool operator<=(string_t             const &lhs, string_t             const &rhs) { return lhs.s_.get() <= rhs.s_.get(); }
+		friend bool operator> (string_t             const &lhs, string_t             const &rhs) { return lhs.s_.get() >  rhs.s_.get(); }
+		friend bool operator>=(string_t             const &lhs, string_t             const &rhs) { return lhs.s_.get() >= rhs.s_.get(); }
+		friend bool operator==(::utility::string_t  const &lhs, string_t             const &rhs) { return lhs          == rhs.s_.get(); }
+		friend bool operator==(string_t             const &lhs, ::utility::string_t  const &rhs) { return lhs.s_.get() == rhs; }
+		friend bool operator!=(::utility::string_t  const &lhs, string_t             const &rhs) { return lhs          != rhs.s_.get(); }
+		friend bool operator!=(string_t             const &lhs, ::utility::string_t  const &rhs) { return lhs.s_.get() != rhs; }
+		friend bool operator< (::utility::string_t  const &lhs, string_t             const &rhs) { return lhs          <  rhs.s_.get(); }
+		friend bool operator< (string_t             const &lhs, ::utility::string_t  const &rhs) { return lhs.s_.get() <  rhs; }
+		friend bool operator<=(::utility::string_t  const &lhs, string_t             const &rhs) { return lhs          <= rhs.s_.get(); }
+		friend bool operator<=(string_t             const &lhs, ::utility::string_t  const &rhs) { return lhs.s_.get() <= rhs; }
+		friend bool operator> (::utility::string_t  const &lhs, string_t             const &rhs) { return lhs          >  rhs.s_.get(); }
+		friend bool operator> (string_t             const &lhs, ::utility::string_t  const &rhs) { return lhs.s_.get() >  rhs; }
+		friend bool operator>=(::utility::string_t  const &lhs, string_t             const &rhs) { return lhs          >= rhs.s_.get(); }
+		friend bool operator>=(string_t             const &lhs, ::utility::string_t  const &rhs) { return lhs.s_.get() >= rhs; }
+		friend bool operator==(string_t::value_type const *lhs, string_t             const &rhs) { return lhs          == rhs.s_.get(); }
+		friend bool operator==(string_t             const &lhs, string_t::value_type const *rhs) { return lhs.s_.get() == rhs; }
+		friend bool operator!=(string_t::value_type const *lhs, string_t             const &rhs) { return lhs          != rhs.s_.get(); }
+		friend bool operator!=(string_t             const &lhs, string_t::value_type const *rhs) { return lhs.s_.get() != rhs; }
+		friend bool operator< (string_t::value_type const *lhs, string_t             const &rhs) { return lhs          <  rhs.s_.get(); }
+		friend bool operator< (string_t             const &lhs, string_t::value_type const *rhs) { return lhs.s_.get() <  rhs; }
+		friend bool operator<=(string_t::value_type const *lhs, string_t             const &rhs) { return lhs          <= rhs.s_.get(); }
+		friend bool operator<=(string_t             const &lhs, string_t::value_type const *rhs) { return lhs.s_.get() <= rhs; }
+		friend bool operator> (string_t::value_type const *lhs, string_t             const &rhs) { return lhs          >  rhs.s_.get(); }
+		friend bool operator> (string_t             const &lhs, string_t::value_type const *rhs) { return lhs.s_.get() >  rhs; }
+		friend bool operator>=(string_t::value_type const *lhs, string_t             const &rhs) { return lhs          >= rhs.s_.get(); }
+		friend bool operator>=(string_t             const &lhs, string_t::value_type const *rhs) { return lhs.s_.get() >= rhs; }
+
+		// swap
+		friend void swap(string_t            &lhs, string_t            &rhs) noexcept { lhs.swap(rhs); }
+		friend void swap(::utility::string_t &lhs, string_t            &rhs) noexcept { rhs.swap(lhs); }
+		friend void swap(string_t            &lhs, ::utility::string_t &rhs) noexcept { lhs.swap(rhs); }
+
+		// erase, erase_if
+		template <typename U>    friend size_type erase(string_t    &c, U const &value) { auto it = std::remove   (c.begin(), c.end(), value); auto r = std::distance(it, c.end()); c.erase(it, c.end()); return r; }
+		template <typename Pred> friend size_type erase_if(string_t &c, Pred pred)      { auto it = std::remove_if(c.begin(), c.end(), pred);  auto r = std::distance(it, c.end()); c.erase(it, c.end()); return r; }
+
+		// Input/output
+		// ============
+
+		// operator<<, >>
+		friend std::basic_ostream<string_t::value_type, string_t::traits_type>& operator<<(std::basic_ostream<string_t::value_type, string_t::traits_type>& os, string_t const& str) { return os << str.s_; }
+		friend std::basic_istream<string_t::value_type, string_t::traits_type>& operator>>(std::basic_istream<string_t::value_type, string_t::traits_type> &is, string_t       &str) { return is >> str.s_; }
+
+		// getline
+		friend std::basic_istream<string_t::value_type, string_t::traits_type>& getline(std::basic_istream<string_t::value_type, string_t::traits_type>  &input, string_t &str, string_t::value_type delim) { ::utility::string_t s; std::getline(input, s, delim); str.s_ = std::move(s); return input; }
+		friend std::basic_istream<string_t::value_type, string_t::traits_type>& getline(std::basic_istream<string_t::value_type, string_t::traits_type> &&input, string_t &str, string_t::value_type delim) { ::utility::string_t s; std::getline(input, s, delim); str.s_ = std::move(s); return input; }
+		friend std::basic_istream<string_t::value_type, string_t::traits_type>& getline(std::basic_istream<string_t::value_type, string_t::traits_type>  &input, string_t &str)                             { ::utility::string_t s; std::getline(input, s);        str.s_ = std::move(s); return input; }
+		friend std::basic_istream<string_t::value_type, string_t::traits_type>& getline(std::basic_istream<string_t::value_type, string_t::traits_type> &&input, string_t &str)                             { ::utility::string_t s; std::getline(input, s);        str.s_ = std::move(s); return input; }
+
+		// Numeric conversions
+		// ===================
+
+		// stoi, stol, stoll
+		friend int       stoi (string_t const &str, string_t::size_type *pos = 0, int base = 10) { return std::stoi (str.s_, pos, base); }
+		friend long      stol (string_t const &str, string_t::size_type *pos = 0, int base = 10) { return std::stol (str.s_, pos, base); }
+		friend long long stoll(string_t const &str, string_t::size_type *pos = 0, int base = 10) { return std::stoll(str.s_, pos, base); }
+
+		// stoul, stoull
+		//friend unsigned int       stoui (string_t const &str, string_t::size_type *pos = 0, int base = 10) { return std::stoui (str.s_, pos, base); } // Why is there no stoui() in the standard?
+		friend unsigned long      stoul (string_t const &str, string_t::size_type *pos = 0, int base = 10) { return std::stoul (str.s_, pos, base); }
+		friend unsigned long long stoull(string_t const &str, string_t::size_type *pos = 0, int base = 10) { return std::stoull(str.s_, pos, base); }
+
+		// stof, stod, stold
+		friend float       stof (string_t const &str, string_t::size_type *pos = 0) { return std::stof (str.s_, pos); }
+		friend double      stod (string_t const &str, string_t::size_type *pos = 0) { return std::stod (str.s_, pos); }
+		friend long double stold(string_t const &str, string_t::size_type *pos = 0) { return std::stold(str.s_, pos); }
+
+		// to_string
+		#ifdef _UTF16_STRINGS
+			friend string_t to_string_t(int value)                { return string_t(std::to_wstring(value)); }
+			friend string_t to_string_t(long value)               { return string_t(std::to_wstring(value)); }
+			friend string_t to_string_t(long long value)          { return string_t(std::to_wstring(value)); }
+			friend string_t to_string_t(unsigned value)           { return string_t(std::to_wstring(value)); }
+			friend string_t to_string_t(unsigned long value)      { return string_t(std::to_wstring(value)); }
+			friend string_t to_string_t(unsigned long long value) { return string_t(std::to_wstring(value)); }
+			friend string_t to_string_t(float value)              { return string_t(std::to_wstring(value)); }
+			friend string_t to_string_t(double value)             { return string_t(std::to_wstring(value)); }
+			friend string_t to_string_t(long double value)        { return string_t(std::to_wstring(value)); }
+		#else
+			friend string_t to_string_t(int value)                { return string_t(std::to_string(value)); }
+			friend string_t to_string_t(long value)               { return string_t(std::to_string(value)); }
+			friend string_t to_string_t(long long value)          { return string_t(std::to_string(value)); }
+			friend string_t to_string_t(unsigned value)           { return string_t(std::to_string(value)); }
+			friend string_t to_string_t(unsigned long value)      { return string_t(std::to_string(value)); }
+			friend string_t to_string_t(unsigned long long value) { return string_t(std::to_string(value)); }
+			friend string_t to_string_t(float value)              { return string_t(std::to_string(value)); }
+			friend string_t to_string_t(double value)             { return string_t(std::to_string(value)); }
+			friend string_t to_string_t(long double value)        { return string_t(std::to_string(value)); }
+		#endif
+
+		// Literals
+		// ========
+
+		// operator""_s_t
+		friend string_t operator ""_s_t(string_t::value_type const *cstr, string_t::size_type len) { return string_t(cstr, len); }
+
+		// Helper classes
+		// ==============
+
+		// std::hash and ::boost::hash
+		friend struct std::hash<string_t>;
+		friend std::size_t hash_value(string_t const &t) { return std::hash<::boost::flyweight<::utility::string_t>>()(t.s_); }
+
+		// Additional cast operators into ::utility::string_t to ease switching the source code between plain ::utility::string_t and boot::flyweight<::utility::string_t>
+		operator ::utility::string_t const&() const { return s_.get(); }
+		//operator ::utility::string_t       ()       { return s_.get(); } // *Does* copy, only use if neccessary! Currently this commented out, as it's not needed. If activated some of the operator mutation must be commented out!
+
+	private:
+		// The encapsulated string flyweight
+		::boost::flyweight<::utility::string_t> s_;
+};
+
+} // namespace odata
+
+// std::hash
+namespace std
+{
+	template<> struct hash<::odata::string_t> { size_t operator()(::odata::string_t const &t) const { return hash<::boost::flyweight<::utility::string_t>>()(t.s_); } };
+}
+
+#else
+
+namespace odata
+{
+
+	typedef ::utility::string_t string_t;
+
+	// operator""_s_t, need to offer an analogously named, forwarding literal operator:
+	inline string_t operator ""_s_t(string_t::value_type const* cstr, string_t::size_type len) { return string_t(cstr, len); }
+
+} // namespace odata
+
+#endif
+
+// ============================================================================================================
+// End extension
+// ============================================================================================================
+
+// ============================================================================================================
+// Begin extension:
+// Select the way shared_ptrs are allocated:
+// Contrary to the best practice we might decide here to do a separate malloc for the object and the shared_ptr
+// control block. That does yield a memory saving as long as the object is not yet constructed or already deleted
+// ============================================================================================================
+
+namespace odata
+{
+	#ifdef _USE_SHARED_PTR_TWO_PHASE_ALLOCATION
+		template<typename T, typename ... A> std::shared_ptr<T> make_shared(A&& ... a) { return std::shared_ptr<T>(new T(std::forward<A>(a) ...)); }
+	#else
+		template<typename T, typename ... A> std::shared_ptr<T> make_shared(A&& ... a) { return std::make_shared<T>(std::forward<A>(a) ...); }
+	#endif
+} // namespace odata
+
+// ============================================================================================================
+// End extension
+// ============================================================================================================
+
 namespace odata { namespace common
 {
 
-ODATACPP_CLIENT_API ::utility::string_t strip_string(const ::utility::string_t& escaped);
+ODATACPP_CLIENT_API ::odata::string_t strip_string(::odata::string_t const &escaped);
 
-ODATACPP_CLIENT_API void split_string(::utility::string_t& source, const ::utility::string_t& delim, std::list<::utility::string_t>& ret);
+ODATACPP_CLIENT_API void split_string(::odata::string_t const &source, ::odata::string_t const &delim, std::list<::odata::string_t> &ret);
 
 template<typename T>
-void to_string(const T& input, ::utility::string_t& result)
+void to_string(T const &input, ::odata::string_t &result)
 {
 	::utility::stringstream_t ostr;
 	ostr << input;
 	result = ostr.str();
 }
 
-ODATACPP_CLIENT_API bool is_relative_path(const ::utility::string_t& root_url, const ::utility::string_t& path);
+ODATACPP_CLIENT_API bool is_relative_path(::odata::string_t const &root_url, ::odata::string_t const &path);
 
-ODATACPP_CLIENT_API ::utility::string_t print_double(const double& db, int precision = 20);
-ODATACPP_CLIENT_API ::utility::string_t print_float(const float& db, int precision = 16);
+ODATACPP_CLIENT_API ::odata::string_t print_double(double const &db, int precision = 20);
+ODATACPP_CLIENT_API ::odata::string_t print_float(float const &db, int precision = 16);
 
 }}

--- a/include/odata/common/xmlhelpers.h
+++ b/include/odata/common/xmlhelpers.h
@@ -14,14 +14,15 @@
 #include <libxml/xmlreader.h>
 #include <libxml/xmlwriter.h>
 #include <stack>
-#endif 
+#endif
 
 #include <string>
-#include "cpprest/basic_types.h"
+#include "cpprest/details/basic_types.h"
 #include "cpprest/streams.h"
 #include "cpprest/containerstream.h"
 
 #include "odata/common/platform.h"
+#include "odata/common/utility.h"
 
 namespace odata { namespace common {
 
@@ -31,122 +32,120 @@ namespace odata { namespace common {
 class xml_reader
 {
 public:
+	virtual ~xml_reader() = default;
 
-    virtual ~xml_reader() {}
-
-    /// <summary>
-    /// Parse the given xml string/stream. Returns true if it finished parsing the stream to the end, and false
-    /// if it was asked to exit early via pause()
-    /// </summary>
-    bool parse();
+	/// <summary>
+	/// Parse the given xml string/stream. Returns true if it finished parsing the stream to the end, and false
+	/// if it was asked to exit early via pause()
+	/// </summary>
+	bool parse();
 
 protected:
+	xml_reader() : m_continueParsing(true), m_streamDone(false)
+	{
+	}
 
-    xml_reader() : m_continueParsing(true), m_streamDone(false)
-    {
-    }
+	xml_reader(concurrency::streams::istream stream) : m_continueParsing(true), m_streamDone(false)
+	{
+		initialize(stream);
+	}
 
-    xml_reader(concurrency::streams::istream stream) : m_continueParsing(true), m_streamDone(false)
-    {
-        initialize(stream);
-    }
+	/// <summary>
+	/// Callback for handling the start of an element.
+	/// </summary>
+	virtual void handle_begin_element(const ::odata::string_t&)
+	{
+	}
 
-    /// <summary>
-    /// Callback for handling the start of an element.
-    /// </summary>
-    virtual void handle_begin_element(const ::utility::string_t&)
-    {
-    }
+	/// <summary>
+	/// Callback for handling the element text.
+	/// </summary>
+	virtual void handle_element(const ::odata::string_t& )
+	{
+	}
 
-    /// <summary>
-    /// Callback for handling the element text.
-    /// </summary>
-    virtual void handle_element(const ::utility::string_t& )
-    {
-    }
+	/// <summary>
+	/// Callback for handling the end of an element.
+	/// </summary>
+	virtual void handle_end_element(const ::odata::string_t& )
+	{
+	}
 
-    /// <summary>
-    /// Callback for handling the end of an element.
-    /// </summary>
-    virtual void handle_end_element(const ::utility::string_t& )
-    {
-    }
+	/// <summary>
+	/// Logs an error from processing XML
+	/// </summary>
+	virtual void log_error_message(const ::odata::string_t& message, unsigned long error = 0)
+	{
+		UNREFERENCED_PARAMETER(message);
+		UNREFERENCED_PARAMETER(error);
+	}
 
-    /// <summary>
-    /// Logs an error from processing XML
-    /// </summary>
-    virtual void log_error_message(const ::utility::string_t& message, unsigned long error = 0)
-    {
-        UNREFERENCED_PARAMETER(message);
-        UNREFERENCED_PARAMETER(error);
-    }
+	/// <summary>
+	/// Returns the parent element name
+	/// </summary>
+	::odata::string_t get_parent_element_name(size_t pos = 0);
 
-    /// <summary>
-    /// Returns the parent element name
-    /// </summary>
-    ::utility::string_t get_parent_element_name(size_t pos = 0);
+	/// <summary>
+	/// Returns the current element name
+	/// </summary>
+	::odata::string_t get_current_element_name();
 
-    /// <summary>
-    /// Returns the current element name
-    /// </summary>
-    ::utility::string_t get_current_element_name();
+	/// <summary>
+	/// Returns the current element name with the prefix if any.
+	/// </summary>
+	::odata::string_t get_current_element_name_with_prefix();
 
-    /// <summary>
-    /// Returns the current element name with the prefix if any. 
-    /// </summary>
-    ::utility::string_t get_current_element_name_with_prefix();
+	/// <summary>
+	/// Returns the current element value
+	/// </summary>
+	::odata::string_t get_current_element_text();
 
-    /// <summary>
-    /// Returns the current element value
-    /// </summary>
-    ::utility::string_t get_current_element_text();
+	/// <summary>
+	/// Moves to the first attribute in the node
+	/// </summary>
+	bool move_to_first_attribute();
 
-    /// <summary>
-    /// Moves to the first attribute in the node
-    /// </summary>
-    bool move_to_first_attribute();
+	/// <summary>
+	/// Moves to the first attribute in the node
+	/// </summary>
+	bool move_to_next_attribute();
 
-    /// <summary>
-    /// Moves to the first attribute in the node
-    /// </summary>
-    bool move_to_next_attribute();
+	/// <summary>
+	/// Extracts the current element value into the provided type
+	/// </summary>
+	template <class T>
+	void extract_current_element(T& value)
+	{
+		::utility::istringstream_t iss(get_current_element_text());
+		iss >> value;
+	}
 
-    /// <summary>
-    /// Extracts the current element value into the provided type
-    /// </summary>
-    template <class T>
-    void extract_current_element(T& value)
-    {
-        ::utility::istringstream_t iss(get_current_element_text());
-        iss >> value;
-    }
+	/// <summary>
+	/// Initialize the reader
+	/// </summary>
+	ODATACPP_CLIENT_API void initialize(concurrency::streams::istream stream);
 
-    /// <summary>
-    /// Initialize the reader
-    /// </summary>
-    ODATACPP_CLIENT_API void initialize(concurrency::streams::istream stream);
+	/// <summary>
+	/// Remove Byte Order Mark from the stream
+	/// </summary>
+	void remove_bom(concurrency::streams::istream stream);
 
-    /// <summary>
-    /// Remove Byte Order Mark from the stream
-    /// </summary>
-    void remove_bom(concurrency::streams::istream stream);
-
-    /// <summary>
-    /// Can be called by the derived classes in the handle_* routines, to cause the parse routine to exit early,
-    /// in order to capture records as they are parsed. Parsing is resumed by invoking the parse method again.
-    /// </summary>
-    void pause() { m_continueParsing = false; }
+	/// <summary>
+	/// Can be called by the derived classes in the handle_* routines, to cause the parse routine to exit early,
+	/// in order to capture records as they are parsed. Parsing is resumed by invoking the parse method again.
+	/// </summary>
+	void pause() { m_continueParsing = false; }
 
 #ifdef WIN32
-    CComPtr<IXmlReader> m_reader;
+	CComPtr<IXmlReader> m_reader;
 #else
-    xmlTextReaderPtr m_reader;
-    std::string m_data;
-#endif 
+	xmlTextReaderPtr m_reader;
+	std::string m_data;
+#endif
 
-    std::vector<::utility::string_t> m_elementStack;
-    bool m_continueParsing;
-    bool m_streamDone;
+	std::vector<::odata::string_t> m_elementStack;
+	bool                           m_continueParsing;
+	bool                           m_streamDone;
 };
 
 }} // namespace odata::edm

--- a/include/odata/common/xmlstream.h
+++ b/include/odata/common/xmlstream.h
@@ -20,109 +20,103 @@ namespace odata { namespace common {
 class xmlstring_stream : public IStream
 {
 protected:
-    xmlstring_stream()
-        : m_refCount(1)
-    {
-    }
+	xmlstring_stream()
+		: m_refCount(1)
+	{
+	}
 
-    virtual ~xmlstring_stream()
-    {
-    }
+	virtual ~xmlstring_stream() = default;
 
 public:
+	virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void ** ppvObject)
+	{
+		if (iid == __uuidof(IUnknown)
+			|| iid == __uuidof(IStream)
+			|| iid == __uuidof(ISequentialStream))
+		{
+			*ppvObject = static_cast<IStream*>(this);
+			AddRef();
+			return S_OK;
+		} else
+			return E_NOINTERFACE;
+	}
 
-    virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void ** ppvObject)
-    { 
-        if (iid == __uuidof(IUnknown)
-            || iid == __uuidof(IStream)
-            || iid == __uuidof(ISequentialStream))
-        {
-            *ppvObject = static_cast<IStream*>(this);
-            AddRef();
-            return S_OK;
-        } else
-            return E_NOINTERFACE; 
-    }
+	virtual ULONG STDMETHODCALLTYPE AddRef(void)
+	{
+		return (ULONG)_InterlockedIncrement(&m_refCount);
+	}
 
-    virtual ULONG STDMETHODCALLTYPE AddRef(void) 
-    { 
-        return (ULONG)_InterlockedIncrement(&m_refCount); 
-    }
+	virtual ULONG STDMETHODCALLTYPE Release(void)
+	{
+		ULONG res = (ULONG) _InterlockedDecrement(&m_refCount);
+		if (res == 0)
+		{
+			delete this;
+		}
+		return res;
+	}
 
-    virtual ULONG STDMETHODCALLTYPE Release(void) 
-    {
-        ULONG res = (ULONG) _InterlockedDecrement(&m_refCount);
-        if (res == 0) 
-        {
-            delete this;
-        }
-        return res;
-    }
-
-    // ISequentialStream Interface
+	// ISequentialStream Interface
 public:
+	virtual HRESULT STDMETHODCALLTYPE Read(void* , ULONG , ULONG*)
+	{
+		return E_NOTIMPL;
+	}
 
-    virtual HRESULT STDMETHODCALLTYPE Read(void* , ULONG , ULONG* )
-    {
-        return E_NOTIMPL;
-    }
+	virtual HRESULT STDMETHODCALLTYPE Write(void const* , ULONG , ULONG*)
+	{
+		return E_NOTIMPL;
+	}
 
-    virtual HRESULT STDMETHODCALLTYPE Write(void const* , ULONG , ULONG* )
-    {
-        return E_NOTIMPL;
-    }
-
-    // IStream Interface
+	// IStream Interface
 public:
-    virtual HRESULT STDMETHODCALLTYPE SetSize(ULARGE_INTEGER)
-    { 
-        return E_NOTIMPL;   
-    }
-    
-    virtual HRESULT STDMETHODCALLTYPE CopyTo(IStream*, ULARGE_INTEGER, ULARGE_INTEGER*,
-        ULARGE_INTEGER*) 
-    { 
-        return E_NOTIMPL;   
-    }
-    
-    virtual HRESULT STDMETHODCALLTYPE Commit(DWORD)                                      
-    { 
-        return E_NOTIMPL;   
-    }
-    
-    virtual HRESULT STDMETHODCALLTYPE Revert(void)                                       
-    { 
-        return E_NOTIMPL;   
-    }
-    
-    virtual HRESULT STDMETHODCALLTYPE LockRegion(ULARGE_INTEGER, ULARGE_INTEGER, DWORD)              
-    { 
-        return E_NOTIMPL;   
-    }
-    
-    virtual HRESULT STDMETHODCALLTYPE UnlockRegion(ULARGE_INTEGER, ULARGE_INTEGER, DWORD)            
-    { 
-        return E_NOTIMPL;   
-    }
-    
-    virtual HRESULT STDMETHODCALLTYPE Clone(IStream **)                                  
-    { 
-        return E_NOTIMPL;   
-    }
+	virtual HRESULT STDMETHODCALLTYPE SetSize(ULARGE_INTEGER)
+	{
+		return E_NOTIMPL;
+	}
 
-    virtual HRESULT STDMETHODCALLTYPE Seek(LARGE_INTEGER , DWORD , ULARGE_INTEGER* )
-    { 
-        return E_NOTIMPL;
-    }
+	virtual HRESULT STDMETHODCALLTYPE CopyTo(IStream*, ULARGE_INTEGER, ULARGE_INTEGER*, ULARGE_INTEGER*)
+	{
+		return E_NOTIMPL;
+	}
 
-    virtual HRESULT STDMETHODCALLTYPE Stat(STATSTG* , DWORD ) 
-    {
-        return E_NOTIMPL;  
-    }
+	virtual HRESULT STDMETHODCALLTYPE Commit(DWORD)
+	{
+		return E_NOTIMPL;
+	}
+
+	virtual HRESULT STDMETHODCALLTYPE Revert(void)
+	{
+		return E_NOTIMPL;
+	}
+
+	virtual HRESULT STDMETHODCALLTYPE LockRegion(ULARGE_INTEGER, ULARGE_INTEGER, DWORD)
+	{
+		return E_NOTIMPL;
+	}
+
+	virtual HRESULT STDMETHODCALLTYPE UnlockRegion(ULARGE_INTEGER, ULARGE_INTEGER, DWORD)
+	{
+		return E_NOTIMPL;
+	}
+
+	virtual HRESULT STDMETHODCALLTYPE Clone(IStream **)
+	{
+		return E_NOTIMPL;
+	}
+
+	virtual HRESULT STDMETHODCALLTYPE Seek(LARGE_INTEGER , DWORD , ULARGE_INTEGER* )
+	{
+		return E_NOTIMPL;
+	}
+
+	virtual HRESULT STDMETHODCALLTYPE Stat(STATSTG* , DWORD )
+	{
+		return E_NOTIMPL;
+	}
 
 private:
-
-    volatile long m_refCount;
+	volatile long m_refCount;
 };
 
 /// <summary>
@@ -131,34 +125,33 @@ private:
 class xmlstring_istream : public xmlstring_stream
 {
 public:
+	static xmlstring_istream* create(concurrency::streams::istream stream)
+	{
+		return new xmlstring_istream(stream);
+	}
 
-    static xmlstring_istream* create(concurrency::streams::istream stream)
-    {
-        return new xmlstring_istream(stream);
-    }
+	virtual HRESULT STDMETHODCALLTYPE Read(_Out_writes_ (cb) void* pv, _In_ ULONG cb, ULONG* pcbRead )
+	{
+		if (cb > 0)
+		{
+			// Synchronous for now.
+			concurrency::streams::rawptr_buffer<uint8_t> buf((uint8_t *)pv, static_cast<std::streamsize>(cb));
+			*pcbRead = (ULONG)m_stream.read(buf, static_cast<size_t>(cb)).get();
+			return S_OK;
+		}
 
-    virtual HRESULT STDMETHODCALLTYPE Read(_Out_writes_ (cb) void* pv, _In_ ULONG cb, ULONG* pcbRead )
-    {
-        if (cb > 0)
-        {
-            // Synchronous for now.
-            concurrency::streams::rawptr_buffer<uint8_t> buf((uint8_t *)pv, static_cast<std::streamsize>(cb));
-            *pcbRead = (ULONG)m_stream.read(buf, static_cast<size_t>(cb)).get();
-            return S_OK;
-        }
-
-        *pcbRead = cb;
-        return S_OK;
-    }
+		*pcbRead = cb;
+		return S_OK;
+	}
 
 protected:
 
-    xmlstring_istream(concurrency::streams::istream stream)
-        : m_stream(stream)
-    {
-    }
+	xmlstring_istream(concurrency::streams::istream stream)
+		: m_stream(stream)
+	{
+	}
 
-    concurrency::streams::istream m_stream;
+	concurrency::streams::istream m_stream;
 };
 
 /// <summary>
@@ -167,35 +160,33 @@ protected:
 class xmlstring_ostream : public xmlstring_stream
 {
 public:
+	static xmlstring_ostream* create(std::ostream& stream)
+	{
+		return new xmlstring_ostream(stream);
+	}
 
-    static xmlstring_ostream* create(std::ostream& stream)
-    {
-        return new xmlstring_ostream(stream);
-    }
+	virtual HRESULT STDMETHODCALLTYPE Write(void const* pv, ULONG cb, ULONG* pcbWritten)
+	{
+		// This method gets called when the XmlWriter is destroyed with cb == 0. We need this
+		// check to ensure that we do not access the underlying stream after finalize is called.
+		if (cb > 0)
+		{
+			const char * buf = (const char *) pv;
+			std::string s(buf, cb);
+			m_stream << s;
+		}
 
-    virtual HRESULT STDMETHODCALLTYPE Write(void const* pv, ULONG cb, ULONG* pcbWritten)
-    {
-        // This method gets called when the XmlWriter is destroyed with cb == 0. We need this
-        // check to ensure that we do not access the underlying stream after finalize is called.
-        if (cb > 0)
-        {
-            const char * buf = (const char *) pv;
-            std::string s(buf, cb);
-            m_stream << s;
-        }
-        
-        *pcbWritten = cb;
-        return S_OK;
-    }
+		*pcbWritten = cb;
+		return S_OK;
+	}
 
 protected:
+	xmlstring_ostream(std::ostream& stream)
+		: m_stream(stream)
+	{
+	}
 
-    xmlstring_ostream(std::ostream& stream)
-        : m_stream(stream)
-    {
-    }
-
-    std::ostream& m_stream;
+	std::ostream& m_stream;
 };
 
 }} // namespace odata::edm

--- a/include/odata/communication/http_communication.h
+++ b/include/odata/communication/http_communication.h
@@ -18,11 +18,11 @@
 namespace odata { namespace communication
 {
 
-#define HTTP_GET U("GET")
-#define HTTP_POST U("POST")
-#define HTTP_PATCH U("PATCH")
-#define HTTP_DELETE U("DELETE")
-#define HTTP_PUT U("PUT")
+#define HTTP_GET _XPLATSTR("GET")
+#define HTTP_POST _XPLATSTR("POST")
+#define HTTP_PATCH _XPLATSTR("PATCH")
+#define HTTP_DELETE _XPLATSTR("DELETE")
+#define HTTP_PUT _XPLATSTR("PUT")
 
 typedef ::web::http::http_response http_client_response;
 
@@ -30,36 +30,62 @@ template<typename _Http_Imple, typename _Http_Response>
 class http_client_proxy
 {
 public:
-    http_client_proxy(const ::utility::string_t& baseAddress, std::shared_ptr<::odata::client::odata_client_credential> credential_setting)
-    {
-        m_client_impl = std::make_shared<_Http_Imple>(baseAddress, credential_setting);
-    }
+	http_client_proxy(const ::odata::string_t& baseAddress, std::shared_ptr<::odata::client::odata_client_credential> credential_setting) : m_client_impl(::odata::make_shared<_Http_Imple>(baseAddress, credential_setting))
+	{
+	}
 
-    http_client_proxy(std::shared_ptr<_Http_Imple> client_impl) : m_client_impl(client_impl)
-    {
-    }
+	http_client_proxy(std::shared_ptr<_Http_Imple> client_impl) : m_client_impl(client_impl)
+	{
+	}
 
-    pplx::task<_Http_Response> send_http_request(const ::utility::string_t& method, const ::utility::string_t& request_uri, const ::utility::string_t accept)
-    {
-        return m_client_impl->send_http_request(method, request_uri, accept);
-    }
+	pplx::task<_Http_Response> send_http_request(const ::odata::string_t& method, const ::odata::string_t& request_uri, const ::odata::string_t accept)
+	{
+		return m_client_impl->send_http_request(method, request_uri, accept);
+	}
 
-    pplx::task<_Http_Response> send_http_request(const ::utility::string_t& method, const ::utility::string_t& request_uri, const ::utility::string_t accept, ::web::json::value object)
-    {
-        return m_client_impl->send_http_request(method, request_uri, accept, object);
-    }
+	pplx::task<_Http_Response> send_http_request(const ::odata::string_t& method, const ::odata::string_t& request_uri, const ::odata::string_t accept, ::web::json::value object)
+	{
+		return m_client_impl->send_http_request(method, request_uri, accept, object);
+	}
 
-    ::utility::string_t base_uri()
-    {
-        return m_client_impl->base_uri();
-    }
+	::odata::string_t base_uri()
+	{
+		return m_client_impl->base_uri();
+	}
 
-    ::web::http::client::http_client_config& get_client_config(){
-        return m_client_impl->get_client_config();
-    }
+	::web::http::client::http_client_config& get_client_config()
+	{
+		return m_client_impl->get_client_config();
+	}
+
+	void clear_request_header()
+	{
+		m_client_impl->clear_request_header();
+	}
+	bool has_request_header(const ::odata::string_t& name) const
+	{
+		return m_client_impl->has_request_header(name);
+	}
+	void add_request_header(const ::odata::string_t& name, const ::odata::string_t& value)
+	{
+		m_client_impl->add_request_header(name, value);
+	}
+	void remove_request_header(const ::odata::string_t& name)
+	{
+		m_client_impl->remove_request_header(name);
+	}
+	::odata::string_t match_request_header(const ::odata::string_t& name) const
+	{
+		return m_client_impl->match_request_header(name);
+	}
+
+	void SetLogCallbacks(std::function<bool()> ShallLogCallback, std::function<void(wchar_t const*, wchar_t const*, size_t, bool, ::odata::string_t const &)> LogCallback)
+	{
+		m_client_impl->SetLogCallbacks(ShallLogCallback, LogCallback);
+	}
 
 private:
-    std::shared_ptr<_Http_Imple>  m_client_impl;
+	std::shared_ptr<_Http_Imple> m_client_impl;
 };
 
 }}

--- a/include/odata/communication/http_implement.h
+++ b/include/odata/communication/http_implement.h
@@ -13,6 +13,7 @@
 #include "cpprest/json.h"
 #include "cpprest/http_client.h"
 #include "odata/edm/odata_edm.h"
+#include "odata/common/utility.h"
 
 namespace odata { namespace communication
 {
@@ -20,51 +21,112 @@ namespace odata { namespace communication
 class http_client_impl
 {
 public:
-    http_client_impl(const ::utility::string_t& address, std::shared_ptr<::odata::client::odata_client_credential> credential)
-    {
-        baseAddress = address;
-        credential_setting = credential;
-    }
+	http_client_impl(const ::odata::string_t& address, std::shared_ptr<::odata::client::odata_client_credential> credential)
+	: m_client(), baseAddress(address), credential_setting(credential), client_config(), m_request_headers(), m_ShallLogCallback(), m_LogCallback()
+	{
+	}
 
-    ::utility::string_t base_uri()
-    {
-        return getOrCreateClient()->base_uri().to_string();
-    }
+	::odata::string_t base_uri()
+	{
+		return getOrCreateClient()->base_uri().to_string();
+	}
 
-    ::web::http::client::http_client_config& get_client_config(){
-        return client_config;
-    }
+	::web::http::client::http_client_config& get_client_config()
+	{
+		return client_config;
+	}
 
-    pplx::task<::web::http::http_response> send_http_request(const ::utility::string_t& method, const ::utility::string_t& request_uri, const ::utility::string_t accept);
-    pplx::task<::web::http::http_response> send_http_request(const ::utility::string_t& method, const ::utility::string_t& request_uri, const ::utility::string_t accept, ::web::json::value object);
+	pplx::task<::web::http::http_response> send_http_request(const ::odata::string_t& method, const ::odata::string_t& request_uri, const ::odata::string_t accept);
+	pplx::task<::web::http::http_response> send_http_request(const ::odata::string_t& method, const ::odata::string_t& request_uri, const ::odata::string_t accept, ::web::json::value object);
 
 private:
+	/// <summary>
+	/// If the client hasn't already been constructed, the method constructs one
+	/// and returns it, while also caching it for future
+	/// </summary>
+	/// <Explanation>
+	/// Delays the construction of m_client until its first use
+	/// This allows others to use and modify the client_config object
+	/// (e.g. change the callback function associated with it) before
+	/// m_client is created.
+	/// </Explanation>
+	std::shared_ptr<::web::http::client::http_client>& getOrCreateClient()
+	{
+		if (m_client == nullptr)
+		{
+			if (credential_setting)
+				client_config.set_credentials(::web::http::client::credentials(credential_setting->get_username(), credential_setting->get_password()));
+			m_client = ::odata::make_shared<::web::http::client::http_client>(::web::http::uri(baseAddress), client_config);
+		}
+		return m_client;
+	}
+	std::shared_ptr<::web::http::client::http_client> m_client;
+	::odata::string_t baseAddress;
+	std::shared_ptr<::odata::client::odata_client_credential> credential_setting;
+	::web::http::client::http_client_config client_config;
+	::web::http::http_request _build_get_request(::web::http::method method, ::web::http::uri_builder request_uri, const ::odata::string_t& accept = _XPLATSTR("")) const;
+	::web::http::http_request _build_request(::web::http::method method, ::web::http::uri_builder request_uri, const ::odata::string_t& accept, ::web::json::value object) const;
 
-    /// <summary>
-    /// If the client hasn't already been constructed, the method constructs one 
-    /// and returns it, while also caching it for future
-    /// </summary>
-    /// <Explanation>
-    /// Delays the construction of m_client until its first use
-    /// This allows others to use and modify the client_config object
-    /// (e.g. change the callback function associated with it) before
-    /// m_client is created.
-    /// </Explanation>
-    std::shared_ptr<::web::http::client::http_client>& getOrCreateClient()
-    {
-        if (m_client == nullptr)
-        {
-            if (credential_setting)  client_config.set_credentials(::web::http::client::credentials(credential_setting->get_username(), credential_setting->get_password()));
-            m_client = std::make_shared<::web::http::client::http_client>(::web::http::uri(baseAddress), client_config);
-        }
-        return m_client;
-    }
-    std::shared_ptr<::web::http::client::http_client> m_client;
-    ::utility::string_t baseAddress;
-    std::shared_ptr<::odata::client::odata_client_credential> credential_setting;
-    ::web::http::client::http_client_config client_config;
-    ::web::http::http_request _build_get_request(::web::http::method method, ::web::http::uri_builder request_uri, const ::utility::string_t& accept = U("")) const;
-    ::web::http::http_request _build_request(::web::http::method method, ::web::http::uri_builder request_uri, const ::utility::string_t& accept, ::web::json::value object) const;
+	web::http::http_headers m_request_headers;
+
+public:
+	void clear_request_header()
+	{
+		m_request_headers.clear();
+	}
+	bool has_request_header(const ::odata::string_t& name) const
+	{
+		return m_request_headers.has(name);
+	}
+	void add_request_header(const ::odata::string_t& name, const ::odata::string_t& value)
+	{
+		m_request_headers.add(name, value);
+	}
+	void remove_request_header(const ::odata::string_t& name)
+	{
+		m_request_headers.remove(name);
+	}
+	::odata::string_t match_request_header(const ::odata::string_t& name) const
+	{
+		::odata::string_t value;
+		m_request_headers.match(name, value);
+		return value;
+	}
+
+	// Logging capability for http requests. Be careful when using, this is a comment from
+	// the casablanca REST SDK method to_string():
+	// "Generates a string representation of the message, including the body when possible.
+	// Mainly this should be used for debugging purposes as it has to copy the message body
+	// and doesn't have excellent performance."
+	// Thus besides setting the callback itself we have a separate callback that needs to
+	// check in advance if any logging should happen, preventing th call to to_string()
+	// if logging is disabled by some means (e. g. logging level).
+	private:
+		std::function<bool()>                                                                       m_ShallLogCallback;
+		std::function<void(wchar_t const*, wchar_t const*, size_t, bool, ::odata::string_t const&)> m_LogCallback;
+
+		void doLog(wchar_t const* Function, wchar_t const *File, size_t Line, web::http::http_request const &request) const
+		{
+			if (m_LogCallback && m_ShallLogCallback && m_ShallLogCallback())
+			{
+				m_LogCallback(Function, File, Line, true, request.to_string()); // true == This is a request
+			}
+		}
+
+	public:
+	void SetLogCallbacks(std::function<bool()> ShallLogCallback, std::function<void(wchar_t const*, wchar_t const*, size_t, bool, ::odata::string_t const &)> LogCallback)
+	{
+		if (ShallLogCallback && LogCallback)
+		{
+			m_ShallLogCallback = ShallLogCallback;
+			m_LogCallback      = LogCallback;
+		}
+		else
+		{
+			m_ShallLogCallback = nullptr;
+			m_LogCallback      = nullptr;
+		}
+	}
 };
 
 }}

--- a/include/odata/communication/http_service_exception.h
+++ b/include/odata/communication/http_service_exception.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <locale>  // std::wstring_convert
+#include <codecvt> // std::codecvt_utf8
+
 #include "odata/common/utility.h"
 #include "cpprest/asyncrt_utils.h"
 
@@ -18,27 +21,49 @@ namespace odata { namespace communication
 class service_exception : public std::exception
 {
 public:
-
-    /// <summary>
-    /// Constructor
-    /// </summary>
-    /// <param name="error">A string value containing the service error.</param>
-    explicit service_exception(::utility::string_t error) : m_error(error)
-    {
-    }
-
-    /// <summary>
-    /// Destructor
-    /// </summary>
-    ~service_exception() _noexcept {}
-
-	const ::utility::string_t& what()
+	/// <summary>
+	/// Constructor
+	/// </summary>
+	/// <param name="error">A string value containing the service error.</param>
+	/// <remarks>
+	/// On Windows string_t is wide, however method what() always is narrow,
+	/// thus we need to convert the string. On POSIX this is not needed.
+	/// </remarks>
+	#ifdef _UTF16_STRINGS
+	explicit service_exception(::odata::string_t error) : m_error()
 	{
-		return m_error;
+		try
+		{
+			// This conversion method was only introduced with C++11 but has already
+			// been deprecated with C++17 without giving any alternatives to use!
+			// So as long as this is the case we use it anyway to be portable.
+			std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> cv;
+			m_error = cv.to_bytes(error);
+		}
+		catch(...)
+		{
+			// to_bytes() might throw std::range_error for invalid input data!
+			m_error.clear();
+		}
+	}
+	#else
+	explicit service_exception(::odata::string_t error) : m_error(error)
+	{
+	}
+	#endif
+
+	/// <summary>
+	/// Destructor
+	/// </summary>
+	~service_exception() _noexcept = default;
+
+	virtual char const* what() const override
+	{
+		return m_error.c_str();
 	}
 
 private:
-    ::utility::string_t m_error;
+	std::string m_error;
 };
 
 }}

--- a/include/odata/communication/http_utility.h
+++ b/include/odata/communication/http_utility.h
@@ -16,9 +16,10 @@ namespace odata { namespace communication
 class http_utility
 {
 public:
-    static bool is_successful_status_code(::web::http::status_code code)
-    {
+	static bool is_successful_status_code(::web::http::status_code code)
+	{
 		return (200 <= code) && (code < 300);
-    }
+	}
 };
+
 }}

--- a/include/odata/core/odata_collection_value.h
+++ b/include/odata/core/odata_collection_value.h
@@ -15,22 +15,22 @@ namespace odata { namespace core
 class odata_collection_value : public odata_value
 {
 public:
-    odata_collection_value(std::shared_ptr<::odata::edm::edm_named_type> type) : odata_value(type)
-    {
-    }
+	odata_collection_value(std::shared_ptr<::odata::edm::edm_named_type> type) : odata_value(type)
+	{
+	}
 
-    void add_collection_value(std::shared_ptr<odata_value> value)
-    {
-        m_values.push_back(value);
-    }
+	void add_collection_value(std::shared_ptr<odata_value> value)
+	{
+		m_values.emplace_back(value);
+	}
 
-	const std::vector<std::shared_ptr<odata_value>>& get_collection_values() const 
+	const std::vector<std::shared_ptr<odata_value>>& get_collection_values() const
 	{
 		return m_values;
 	}
 
 private:
-    std::vector<std::shared_ptr<odata_value>>  m_values;
+	std::vector<std::shared_ptr<odata_value>> m_values;
 };
 
 }}

--- a/include/odata/core/odata_complex_value.h
+++ b/include/odata/core/odata_complex_value.h
@@ -17,8 +17,12 @@ class odata_complex_value : public odata_structured_value
 {
 public:
 	odata_complex_value(std::shared_ptr<::odata::edm::edm_named_type> type) : odata_structured_value(type)
-    {
-    }
+	{
+	}
+
+	odata_complex_value(std::shared_ptr<::odata::edm::edm_named_type> type, std::pair<odata_property_map, odata_property_map> properties) : odata_structured_value(type, properties)
+	{
+	}
 };
 
 }}

--- a/include/odata/core/odata_context_url_parser.h
+++ b/include/odata/core/odata_context_url_parser.h
@@ -17,19 +17,19 @@ namespace odata { namespace core
 class odata_contex_url_parser
 {
 public:
-	odata_contex_url_parser(std::shared_ptr<::odata::edm::edm_model> model, ::utility::string_t service_root_url) 
+	odata_contex_url_parser(std::shared_ptr<::odata::edm::edm_model> model, ::odata::string_t service_root_url)
 		: m_model(model), m_service_root_url(std::move(service_root_url))
 	{
 	}
 
-	ODATACPP_CLIENT_API std::shared_ptr<::odata::edm::edm_named_type> get_payload_content_type(const ::utility::string_t& context_url);
+	ODATACPP_CLIENT_API std::shared_ptr<::odata::edm::edm_named_type> get_payload_content_type(const ::odata::string_t& context_url);
 
 private:
-	std::shared_ptr<::odata::edm::edm_named_type> parse_context_url(std::list<::utility::string_t>& paths, const std::shared_ptr<::odata::edm::edm_named_type>& current_type);
-	std::shared_ptr<::odata::edm::edm_named_type> parse_complex_or_primitive(const ::utility::string_t& current_path);
+	std::shared_ptr<::odata::edm::edm_named_type> parse_context_url(std::list<::odata::string_t>& paths, const std::shared_ptr<::odata::edm::edm_named_type>& current_type);
+	std::shared_ptr<::odata::edm::edm_named_type> parse_complex_or_primitive(const ::odata::string_t& current_path);
 
-	std::shared_ptr<::odata::edm::edm_model>  m_model;
-	::utility::string_t m_service_root_url; 
+	std::shared_ptr<::odata::edm::edm_model> m_model;
+	::odata::string_t m_service_root_url;
 };
 
 }}

--- a/include/odata/core/odata_entity_factory.h
+++ b/include/odata/core/odata_entity_factory.h
@@ -18,19 +18,19 @@ template<typename _Entity_Impl>
 class entity_factory
 {
 public:
-	static std::shared_ptr<_Entity_Impl> create_reader_instance(std::shared_ptr<::odata::edm::edm_model> model, const ::utility::string_t& service_root_url)
+	static std::shared_ptr<_Entity_Impl> create_reader_instance(std::shared_ptr<::odata::edm::edm_model> model, const ::odata::string_t& service_root_url)
 	{
-		return std::make_shared<_Entity_Impl>(model, service_root_url);
+		return ::odata::make_shared<_Entity_Impl>(model, service_root_url);
 	}
 
 	static std::shared_ptr<_Entity_Impl> create_writer_instance(std::shared_ptr<::odata::edm::edm_model> model)
 	{
-		return std::make_shared<_Entity_Impl>(model);
+		return ::odata::make_shared<_Entity_Impl>(model);
 	}
 
-	static std::shared_ptr<_Entity_Impl> create_context_url_parser(std::shared_ptr<::odata::edm::edm_model> model, const ::utility::string_t& service_root_url)
+	static std::shared_ptr<_Entity_Impl> create_context_url_parser(std::shared_ptr<::odata::edm::edm_model> model, const ::odata::string_t& service_root_url)
 	{
-		return std::make_shared<_Entity_Impl>(model, service_root_url); 
+		return ::odata::make_shared<_Entity_Impl>(model, service_root_url);
 	}
 };
 

--- a/include/odata/core/odata_entity_model_builder.h
+++ b/include/odata/core/odata_entity_model_builder.h
@@ -15,13 +15,8 @@ namespace odata { namespace core
 class odata_entity_model_builder
 {
 public:
-	ODATACPP_CLIENT_API static ::utility::string_t compute_edit_link(
-		const ::utility::string_t& root_url, 
-		std::shared_ptr<odata_entity_value> entity_value, 
-		const ::utility::string_t& parent_edit_link, 
-		bool is_collection_navigation);
-
-	ODATACPP_CLIENT_API static ::utility::string_t get_entity_key_value_string(const std::shared_ptr<odata_entity_value>& entity_value);
+	ODATACPP_CLIENT_API static ::odata::string_t compute_edit_link(const ::odata::string_t& root_url, std::shared_ptr<odata_entity_value> entity_value, const ::odata::string_t& parent_edit_link, bool is_collection_navigation);
+	ODATACPP_CLIENT_API static ::odata::string_t get_entity_key_value_string(const std::shared_ptr<odata_entity_value>& entity_value);
 };
 
 }}

--- a/include/odata/core/odata_entity_value.h
+++ b/include/odata/core/odata_entity_value.h
@@ -19,13 +19,13 @@ public:
 	odata_entity_value(std::shared_ptr<::odata::edm::edm_entity_type> type) : odata_structured_value(type)
 	{}
 
-    odata_entity_value(odata_property_map properties, std::shared_ptr<::odata::edm::edm_entity_type> type) : odata_structured_value(type, properties)
+	odata_entity_value(std::pair<odata_property_map, odata_property_map> properties, std::shared_ptr<::odata::edm::edm_entity_type> type) : odata_structured_value(type, properties)
 	{}
 
-	ODATACPP_CLIENT_API ::utility::string_t get_entity_key_string();
+	ODATACPP_CLIENT_API ::odata::string_t get_entity_key_string();
 
 private:
-    ::utility::string_t to_key(std::shared_ptr<odata_primitive_value> value);
+	::odata::string_t to_key(std::shared_ptr<odata_primitive_value> value);
 };
 
 }}

--- a/include/odata/core/odata_enum_value.h
+++ b/include/odata/core/odata_enum_value.h
@@ -15,18 +15,17 @@ namespace odata { namespace core
 class odata_enum_value : public odata_value
 {
 public:
-    odata_enum_value(std::shared_ptr<::odata::edm::edm_named_type>type, ::utility::string_t stringRep) : odata_value(type), m_string_rep(std::move(stringRep))
-    {
-    }
+	odata_enum_value(std::shared_ptr<::odata::edm::edm_named_type>type, ::odata::string_t stringRep) : odata_value(type), m_string_rep(std::move(stringRep))
+	{
+	}
 
-    const ::utility::string_t& to_string() const
-    {
-        return m_string_rep; 
-    }
+	const ::odata::string_t& to_string() const
+	{
+		return m_string_rep;
+	}
 
 private:
-	::utility::string_t    m_string_rep;
-
+	::odata::string_t m_string_rep;
 };
 
 }}

--- a/include/odata/core/odata_json_constants.h
+++ b/include/odata/core/odata_json_constants.h
@@ -6,19 +6,21 @@
 
 #pragma once
 
-#include "cpprest/basic_types.h"
+#include "cpprest/details/basic_types.h"
 #include "odata/common/platform.h"
+#include "odata/common/utility.h"
 
 namespace odata { namespace core
 {
 class odata_json_constants
 {
 public:
-    ODATACPP_CLIENT_API static const ::utility::string_t PAYLOAD_ANNOTATION_NAVIGATIONLINK;
-    ODATACPP_CLIENT_API static const ::utility::string_t PAYLOAD_ANNOTATION_READLINK;
-    ODATACPP_CLIENT_API static const ::utility::string_t PAYLOAD_ANNOTATION_EDITLINK;
-    ODATACPP_CLIENT_API static const ::utility::string_t PAYLOAD_ANNOTATION_TYPE;
-    ODATACPP_CLIENT_API static const ::utility::string_t PAYLOAD_ANNOTATION_ID;
+	ODATACPP_CLIENT_API static const ::odata::string_t PAYLOAD_ANNOTATION_NAVIGATIONLINK;
+	ODATACPP_CLIENT_API static const ::odata::string_t PAYLOAD_ANNOTATION_READLINK;
+	ODATACPP_CLIENT_API static const ::odata::string_t PAYLOAD_ANNOTATION_EDITLINK;
+	ODATACPP_CLIENT_API static const ::odata::string_t PAYLOAD_ANNOTATION_TYPE;
+	ODATACPP_CLIENT_API static const ::odata::string_t PAYLOAD_ANNOTATION_ID;
+	ODATACPP_CLIENT_API static const ::odata::string_t PAYLOAD_ANNOTATION_BIND;
 };
 
 }}

--- a/include/odata/core/odata_json_operation_payload_parameter_writer.h
+++ b/include/odata/core/odata_json_operation_payload_parameter_writer.h
@@ -19,7 +19,7 @@ namespace odata { namespace core
 class odata_json_operation_payload_parameter_writer
 {
 public:
-	odata_json_operation_payload_parameter_writer(std::shared_ptr<::odata::edm::edm_model> model) : m_model(model)
+	odata_json_operation_payload_parameter_writer(std::shared_ptr<::odata::edm::edm_model> model, ::odata::client::client_options const &options) : m_model(model), m_options(options)
 	{
 	}
 
@@ -31,10 +31,11 @@ private:
 	void handle_serialize_primitive_value(::utility::stringstream_t& ss, const std::shared_ptr<::odata::edm::edm_primitive_type>& p_primitive_type, const std::shared_ptr<odata_primitive_value>& p_value);
 	void handle_serialize_enum_value(::utility::stringstream_t& ss, const std::shared_ptr<odata_enum_value>& p_value);
 	void handle_serialize_collection_value(::utility::stringstream_t& ss, const std::shared_ptr<odata_collection_value>& p_value);
-	void handle_serialize_odata_properties(::utility::stringstream_t& ss, const odata_property_map& properties);
+	void handle_serialize_odata_properties(::utility::stringstream_t& ss, const std::pair<odata_property_map, odata_property_map>& properties);
 	bool is_type_serializable(const std::shared_ptr<::odata::edm::edm_named_type>& property_type);
-	
+
 	std::shared_ptr<::odata::edm::edm_model> m_model;
+	::odata::client::client_options const    &m_options;
 };
 
 }}

--- a/include/odata/core/odata_json_operation_url_parameter_writer.h
+++ b/include/odata/core/odata_json_operation_url_parameter_writer.h
@@ -22,14 +22,14 @@ public:
 	{
 	}
 
-	ODATACPP_CLIENT_API ::utility::string_t serialize(std::vector<std::shared_ptr<odata_parameter>> parameters);
+	ODATACPP_CLIENT_API ::odata::string_t serialize(std::vector<std::shared_ptr<odata_parameter>> parameters);
 
 private:
 	void handle_serialize_odata_parameter(::utility::stringstream_t& ss, const std::shared_ptr<::odata::core::odata_parameter>& parameter, ::utility::char_t mark, ::utility::char_t separator);
 	void handle_serialize_odata_value(::utility::stringstream_t& ss, const std::shared_ptr<::odata::edm::edm_named_type>& property_type, const std::shared_ptr<odata_value>& property_value);
 	void handle_serialize_primitive_value(::utility::stringstream_t& ss, const std::shared_ptr<::odata::edm::edm_primitive_type>& p_primitive_type, const std::shared_ptr<odata_primitive_value>& p_value);
-	void handle_serialize_enum_value(::utility::stringstream_t& ss, const std::shared_ptr<odata_enum_value>& p_value);	
-	
+	void handle_serialize_enum_value(::utility::stringstream_t& ss, const std::shared_ptr<odata_enum_value>& p_value);
+
 	std::shared_ptr<::odata::edm::edm_model> m_model;
 };
 

--- a/include/odata/core/odata_json_reader.h
+++ b/include/odata/core/odata_json_reader.h
@@ -19,25 +19,25 @@ namespace odata { namespace core
 class odata_json_reader
 {
 public:
-	odata_json_reader(std::shared_ptr<::odata::edm::edm_model> model, ::utility::string_t service_root_url) 
-		: m_model(model), m_service_root_url(std::move(service_root_url))
+	odata_json_reader(std::shared_ptr<::odata::edm::edm_model> model, ::odata::string_t service_root_url)
+	:	m_model(model), m_service_root_url(std::move(service_root_url))
 	{
 	};
-	
-	ODATACPP_CLIENT_API std::shared_ptr<odata_payload> deserilize(const web::json::value& content);
-   
+
+	ODATACPP_CLIENT_API std::shared_ptr<odata_payload> deserialize(const web::json::value& content);
+
 private:
-	odata_property_map handle_extract_entity_property(::web::json::value& value, std::shared_ptr<::odata::edm::edm_entity_type>& edm_entity_type);
-    odata_property_map handle_extract_complex_property(::web::json::value& value, std::shared_ptr<::odata::edm::edm_complex_type>& edm_complex_type);
-	std::shared_ptr<odata_collection_value> handle_extract_collection_property(std::shared_ptr<::odata::edm::edm_named_type> type, web::json::value& value);
-	void handle_extract_entity_annotation(const ::utility::string_t& annotation, const ::utility::string_t& value, odata_property_map& result);
-	void handle_extract_navigation_property(::web::json::value& value, std::shared_ptr<::odata::edm::edm_navigation_type> navigation_type, odata_property_map& result, const ::utility::string_t& name);
-	::utility::string_t get_edit_link_from_context_url(const ::utility::string_t& context_url);
-	void set_edit_link_for_entity_value(const std::shared_ptr<odata_entity_value>& entity_value, const ::utility::string_t& expect_type_name, const ::utility::string_t& edit_link, bool is_collection);
-   
+	std::pair<odata_property_map, odata_property_map> handle_extract_entity_property(::web::json::value& value, std::shared_ptr<::odata::edm::edm_entity_type>& edm_entity_type);
+	std::pair<odata_property_map, odata_property_map> handle_extract_complex_property(::web::json::value& value, std::shared_ptr<::odata::edm::edm_complex_type>& edm_complex_type);
+	std::shared_ptr<odata_collection_value>           handle_extract_collection_property(std::shared_ptr<::odata::edm::edm_named_type> type, web::json::value& value);
+	void                                              handle_extract_entity_annotation(const ::odata::string_t& annotation, const ::odata::string_t& value, odata_property_map& result);
+	void                                              handle_extract_navigation_property(::web::json::value& value, std::shared_ptr<::odata::edm::edm_navigation_type> navigation_type, odata_property_map& result, const ::odata::string_t& name);
+	::odata::string_t                                 get_edit_link_from_context_url(const ::odata::string_t& context_url);
+	void                                              set_edit_link_for_entity_value(const std::shared_ptr<odata_entity_value>& entity_value, const ::odata::string_t& expect_type_name, const ::odata::string_t& edit_link, bool is_collection);
+
 	std::shared_ptr<::odata::edm::edm_model> m_model;
-	::utility::string_t m_service_root_url; 
-    std::shared_ptr<::odata::edm::edm_entity_set> m_entity_set;
+	::odata::string_t m_service_root_url;
+	std::shared_ptr<::odata::edm::edm_entity_set> m_entity_set;
 };
 
 }}

--- a/include/odata/core/odata_json_writer.h
+++ b/include/odata/core/odata_json_writer.h
@@ -19,7 +19,7 @@ namespace odata { namespace core
 class odata_json_writer
 {
 public:
-	odata_json_writer(std::shared_ptr<::odata::edm::edm_model> model) : m_model(model)
+	odata_json_writer(std::shared_ptr<::odata::edm::edm_model> model, ::odata::client::client_options const &options) : m_model(model), m_options(options)
 	{
 	}
 
@@ -28,14 +28,15 @@ public:
 
 private:
 	void handle_serialize_odata_parameter(::utility::stringstream_t& ss, const std::shared_ptr<::odata::core::odata_parameter>& parameter, ::utility::char_t mark, ::utility::char_t separator);
-	void handle_serialize_odata_properties(::utility::stringstream_t& ss, const odata_property_map& properties);
+	void handle_serialize_odata_properties(::utility::stringstream_t& ss, const std::pair<odata_property_map, odata_property_map>& properties);
 	void handle_serialize_odata_value(::utility::stringstream_t& ss, const std::shared_ptr<::odata::edm::edm_named_type>& property_type, const std::shared_ptr<odata_value>& property_value);
 	void handle_serialize_primitive_value(::utility::stringstream_t& ss, const std::shared_ptr<::odata::edm::edm_primitive_type>& p_primitive_type, const std::shared_ptr<odata_primitive_value>& p_value);
 	void handle_serialize_enum_value(::utility::stringstream_t& ss, const std::shared_ptr<odata_enum_value>& p_value);
-    void handle_serialize_collection_value(::utility::stringstream_t& ss, const std::shared_ptr<odata_collection_value>& p_value);
+	void handle_serialize_collection_value(::utility::stringstream_t& ss, const std::shared_ptr<odata_collection_value>& p_value);
 	bool is_type_serializable(const std::shared_ptr<::odata::edm::edm_named_type>& property_type);
 
 	std::shared_ptr<::odata::edm::edm_model> m_model;
+	::odata::client::client_options const    &m_options;
 };
 
 }}

--- a/include/odata/core/odata_parameter.h
+++ b/include/odata/core/odata_parameter.h
@@ -14,25 +14,25 @@ namespace odata { namespace core
 class odata_parameter
 {
 public:
-    /// <summary>Default constructor</summary>
-	odata_parameter() 
-		: m_value(std::make_shared<::odata::core::odata_value>())
+	/// <summary>Default constructor</summary>
+	odata_parameter()
+		: m_name(), m_value(::odata::make_shared<::odata::core::odata_value>())
 	{
 	}
 
-    odata_parameter(::utility::string_t name, const std::shared_ptr<::odata::core::odata_value>& value) 
+	odata_parameter(::odata::string_t name, const std::shared_ptr<::odata::core::odata_value>& value)
 		: m_name(std::move(name)), m_value(value)
 	{
 	}
-	
-	const ::utility::string_t& get_name() const { return m_name; }
 
-	void set_name(::utility::string_t name)
+	const ::odata::string_t& get_name() const { return m_name; }
+
+	void set_name(::odata::string_t name)
 	{
 		m_name = std::move(name);
 	}
 
-    const std::shared_ptr<::odata::core::odata_value>& get_value() const { return m_value; }
+	const std::shared_ptr<::odata::core::odata_value>& get_value() const { return m_value; }
 
 	void set_value(const std::shared_ptr<::odata::core::odata_value>& value)
 	{
@@ -40,8 +40,8 @@ public:
 	}
 
 private:
-	::utility::string_t m_name;
-    std::shared_ptr<::odata::core::odata_value> m_value;
+	::odata::string_t m_name;
+	std::shared_ptr<::odata::core::odata_value> m_value;
 };
 
 }}

--- a/include/odata/core/odata_payload.h
+++ b/include/odata/core/odata_payload.h
@@ -34,44 +34,44 @@ enum odata_payload_kind
 class odata_payload
 {
 public:
-	odata_payload() {}
+	odata_payload() = default;
 
 	void add_value(std::shared_ptr<odata_value> value)
 	{
-		m_odata_values.push_back(value);
+		m_odata_values.emplace_back(value);
 	}
 
 	void insert_values(const std::vector<std::shared_ptr<odata_value>>& values)
 	{
-		m_odata_values.insert(m_odata_values.end(), values.begin(), values.end()); 
+		m_odata_values.insert(m_odata_values.end(), values.begin(), values.end());
 	}
 
-	const int value_count() const
+	const size_t value_count() const
 	{
 		return m_odata_values.size();
 	}
 
-	const std::vector<std::shared_ptr<odata_value>>& get_values() const 
+	const std::vector<std::shared_ptr<odata_value>>& get_values() const
 	{
 		return m_odata_values;
 	}
 
-	const ::utility::string_t& get_next_link() const
+	const ::odata::string_t& get_next_link() const
 	{
 		return m_next_link;
 	}
 
-	void set_next_link(::utility::string_t next_link)
+	void set_next_link(::odata::string_t next_link)
 	{
 		m_next_link = std::move(next_link);
 	}
 
-	const ::utility::string_t& get_context_url() const
+	const ::odata::string_t& get_context_url() const
 	{
 		return m_context_url;
 	}
 
-	void set_context_url(::utility::string_t context_ur)
+	void set_context_url(::odata::string_t context_ur)
 	{
 		m_context_url = std::move(context_ur);
 	}
@@ -82,9 +82,9 @@ public:
 	}
 
 private:
-	std::vector<std::shared_ptr<odata_value>>   m_odata_values;
-	::utility::string_t               m_next_link;
-	::utility::string_t               m_context_url;
+	std::vector<std::shared_ptr<odata_value>> m_odata_values;
+	::odata::string_t                         m_next_link;
+	::odata::string_t                         m_context_url;
 };
 
 }}

--- a/include/odata/core/odata_primitive_value.h
+++ b/include/odata/core/odata_primitive_value.h
@@ -15,103 +15,103 @@ namespace odata { namespace core
 class odata_primitive_value : public odata_value
 {
 public:
-    odata_primitive_value(std::shared_ptr<::odata::edm::edm_named_type>type, ::utility::string_t stringRep) : odata_value(type), m_string_rep(std::move(stringRep))
-    {
-    }
+	odata_primitive_value(std::shared_ptr<::odata::edm::edm_named_type>type, ::odata::string_t stringRep) : odata_value(type), m_string_rep(std::move(stringRep))
+	{
+	}
 
 	static std::shared_ptr<odata_primitive_value> make_primitive_value(int16_t int16_value)
 	{
-		return std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::INT16(), ::utility::conversions::print_string(int16_value));
+		return ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::INT16(), ::utility::conversions::print_string(int16_value));
 	}
 
 	static std::shared_ptr<odata_primitive_value> make_primitive_value(int32_t int32_value)
 	{
-		return std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::INT32(), ::utility::conversions::print_string(int32_value));
+		return ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::INT32(), ::utility::conversions::print_string(int32_value));
 	}
 
 	static std::shared_ptr<odata_primitive_value> make_primitive_value(const std::vector<unsigned char>& binary_data)
 	{
-		return std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::BINARY(), ::utility::conversions::to_base64(binary_data));
+		return ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::BINARY(), ::utility::conversions::to_base64(binary_data));
 	}
 
 	static std::shared_ptr<odata_primitive_value> make_primitive_value(bool boolean_value)
 	{
-		return std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::BOOLEAN(), ::utility::conversions::print_string(boolean_value));
+		return ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::BOOLEAN(), ::utility::conversions::print_string(boolean_value));
 	}
 
 	static std::shared_ptr<odata_primitive_value> make_primitive_value(::utility::datetime datetime_value)
 	{
-		return std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::DATETIMEOFFSET(), datetime_value.to_string(::utility::datetime::date_format::ISO_8601));
+		return ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::DATETIMEOFFSET(), datetime_value.to_string(::utility::datetime::date_format::ISO_8601));
 	}
 
 	static std::shared_ptr<odata_primitive_value> make_primitive_value(::utility::seconds duration_value)
 	{
-		return std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::DURATION(), ::utility::timespan::seconds_to_xml_duration(duration_value));
+		return ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::DURATION(), ::utility::timespan::seconds_to_xml_duration(duration_value));
 	}
 
 	static std::shared_ptr<odata_primitive_value> make_primitive_value(double double_precision_value)
 	{
-		return std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::DOUBLE(), ::odata::common::print_double(double_precision_value));
+		return ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::DOUBLE(), ::odata::common::print_double(double_precision_value));
 	}
 
 	static std::shared_ptr<odata_primitive_value> make_primitive_value(float float_precision_value)
 	{
-		return std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::SINGLE(), ::odata::common::print_float(float_precision_value));
+		return ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::SINGLE(), ::odata::common::print_float(float_precision_value));
 	}
 
 	static std::shared_ptr<odata_primitive_value> make_primitive_value(int64_t int64_value)
 	{
-		return std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::INT64(), ::utility::conversions::print_string(int64_value));
+		return ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::INT64(), ::utility::conversions::print_string(int64_value));
 	}
 
 	static std::shared_ptr<odata_primitive_value> make_primitive_value(uint64_t u_int64_value)
 	{
-		return std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::INT64(), ::utility::conversions::print_string(u_int64_value));
+		return ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::INT64(), ::utility::conversions::print_string(u_int64_value));
 	}
 
-	static std::shared_ptr<odata_primitive_value> make_primitive_value(::utility::string_t string_value)
+	static std::shared_ptr<odata_primitive_value> make_primitive_value(::odata::string_t string_value)
 	{
-		return std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::STRING(), std::move(string_value));
+		return ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::STRING(), std::move(string_value));
 	}
 
 	static std::shared_ptr<odata_primitive_value> make_primitive_value(const ::utility::char_t* string_value)
 	{
-		return std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::STRING(), string_value);
+		return ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::STRING(), string_value);
 	}
 
-    const ::utility::string_t& to_string() const
-    {
-        return m_string_rep; 
-    }
+	const ::odata::string_t& to_string() const
+	{
+		return m_string_rep;
+	}
 
-    std::shared_ptr<::odata::edm::edm_primitive_type> get_primitive_type() const 
-    { 
-        return std::dynamic_pointer_cast<::odata::edm::edm_primitive_type>(get_value_type()); 
-    }
+	std::shared_ptr<::odata::edm::edm_primitive_type> get_primitive_type() const
+	{
+		return std::dynamic_pointer_cast<::odata::edm::edm_primitive_type>(get_value_type());
+	}
 
-    template<typename T> T as()
-    {
-        T result;
-        _try_get(result);
-        return result;
-    }
+	template<typename T> T as()
+	{
+		T result;
+		_try_get(result);
+		return result;
+	}
 
 private:
-	::utility::string_t    m_string_rep;
+	::odata::string_t m_string_rep;
 
-    ODATACPP_CLIENT_API void _try_get(std::vector<unsigned char>& value) const;
-    ODATACPP_CLIENT_API void _try_get(unsigned char& value) const;
-    ODATACPP_CLIENT_API void _try_get(char& value) const;
-    ODATACPP_CLIENT_API void _try_get(bool& value) const;
-    ODATACPP_CLIENT_API void _try_get(::utility::datetime& value) const;
+	ODATACPP_CLIENT_API void _try_get(std::vector<unsigned char>& value) const;
+	ODATACPP_CLIENT_API void _try_get(unsigned char& value) const;
+	ODATACPP_CLIENT_API void _try_get(char& value) const;
+	ODATACPP_CLIENT_API void _try_get(bool& value) const;
+	ODATACPP_CLIENT_API void _try_get(::utility::datetime& value) const;
 	ODATACPP_CLIENT_API void _try_get(::utility::seconds& value) const;
-    ODATACPP_CLIENT_API void _try_get(double& value) const;
+	ODATACPP_CLIENT_API void _try_get(double& value) const;
 	ODATACPP_CLIENT_API void _try_get(float& value) const;
 	ODATACPP_CLIENT_API void _try_get(int16_t& value) const;
-    ODATACPP_CLIENT_API void _try_get(int32_t& value) const;
-    ODATACPP_CLIENT_API void _try_get(int64_t& value) const;
+	ODATACPP_CLIENT_API void _try_get(int32_t& value) const;
+	ODATACPP_CLIENT_API void _try_get(int64_t& value) const;
 	ODATACPP_CLIENT_API void _try_get(uint64_t& value) const;
-    ODATACPP_CLIENT_API void _try_get(::utility::string_t& value) const;
+	ODATACPP_CLIENT_API void _try_get(::odata::string_t& value) const;
 };
 
 }}

--- a/include/odata/core/odata_property_map.h
+++ b/include/odata/core/odata_property_map.h
@@ -18,137 +18,124 @@ class odata_primitive_value;
 class odata_enum_value;
 class odata_collection_value;
 
-typedef ::utility::string_t odata_property_key;
-typedef ::utility::string_t odata_property_name;
+typedef ::odata::string_t odata_property_key;
+typedef ::odata::string_t odata_property_name;
 typedef std::unordered_map<odata_property_name, std::shared_ptr<odata_value>> odata_properties;
 
 /// <summary>
 /// A type that holds the properties for an entity or a complex.
-///     Key (odata_property_name) - The property name 
-///     Value (property_value) - see above 
+///     Key (odata_property_name) - The property name
+///     Value (property_value) - see above
 /// </summary>
-class odata_property_map 
+class odata_property_map
 {
 public:
-    odata_property_map()
-    {
-    }
-
-    odata_property_map(odata_property_map& property_map)
+	odata_property_map() : m_properties()
 	{
-		m_properties = std::move(property_map.m_properties);
-	}
-    
-    odata_property_map(odata_property_map&& property_map)
-	{
-		m_properties = std::move(property_map.m_properties);
-	}
-    
-    odata_property_map(const odata_property_map& property_map)
-	{
-		m_properties = std::move(property_map.m_properties);
-	}
-    
-    odata_property_map(const odata_property_map&& property_map)
-	{
-		m_properties = std::move(property_map.m_properties);
 	}
 
-	odata_property_map& operator = (odata_property_map&& property_map)
+	odata_property_map(odata_property_map &&property_map) : m_properties(std::move(property_map.m_properties))
 	{
-		m_properties = std::move(property_map.m_properties);
-		return *this;
 	}
-    
-    odata_property_map& operator = (odata_property_map& property_map)
+
+	odata_property_map(odata_property_map const &property_map) : m_properties(property_map.m_properties)
 	{
-		m_properties = std::move(property_map.m_properties);
-		return *this;
 	}
-    
-    odata_property_map& operator = (const odata_property_map&& property_map)
-	{
-		m_properties = std::move(property_map.m_properties);
-		return *this;
-	}
-    
-    odata_property_map& operator = (const odata_property_map& property_map)
+
+	odata_property_map& operator = (odata_property_map &&property_map)
 	{
 		m_properties = std::move(property_map.m_properties);
 		return *this;
 	}
 
-	ODATACPP_CLIENT_API std::shared_ptr<odata_value>& operator[](odata_property_name&& _Keyval)
-    {
-         return m_properties[_Keyval];
-    }
+	odata_property_map& operator = (odata_property_map const &property_map)
+	{
+		m_properties = property_map.m_properties;
+		return *this;
+	}
 
-	ODATACPP_CLIENT_API std::shared_ptr<odata_value>& operator[](odata_property_name& _Keyval)
-    {
-         return m_properties[_Keyval];
-    }
+	ODATACPP_CLIENT_API std::shared_ptr<odata_value>& operator[](odata_property_name const &_Keyval)
+	{
+		return m_properties[_Keyval];
+	}
 
-	ODATACPP_CLIENT_API std::shared_ptr<odata_value>& operator[](const odata_property_name& _Keyval)
-    {
-         return m_properties[_Keyval];
-    }
+	ODATACPP_CLIENT_API odata_properties::iterator erase(odata_properties::const_iterator &_Where)
+	{
+		return m_properties.erase(_Where);
+	}
 
-    ODATACPP_CLIENT_API odata_properties::iterator erase(odata_properties::const_iterator _Where)
-    {
-        return m_properties.erase(_Where);
-    }
+	ODATACPP_CLIENT_API odata_properties::size_type erase(odata_property_name const &_Keyval)
+	{
+		return m_properties.erase(_Keyval);
+	}
 
-    ODATACPP_CLIENT_API odata_properties::size_type erase(const odata_property_name& _Keyval)
-    {
-        return m_properties.erase(_Keyval);
-    }
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, std::shared_ptr<odata_value>& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, std::shared_ptr<odata_complex_value>& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, std::shared_ptr<odata_primitive_value>& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, std::shared_ptr<odata_entity_value>& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, std::shared_ptr<odata_enum_value>& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, std::shared_ptr<odata_collection_value>& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, char& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, unsigned char& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, std::vector<unsigned char>& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, bool& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, ::utility::datetime& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, ::utility::seconds& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, double& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, float& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, int16_t& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, int32_t& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, int64_t& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, ::odata::string_t& value) const;
+	ODATACPP_CLIENT_API bool try_get(const ::odata::string_t& property_name, odata_property_map& value) const;
 
-    ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, std::shared_ptr<odata_value>& value) const;
-	ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, std::shared_ptr<odata_complex_value>& value) const;
-	ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, std::shared_ptr<odata_primitive_value>& value) const;
-	ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, std::shared_ptr<odata_entity_value>& value) const;
-	ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, std::shared_ptr<odata_enum_value>& value) const;
-	ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, std::shared_ptr<odata_collection_value>& value) const;
-	ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, char& value) const;
-	ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, unsigned char& value) const;
-    ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, std::vector<unsigned char>& value) const;
-    ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, bool& value) const;
-    ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, ::utility::datetime& value) const;
-    ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, ::utility::seconds& value) const;
-    ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, double& value) const;
-	ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, float& value) const;
-    ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, int32_t& value) const;
-	ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, int16_t& value) const;
-    ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, int64_t& value) const;
-    ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, ::utility::string_t& value) const;
-    ODATACPP_CLIENT_API bool try_get(const ::utility::string_t& property_name, odata_property_map& value) const;
+	/// <summary>
+	/// Gets the beginning const_iterator of the properties
+	/// </summary>
+	odata_properties::const_iterator begin() const
+	{
+		return m_properties.cbegin();
+	}
 
-    /// <summary>
-    /// Gets the beginning const_iterator of the properties
-    /// </summary>
-    odata_properties::const_iterator cbegin() const
-    {
-        return m_properties.cbegin();
-    }
+	/// <summary>
+	/// Gets the beginning const_iterator of the properties
+	/// </summary>
+	odata_properties::const_iterator cbegin() const
+	{
+		return m_properties.cbegin();
+	}
 
-    /// <summary>
-    /// Gets the end const_iterator of the properties
-    /// </summary>
-    odata_properties::const_iterator cend() const
-    {
-        return m_properties.cend();
-    }
+	/// <summary>
+	/// Gets the end const_iterator of the properties
+	/// </summary>
+	odata_properties::const_iterator end() const
+	{
+		return m_properties.cend();
+	}
 
-	int size() const 
+	/// <summary>
+	/// Gets the end const_iterator of the properties
+	/// </summary>
+	odata_properties::const_iterator cend() const
+	{
+		return m_properties.cend();
+	}
+
+	size_t size() const
 	{
 		return m_properties.size();
 	}
 
-private:
-    friend class entity;
-    odata_properties m_properties;
+	bool empty() const
+	{
+		return m_properties.empty();
+	}
 
-	ODATACPP_CLIENT_API std::pair<bool, std::shared_ptr<odata_value>> find_property(const ::utility::string_t& property_name) const;
+private:
+	friend class entity;
+	odata_properties m_properties;
+
+	ODATACPP_CLIENT_API std::pair<bool, std::shared_ptr<odata_value>> find_property(const ::odata::string_t& property_name) const;
 };
 
 }}

--- a/include/odata/core/odata_structured_value.h
+++ b/include/odata/core/odata_structured_value.h
@@ -20,152 +20,207 @@ class odata_enum_value;
 class odata_structured_value : public odata_value
 {
 public:
-	odata_structured_value(std::shared_ptr<::odata::edm::edm_named_type>type) : odata_value(type)
+	odata_structured_value(std::shared_ptr<::odata::edm::edm_named_type> type)
+		: odata_value(type), m_properties()
 	{
 	}
 
-	odata_structured_value(std::shared_ptr<::odata::edm::edm_named_type>type, odata_property_map properties) 
-		: m_properties(std::move(properties)), odata_value(type)
+	odata_structured_value(std::shared_ptr<::odata::edm::edm_named_type> type, std::pair<odata_property_map, odata_property_map> properties)
+		: odata_value(type), m_properties(std::move(properties))
 	{
-		
 	}
 
-	virtual ~odata_structured_value(){}
+	virtual ~odata_structured_value() = default;
 
-    /// <summary>Returns a const reference to the property map.</summary>
-    const odata_property_map& properties() const { return m_properties; }
+	/// <summary>Returns a const reference to the property map.</summary>
+	const odata_property_map& properties() const { return m_properties.first; }
 
-	void set_properties(odata_property_map map)
+	void set_properties(odata_property_map map) { m_properties.first = std::move(map); }
+
+	/// <summary>Tells whether the structured object has a property of a given name.</summary>
+	/// <param name="property_name">The name of the property</param>
+	bool has_property(const ::odata::string_t& property_name) const
 	{
-		m_properties = std::move(map);
+		std::shared_ptr<odata_value> details;
+		return m_properties.first.try_get(property_name, details);
 	}
 
-    /// <summary>Tells whether the structured object has a property of a given name.</summary>
-    /// <param name="property_name">The name of the property</param>
-    bool has_property(const ::utility::string_t& property_name) const
-    {
-        std::shared_ptr<odata_value> details;
-        return m_properties.try_get(property_name, details);
-    }
-
-    /// <summary>Tells whether the structured object has a property of a given name.</summary>
-    /// <param name="property_name">The name of the property</param>
-	bool has_property(const ::utility::string_t& property_name, std::shared_ptr<::odata::edm::edm_named_type>& type) const
-    {
-        std::shared_ptr<odata_value> details;
-        bool result = m_properties.try_get(property_name, details);
-        if ( result )
-        {
-            type = details->get_value_type();
-        }
-        return result;
-    }
-
-	bool get_property_value(const ::utility::string_t& property_name, std::shared_ptr<odata_value>& property_value)
+	/// <summary>Tells whether the structured object has a property of a given name.</summary>
+	/// <param name="property_name">The name of the property</param>
+	bool has_property(const ::odata::string_t& property_name, std::shared_ptr<::odata::edm::edm_named_type>& type) const
 	{
-		return m_properties.try_get(property_name, property_value);
+		std::shared_ptr<odata_value> details;
+		bool result = m_properties.first.try_get(property_name, details);
+		if (result)
+		{
+			type = details->get_value_type();
+		}
+		return result;
 	}
 
-    template<typename T>
-    bool try_get(const ::utility::string_t& property_name, T& value) const
-    {
-        return m_properties.try_get(property_name, value);
-    }
-
-	void set_value(const ::utility::string_t& property_name, float float_value)
+	bool get_property_value(const ::odata::string_t& property_name, std::shared_ptr<odata_value>& property_value)
 	{
-		m_properties[property_name] = std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::SINGLE(), ::odata::common::print_float(float_value));
+		return m_properties.first.try_get(property_name, property_value);
 	}
 
-	void set_value(const ::utility::string_t& property_name, unsigned char ubyte_value)
+	template<typename T>
+	bool try_get(const ::odata::string_t& property_name, T& value) const
 	{
-		m_properties[property_name] = std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::BYTE(), ::utility::conversions::print_string(ubyte_value));
+		return m_properties.first.try_get(property_name, value);
 	}
 
-	void set_value(const ::utility::string_t& property_name, char byte_value)
+	void set_value(const ::odata::string_t& property_name, float float_value)
 	{
-		m_properties[property_name] = std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::BYTE(), ::utility::conversions::print_string(byte_value));
+		m_properties.first[property_name] = ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::SINGLE(), ::odata::common::print_float(float_value));
 	}
 
-	void set_value(const ::utility::string_t& property_name, int32_t int32_value)
+	void set_value(const ::odata::string_t& property_name, unsigned char ubyte_value)
 	{
-		m_properties[property_name] = std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::INT32(), ::utility::conversions::print_string(int32_value));
+		m_properties.first[property_name] = ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::BYTE(), ::utility::conversions::print_string(ubyte_value));
 	}
 
-	void set_value(const ::utility::string_t& property_name, const std::vector<unsigned char>& binary_data)
+	void set_value(const ::odata::string_t& property_name, char byte_value)
 	{
-		m_properties[property_name] = std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::BINARY(), ::utility::conversions::to_base64(binary_data));
+		m_properties.first[property_name] = ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::BYTE(), ::utility::conversions::print_string(byte_value));
 	}
 
-	void set_value(const ::utility::string_t& property_name, bool boolean_value)
+	void set_value(const ::odata::string_t& property_name, int32_t int32_value)
 	{
-		m_properties[property_name] = std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::BOOLEAN(), ::utility::conversions::print_string(boolean_value));
+		m_properties.first[property_name] = ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::INT32(), ::utility::conversions::print_string(int32_value));
 	}
 
-	void set_value(const ::utility::string_t& property_name, ::utility::datetime datetime_value)
+	void set_value(const ::odata::string_t& property_name, const std::vector<unsigned char>& binary_data)
 	{
-		m_properties[property_name] = std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::DATETIMEOFFSET(), datetime_value.to_string(::utility::datetime::date_format::ISO_8601));
+		m_properties.first[property_name] = ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::BINARY(), ::utility::conversions::to_base64(binary_data));
 	}
 
-	void set_value(const ::utility::string_t& property_name, ::utility::seconds duration_value)
+	void set_value(const ::odata::string_t& property_name, bool boolean_value)
 	{
-		m_properties[property_name] = std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::DURATION(), ::utility::timespan::seconds_to_xml_duration(duration_value));
+		m_properties.first[property_name] = ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::BOOLEAN(), ::utility::conversions::print_string(boolean_value));
 	}
 
-	void set_value(const ::utility::string_t& property_name, double double_precision_value)
+	void set_value(const ::odata::string_t& property_name, ::utility::datetime datetime_value)
 	{
-		m_properties[property_name] = std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::DOUBLE(), ::odata::common::print_double(double_precision_value));
+		m_properties.first[property_name] = ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::DATETIMEOFFSET(), datetime_value.to_string(::utility::datetime::date_format::ISO_8601));
 	}
 
-	void set_value(const ::utility::string_t& property_name, int64_t int64_value)
+	void set_value(const ::odata::string_t& property_name, ::utility::seconds duration_value)
 	{
-		m_properties[property_name] = std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::INT64(), ::utility::conversions::print_string(int64_value));
+		m_properties.first[property_name] = ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::DURATION(), ::utility::timespan::seconds_to_xml_duration(duration_value));
 	}
 
-	void set_value(const ::utility::string_t& property_name, uint64_t u_int64_value)
+	void set_value(const ::odata::string_t& property_name, double double_precision_value)
 	{
-		m_properties[property_name] = std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::INT64(), ::utility::conversions::print_string(u_int64_value));
+		m_properties.first[property_name] = ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::DOUBLE(), ::odata::common::print_double(double_precision_value));
 	}
 
-	void set_value(const ::utility::string_t& property_name, int16_t int16_value)
+	void set_value(const ::odata::string_t& property_name, int64_t int64_value)
 	{
-		m_properties[property_name] = std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::INT16(), ::utility::conversions::print_string(int16_value));
+		m_properties.first[property_name] = ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::INT64(), ::utility::conversions::print_string(int64_value));
 	}
 
-	void set_value(const ::utility::string_t& property_name, const ::utility::char_t* string_value)
+	void set_value(const ::odata::string_t& property_name, uint64_t u_int64_value)
 	{
-		m_properties[property_name] = std::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::STRING(), string_value);
+		m_properties.first[property_name] = ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::INT64(), ::utility::conversions::print_string(u_int64_value));
 	}
 
-	void set_value(const ::utility::string_t& property_name, std::shared_ptr<odata_value> property_value)
+	void set_value(const ::odata::string_t& property_name, int16_t int16_value)
 	{
-		m_properties[property_name] = property_value;
+		m_properties.first[property_name] = ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::INT16(), ::utility::conversions::print_string(int16_value));
 	}
 
-	ODATACPP_CLIENT_API void set_value(const ::utility::string_t& property_name, std::shared_ptr<odata_primitive_value> property_value);
+	void set_value(const ::odata::string_t& property_name, const ::utility::char_t* string_value)
+	{
+		m_properties.first[property_name] = ::odata::make_shared<odata_primitive_value>(::odata::edm::edm_primitive_type::STRING(), string_value);
+	}
 
-	ODATACPP_CLIENT_API void set_value(const ::utility::string_t& property_name, std::shared_ptr<odata_complex_value> property_value);
+	void set_value(const ::odata::string_t& property_name, std::shared_ptr<odata_value> property_value)
+	{
+		m_properties.first[property_name] = property_value;
+	}
 
-	ODATACPP_CLIENT_API void set_value(const ::utility::string_t& property_name, std::shared_ptr<odata_entity_value> property_value);
+	ODATACPP_CLIENT_API void set_value(const ::odata::string_t& property_name, std::shared_ptr<odata_primitive_value> property_value);
 
-	ODATACPP_CLIENT_API void set_value(const ::utility::string_t& property_name, std::shared_ptr<odata_enum_value> property_value);
+	ODATACPP_CLIENT_API void set_value(const ::odata::string_t& property_name, std::shared_ptr<odata_complex_value> property_value);
 
-	ODATACPP_CLIENT_API void set_value(const ::utility::string_t& property_name, std::shared_ptr<odata_collection_value> property_value);
+	ODATACPP_CLIENT_API void set_value(const ::odata::string_t& property_name, std::shared_ptr<odata_entity_value> property_value);
 
-	ODATACPP_CLIENT_API void set_value(const ::utility::string_t& property_name, const ::utility::string_t& string_value);
+	ODATACPP_CLIENT_API void set_value(const ::odata::string_t& property_name, std::shared_ptr<odata_enum_value> property_value);
 
-    /// <summary>
-    /// Removes a property from the structured object if it is present.
-    /// </summary>
-    /// <param name="string_value">A string representing the property value.</param>
-    odata_structured_value& remove(const ::utility::string_t& property_name)
-    {
-        m_properties.erase(property_name);
-        return *this;
-    }
+	ODATACPP_CLIENT_API void set_value(const ::odata::string_t& property_name, std::shared_ptr<odata_collection_value> property_value);
+
+	ODATACPP_CLIENT_API void set_value(const ::odata::string_t& property_name, const ::odata::string_t& string_value);
+
+	/// <summary>
+	/// Removes a property from the structured object if it is present.
+	/// </summary>
+	/// <param name="string_value">A string representing the property value.</param>
+	odata_structured_value& remove(const ::odata::string_t& property_name)
+	{
+		m_properties.first.erase(property_name);
+		return *this;
+	}
+
+	const bool is_open() const
+	{
+		auto type = get_value_type();
+		if (type->get_type_kind() == ::odata::edm::edm_type_kind_t::Entity)
+		{
+			 return std::dynamic_pointer_cast<::odata::edm::edm_entity_type>(type)->is_open();
+		}
+		if (type->get_type_kind() == ::odata::edm::edm_type_kind_t::Complex)
+		{
+			return std::dynamic_pointer_cast<::odata::edm::edm_complex_type>(type)->is_open();
+		}
+		return false;
+	}
+
+	/// <summary>Returns a const reference to the complete property map.</summary>
+	const std::pair<odata_property_map, odata_property_map>& all_properties() const { return m_properties; }
+
+	const odata_property_map& open_properties() const { return m_properties.second; }
+
+	void set_properties(std::pair<odata_property_map, odata_property_map> maps) { m_properties = std::move(maps); }
+
+	void set_open_properties(odata_property_map map) { m_properties.second = std::move(map); }
+
+	bool has_open_property(const ::odata::string_t& property_name) const
+	{
+		std::shared_ptr<odata_value> details;
+		return m_properties.second.try_get(property_name, details);
+	}
+
+	bool has_open_property(const ::odata::string_t& property_name, std::shared_ptr<::odata::edm::edm_named_type>& type) const
+	{
+		std::shared_ptr<odata_value> details;
+		bool result = m_properties.second.try_get(property_name, details);
+		if (result)
+		{
+			type = details->get_value_type();
+		}
+		return result;
+	}
+
+	bool get_open_property_value(const ::odata::string_t& property_name, std::shared_ptr<odata_value>& property_value)
+	{
+		return m_properties.second.try_get(property_name, property_value);
+	}
+
+	bool try_get_open(const ::odata::string_t& property_name, ::odata::string_t& value) const
+	{
+		return m_properties.second.try_get(property_name, value);
+	}
+
+	ODATACPP_CLIENT_API void set_open_value(const ::odata::string_t& property_name, const ::odata::string_t& string_value);
+
+	odata_structured_value& remove_open(const ::odata::string_t& property_name)
+	{
+		m_properties.second.erase(property_name);
+		return *this;
+	}
 
 protected:
-	odata_property_map             m_properties;
+	std::pair<odata_property_map, odata_property_map> m_properties;
 };
 
 }}

--- a/include/odata/core/odata_value.h
+++ b/include/odata/core/odata_value.h
@@ -18,17 +18,17 @@ class odata_entity_value;
 class odata_value
 {
 public:
-    /// <summary>Default constructor</summary>
-    odata_value() : m_property_type(std::make_shared<::odata::edm::edm_named_type>()){}
+	/// <summary>Default constructor</summary>
+	odata_value() : m_property_type(::odata::make_shared<::odata::edm::edm_named_type>()), m_is_null_value(false) {}
 
-    odata_value(std::shared_ptr<::odata::edm::edm_named_type>type, bool is_null_value = false) 
+	odata_value(std::shared_ptr<::odata::edm::edm_named_type>type, bool is_null_value = false)
 		: m_property_type(type), m_is_null_value(is_null_value)
 	{
 	}
 
-    virtual ~odata_value(){};
+	virtual ~odata_value() = default;
 
-    std::shared_ptr<::odata::edm::edm_named_type> get_value_type() const { return m_property_type; }
+	std::shared_ptr<::odata::edm::edm_named_type> get_value_type() const { return m_property_type; }
 
 	void set_value_type(std::shared_ptr<::odata::edm::edm_named_type> property_type)
 	{
@@ -36,10 +36,10 @@ public:
 	}
 
 private:
-    friend class entity;
-    friend class odata_property_map;
+	friend class entity;
+	friend class odata_property_map;
 
-    std::shared_ptr<::odata::edm::edm_named_type> m_property_type;
+	std::shared_ptr<::odata::edm::edm_named_type> m_property_type;
 	bool m_is_null_value;
 };
 

--- a/include/odata/edm/edm_entity_container.h
+++ b/include/odata/edm/edm_entity_container.h
@@ -20,47 +20,47 @@ namespace odata { namespace edm
 class edm_entity_container
 {
 public:
-    /// <summary>
-    /// Constructor
-    /// </summary>
-    /// <param name="name">The name of the entity container.</param>
-    edm_entity_container(::utility::string_t name, bool is_default) : 
-        m_name(std::move(name)), m_is_default(is_default)
-    {
-    }
+	/// <summary>
+	/// Constructor
+	/// </summary>
+	/// <param name="name">The name of the entity container.</param>
+	edm_entity_container(::odata::string_t name, bool is_default)
+	:	m_is_default(is_default), m_name(std::move(name)), m_extends(), m_entity_sets(), m_singletons(), m_operation_imports()
+	{
+	}
 
-    /// <summary>
-    /// Gets the name of the entity container
-    /// </summary>
-    /// <returns>The name of the entity container.</returns>
-    const ::utility::string_t& get_name() const 
-    {
-        return m_name;
-    }
+	/// <summary>
+	/// Gets the name of the entity container
+	/// </summary>
+	/// <returns>The name of the entity container.</returns>
+	const ::odata::string_t& get_name() const
+	{
+		return m_name;
+	}
 
-    /// <summary>
-    /// Gets the is_default_container property
-    /// </summary>
-    /// <returns>true if this is the default container of the service, false otherwise</returns>
-    bool is_default_container() const 
-    {
-        return m_is_default;
-    }
+	/// <summary>
+	/// Gets the is_default_container property
+	/// </summary>
+	/// <returns>true if this is the default container of the service, false otherwise</returns>
+	bool is_default_container() const
+	{
+		return m_is_default;
+	}
 
-    /// <summary>
-    /// 
-    /// </summary>
-    void add_entity_set(std::shared_ptr<edm_entity_set> et)
-    {
+	/// <summary>
+	///
+	/// </summary>
+	void add_entity_set(std::shared_ptr<edm_entity_set> et)
+	{
 		if (et)
 		{
-		    m_entity_sets[et->get_name()] = et;
+			m_entity_sets[et->get_name()] = et;
 		}
-    }
+	}
 
-    /// <summary>
-    /// 
-    /// </summary>
+	/// <summary>
+	///
+	/// </summary>
 	void add_singleton(std::shared_ptr<edm_singleton> sg)
 	{
 		if (sg)
@@ -70,76 +70,75 @@ public:
 	}
 
 	/// <summary>
-    /// 
-    /// </summary>
-	const std::unordered_map<::utility::string_t, std::shared_ptr<edm_operation_import>>& get_operation_imports() const
+	///
+	/// </summary>
+	const std::unordered_map<::odata::string_t, std::shared_ptr<edm_operation_import>>& get_operation_imports() const
 	{
 		return m_operation_imports;
 	}
 
-	const std::unordered_map<::utility::string_t, std::shared_ptr<edm_singleton>>& get_singletons() const
+	const std::unordered_map<::odata::string_t, std::shared_ptr<edm_singleton>>& get_singletons() const
 	{
 		return m_singletons;
 	}
 
-    /// <summary>
-    /// 
-    /// </summary>
+	/// <summary>
+	///
+	/// </summary>
 	void add_operation_import(std::shared_ptr<edm_operation_import> op)
 	{
 		if (op)
 		{
-		    m_operation_imports[op->get_name()] = op;
+			m_operation_imports[op->get_name()] = op;
 		}
 	}
 
-    /// <summary>
-    /// Gets the beginning iterator of the properties of the type
-    /// </summary>
-    std::unordered_map<::utility::string_t, std::shared_ptr<edm_entity_set>>::const_iterator begin() const
-    {
-        return m_entity_sets.cbegin();
-    }
+	/// <summary>
+	/// Gets the beginning iterator of the properties of the type
+	/// </summary>
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_entity_set>>::const_iterator begin() const
+	{
+		return m_entity_sets.cbegin();
+	}
 
-    /// <summary>
-    /// Gets the end iterator of the properties of the type
-    /// </summary>
-    std::unordered_map<::utility::string_t, std::shared_ptr<edm_entity_set>>::const_iterator end() const
-    {
-        return m_entity_sets.cend();
-    }
+	/// <summary>
+	/// Gets the end iterator of the properties of the type
+	/// </summary>
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_entity_set>>::const_iterator end() const
+	{
+		return m_entity_sets.cend();
+	}
 
-    /// <summary>
-    /// Looks up an entity set of the container by name.
-    /// </summary>
-    /// <param name="name">The qualified or unqualified name of the entity set.</param>
-    /// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
-    ODATACPP_CLIENT_API std::shared_ptr<edm_entity_set> find_entity_set(::utility::string_t name) const;
+	/// <summary>
+	/// Looks up an entity set of the container by name.
+	/// </summary>
+	/// <param name="name">The qualified or unqualified name of the entity set.</param>
+	/// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
+	ODATACPP_CLIENT_API std::shared_ptr<edm_entity_set> find_entity_set(::odata::string_t name) const;
 
-    /// <summary>
-    /// Looks up a singleton of the container by name.
-    /// </summary>
-    /// <param name="name">The qualified or unqualified name of the singleton.</param>
-    /// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
-	ODATACPP_CLIENT_API std::shared_ptr<edm_singleton> find_singleton(::utility::string_t name) const;
+	/// <summary>
+	/// Looks up a singleton of the container by name.
+	/// </summary>
+	/// <param name="name">The qualified or unqualified name of the singleton.</param>
+	/// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
+	ODATACPP_CLIENT_API std::shared_ptr<edm_singleton> find_singleton(::odata::string_t name) const;
 
-    /// <summary>
-    /// Looks up an operation import of the container by name.
-    /// </summary>
-    /// <param name="name">The qualified or unqualified name of the operation import.</param>
-    /// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
-    ODATACPP_CLIENT_API std::shared_ptr<edm_operation_import> find_operation_import(::utility::string_t name) const;
+	/// <summary>
+	/// Looks up an operation import of the container by name.
+	/// </summary>
+	/// <param name="name">The qualified or unqualified name of the operation import.</param>
+	/// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
+	ODATACPP_CLIENT_API std::shared_ptr<edm_operation_import> find_operation_import(::odata::string_t name) const;
 
 private:
-    friend class edm_schema;
+	friend class edm_schema;
 
-    bool m_is_default;
-    ::utility::string_t m_name;
-	::utility::string_t m_extends;
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_entity_set>> m_entity_sets;
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_singleton>> m_singletons;
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_operation_import>> m_operation_imports;
-
+	bool m_is_default;
+	::odata::string_t m_name;
+	::odata::string_t m_extends;
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_entity_set>> m_entity_sets;
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_singleton>> m_singletons;
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_operation_import>> m_operation_imports;
 };
 
 }}

--- a/include/odata/edm/edm_entity_set.h
+++ b/include/odata/edm/edm_entity_set.h
@@ -21,26 +21,26 @@ class edm_entity_container;
 class edm_entity_set : public edm_navigation_source
 {
 public:
-    /// <summary>
-    /// Constructor
-    /// </summary>
-    /// <param name="name">The name of the entity set.</param>
-    edm_entity_set(::utility::string_t name, ::utility::string_t type) 
-		: m_type_name(std::move(type)), edm_navigation_source(std::move(name), container_resource_type::E_RESOURCE_ENTITY_SET)
-    {}
+	/// <summary>
+	/// Constructor
+	/// </summary>
+	/// <param name="name">The name of the entity set.</param>
+	edm_entity_set(::odata::string_t name, ::odata::string_t type)
+	:	edm_navigation_source(std::move(name), container_resource_type::E_RESOURCE_ENTITY_SET), m_type_name(std::move(type)), m_entity_type()
+	{}
 
-	edm_entity_set(::utility::string_t name, std::shared_ptr<edm_entity_type> type) 
-		: m_entity_type(type), edm_navigation_source(std::move(name), container_resource_type::E_RESOURCE_ENTITY_SET)
-    {}
+	edm_entity_set(::odata::string_t name, std::shared_ptr<edm_entity_type> type)
+	:	edm_navigation_source(std::move(name), container_resource_type::E_RESOURCE_ENTITY_SET), m_type_name(), m_entity_type(type)
+	{}
 
-    /// <summary>
-    /// Gets the name of the type of the entity set
-    /// </summary>
-    /// <returns>The name of the type of the entity set.</returns>
-    const ::utility::string_t& get_entity_type_name() const 
-    {
-        return m_type_name;
-    }
+	/// <summary>
+	/// Gets the name of the type of the entity set
+	/// </summary>
+	/// <returns>The name of the type of the entity set.</returns>
+	const ::odata::string_t& get_entity_type_name() const
+	{
+		return m_type_name;
+	}
 
 	std::shared_ptr<edm_entity_type> get_entity_type() const
 	{
@@ -53,8 +53,8 @@ public:
 	}
 
 private:
-    friend class edm_entity_container;
-    ::utility::string_t m_type_name;
+	friend class edm_entity_container;
+	::odata::string_t m_type_name;
 	std::weak_ptr<edm_entity_type> m_entity_type;
 };
 

--- a/include/odata/edm/edm_model.h
+++ b/include/odata/edm/edm_model.h
@@ -15,78 +15,77 @@ namespace odata { namespace edm
 class edm_model
 {
 public:
-    std::shared_ptr<edm_schema> operator[](const ::utility::string_t& name)
-    {
-        for (size_t i = 0; i < m_schemata.size(); ++i)
-        {
-            if (m_schemata[i]->get_name() == name)
-            {
-                return m_schemata[i];
-            }
-        }
-        return nullptr;
-    }
-    
-    std::shared_ptr<edm_schema> add_schema(const ::utility::string_t& name, const ::utility::string_t& alias)
-    {
-        auto val = std::make_shared<edm_schema>(name, alias);
-        m_schemata.push_back(val);
-        return val;
-    }
+	std::shared_ptr<edm_schema> operator[](const ::odata::string_t& name)
+	{
+		for (size_t i = 0; i < m_schemata.size(); ++i)
+		{
+			if (m_schemata[i]->get_name() == name)
+			{
+				return m_schemata[i];
+			}
+		}
+		return nullptr;
+	}
+
+	std::shared_ptr<edm_schema> add_schema(const ::odata::string_t& name, const ::odata::string_t& alias)
+	{
+		m_schemata.emplace_back(::odata::make_shared<edm_schema>(name, alias));
+		return m_schemata.back();
+	}
 
 	const std::vector<std::shared_ptr<edm_schema>>& get_schema()
 	{
 		return m_schemata;
 	}
 
-	const ::utility::string_t& get_version() const
+	const ::odata::string_t& get_version() const
 	{
 		return m_version;
 	}
 
-	void set_version(::utility::string_t version)
+	void set_version(::odata::string_t version)
 	{
 		m_version = std::move(version);
 	}
 
-    /// <summary>
-    /// Looks up an entity type of the schema by name.
-    /// </summary>
-    /// <param name="name">The qualified or unqualified name of the entity type.</param>
-    /// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
-    ODATACPP_CLIENT_API std::shared_ptr<edm_entity_type> find_entity_type(::utility::string_t name) const;
-
-    /// <summary>
-    /// Looks up a complex type of the schema by name.
-    /// </summary>
-    /// <param name="name">The qualified or unqualified name of the entity type.</param>
-    /// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
-    ODATACPP_CLIENT_API std::shared_ptr<edm_complex_type> find_complex_type(::utility::string_t name) const;
+	/// <summary>
+	/// Looks up an entity type of the schema by name.
+	/// </summary>
+	/// <param name="name">The qualified or unqualified name of the entity type.</param>
+	/// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
+	ODATACPP_CLIENT_API std::shared_ptr<edm_entity_type> find_entity_type(::odata::string_t name) const;
 
 	/// <summary>
-    /// Looks up an enum type of the schema by name.
-    /// </summary>
-    /// <param name="name">The qualified or unqualified name of the enum type.</param>
-    /// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
-	ODATACPP_CLIENT_API std::shared_ptr<edm_enum_type> find_enum_type(::utility::string_t name) const;
+	/// Looks up a complex type of the schema by name.
+	/// </summary>
+	/// <param name="name">The qualified or unqualified name of the entity type.</param>
+	/// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
+	ODATACPP_CLIENT_API std::shared_ptr<edm_complex_type> find_complex_type(::odata::string_t name) const;
 
 	/// <summary>
-    /// Looks up an operation type of the schema by name.
-    /// </summary>
-    /// <param name="name">The qualified or unqualified name of the operation type.</param>
-    /// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
-	ODATACPP_CLIENT_API std::shared_ptr<edm_operation_type> find_operation_type(::utility::string_t name) const;
+	/// Looks up an enum type of the schema by name.
+	/// </summary>
+	/// <param name="name">The qualified or unqualified name of the enum type.</param>
+	/// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
+	ODATACPP_CLIENT_API std::shared_ptr<edm_enum_type> find_enum_type(::odata::string_t name) const;
 
-    /// <summary>
-    /// Looks up an entity container of the schema by name.
-    /// </summary>
-    /// <param name="name">The qualified or unqualified name of the entity container; an empty string refers to the default container</param>
-    /// <returns>A pointer to the container if found, an empty pointer otherwise.</returns>
-    ODATACPP_CLIENT_API std::shared_ptr<edm_entity_container> find_container(::utility::string_t name = U("")) const;
+	/// <summary>
+	/// Looks up an operation type of the schema by name.
+	/// </summary>
+	/// <param name="name">The qualified or unqualified name of the operation type.</param>
+	/// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
+	ODATACPP_CLIENT_API std::shared_ptr<edm_operation_type> find_operation_type(::odata::string_t name) const;
+
+	/// <summary>
+	/// Looks up an entity container of the schema by name.
+	/// </summary>
+	/// <param name="name">The qualified or unqualified name of the entity container; an empty string refers to the default container</param>
+	/// <returns>A pointer to the container if found, an empty pointer otherwise.</returns>
+	ODATACPP_CLIENT_API std::shared_ptr<edm_entity_container> find_container(::odata::string_t name = _XPLATSTR("")) const;
 
 private:
-    std::vector<std::shared_ptr<edm_schema>> m_schemata;
-	::utility::string_t  m_version;
+	std::vector<std::shared_ptr<edm_schema>> m_schemata;
+	::odata::string_t  m_version;
 };
 
 }}

--- a/include/odata/edm/edm_model_reader.h
+++ b/include/odata/edm/edm_model_reader.h
@@ -16,41 +16,41 @@ namespace odata { namespace edm
 class edm_model_reader : public ::odata::common::xml_reader
 {
 public:
-    edm_model_reader(concurrency::streams::istream stream) : 
-		xml_reader(stream), m_parsing_key(false), m_model(std::make_shared<edm_model>()), 
-		m_current_st(nullptr), m_current_enum(nullptr), m_current_operation(nullptr)
-    {
-    }
+	edm_model_reader(concurrency::streams::istream stream) :
+	xml_reader(stream), m_parsing_key(false), m_model(::odata::make_shared<edm_model>()),
+	m_current_st(nullptr), m_current_enum(nullptr), m_current_operation(nullptr)
+	{
+	}
 
-    std::shared_ptr<edm_model> get_model()
-    {
-        return m_model;
-    }
+	std::shared_ptr<edm_model> get_model()
+	{
+		return m_model;
+	}
 
 	ODATACPP_CLIENT_API bool parse();
 
 protected:
-    ODATACPP_CLIENT_API virtual void handle_begin_element(const ::utility::string_t& elementName);
-    ODATACPP_CLIENT_API virtual void handle_end_element(const ::utility::string_t& elementName);
-    ODATACPP_CLIENT_API virtual void handle_element(const ::utility::string_t& elementName);
+	ODATACPP_CLIENT_API virtual void handle_begin_element(const ::odata::string_t& elementName);
+	ODATACPP_CLIENT_API virtual void handle_end_element(const ::odata::string_t& elementName);
+	ODATACPP_CLIENT_API virtual void handle_element(const ::odata::string_t& elementName);
 
 
 private:
-    void _process_property();
+	void _process_property();
 	void _process_navigation_property();
 	void _process_operation_parameter();
 	void _process_operation_return_type();
 	void _process_navigation_property_binding();
 
-    bool m_parsing_key;
+	bool m_parsing_key;
 
-    // These variables are used to cache values for each entity
-    std::shared_ptr<edm_model> m_model;
-    std::shared_ptr<edm_schema> m_current_schema;
-    std::shared_ptr<edm_entity_container> m_current_container;
+	// These variables are used to cache values for each entity
+	std::shared_ptr<edm_model> m_model;
+	std::shared_ptr<edm_schema> m_current_schema;
+	std::shared_ptr<edm_entity_container> m_current_container;
 	std::shared_ptr<edm_entity_set> m_current_entity_set;
 	std::shared_ptr<edm_singleton> m_current_singleton;
-    edm_structured_type* m_current_st;
+	edm_structured_type* m_current_st;
 	edm_enum_type* m_current_enum;
 	edm_operation_type* m_current_operation;
 };

--- a/include/odata/edm/edm_model_utility.h
+++ b/include/odata/edm/edm_model_utility.h
@@ -14,20 +14,20 @@ namespace odata { namespace edm
 class edm_model_utility
 {
 public:
-	ODATACPP_CLIENT_API static std::shared_ptr<edm_named_type> get_edm_type_from_name(const ::utility::string_t& type_name);
-	ODATACPP_CLIENT_API static ::utility::string_t get_strong_type_name_from_edm_type_name(const std::shared_ptr<edm_primitive_type>& primitive_type);
-	ODATACPP_CLIENT_API static ::utility::string_t get_strong_type_default_value_from_edm_type_name(const std::shared_ptr<edm_primitive_type>& primitive_type);
-	ODATACPP_CLIENT_API static std::shared_ptr<edm_named_type> get_edm_primitive_type_from_name(const ::utility::string_t& type_name);
-    ODATACPP_CLIENT_API static ::utility::string_t get_type_kind_name_from_edm_type(const std::shared_ptr<edm_named_type>& ptype);
-    ODATACPP_CLIENT_API static bool get_primitive_kind_from_edm_type(const std::shared_ptr<edm_named_type>& edm_type, edm_primitive_type_kind_t& primitive_kind);
+	ODATACPP_CLIENT_API static std::shared_ptr<edm_named_type> get_edm_type_from_name(const ::odata::string_t& type_name);
+	ODATACPP_CLIENT_API static ::odata::string_t get_strong_type_name_from_edm_type_name(const std::shared_ptr<edm_primitive_type>& primitive_type);
+	ODATACPP_CLIENT_API static ::odata::string_t get_strong_type_default_value_from_edm_type_name(const std::shared_ptr<edm_primitive_type>& primitive_type);
+	ODATACPP_CLIENT_API static std::shared_ptr<edm_named_type> get_edm_primitive_type_from_name(const ::odata::string_t& type_name);
+	ODATACPP_CLIENT_API static ::odata::string_t get_type_kind_name_from_edm_type(const std::shared_ptr<edm_named_type>& ptype);
+	ODATACPP_CLIENT_API static bool get_primitive_kind_from_edm_type(const std::shared_ptr<edm_named_type>& edm_type, edm_primitive_type_kind_t& primitive_kind);
 	ODATACPP_CLIENT_API static void resolve_edm_types_after_parsing(const std::shared_ptr<edm_model>& model);
-	ODATACPP_CLIENT_API static std::shared_ptr<::odata::edm::edm_named_type> get_property_type_from_name(const std::shared_ptr<::odata::edm::edm_entity_type>& entity_type, const ::utility::string_t& property_name);
+	ODATACPP_CLIENT_API static std::shared_ptr<::odata::edm::edm_named_type> get_property_type_from_name(const std::shared_ptr<::odata::edm::edm_entity_type>& entity_type, const ::odata::string_t& property_name);
 
 	ODATACPP_CLIENT_API static std::shared_ptr<edm_named_type> get_collection_element_type(const std::shared_ptr<edm_named_type>& input_type);
 	ODATACPP_CLIENT_API static std::shared_ptr<edm_named_type> get_navigation_element_type(const std::shared_ptr<edm_named_type>& input_type);
 
 private:
-	static std::shared_ptr<edm_named_type> resolve_type_from_name(const std::shared_ptr<edm_model>& model, ::utility::string_t qualified_name);
+	static std::shared_ptr<edm_named_type> resolve_type_from_name(const std::shared_ptr<edm_model>& model, ::odata::string_t qualified_name);
 	static void resolve_type_under_structured_type(const std::shared_ptr<edm_model>& model, const std::shared_ptr<edm_structured_type>& structyred_type);
 	static void resolve_type_under_operation_type(const std::shared_ptr<edm_model>& model, const std::shared_ptr<edm_operation_type>& operationType);
 	static std::shared_ptr<edm_named_type> resolve_undetermined_type(const std::shared_ptr<edm_model>& model, const std::shared_ptr<edm_named_type>& undeterminedType);
@@ -35,8 +35,8 @@ private:
 	static void resovle_entity_base_type(const std::shared_ptr<edm_model>& model, const std::shared_ptr<edm_entity_type>& entity_type);
 	static void resovle_complex_base_type(const std::shared_ptr<edm_model>& model, const std::shared_ptr<edm_complex_type>& complex_type);
 	static void resolve_navigation_path_for_non_contained_navigation(const std::shared_ptr<edm_model>& model, const std::shared_ptr<edm_entity_container>& entity_container);
-	static ::utility::string_t get_collection_element_name(const ::utility::string_t& collection_full_name);
-	static std::shared_ptr<edm_navigation_type> get_navigation_property_from_path(const std::shared_ptr<edm_model>& model, const std::shared_ptr<edm_entity_type>& entity_type, const ::utility::string_t& navigation_path);
+	static ::odata::string_t get_collection_element_name(const ::odata::string_t& collection_full_name);
+	static std::shared_ptr<edm_navigation_type> get_navigation_property_from_path(const std::shared_ptr<edm_model>& model, const std::shared_ptr<edm_entity_type>& entity_type, const ::odata::string_t& navigation_path);
 };
 
 }}

--- a/include/odata/edm/edm_navigation_source.h
+++ b/include/odata/edm/edm_navigation_source.h
@@ -21,32 +21,31 @@ enum container_resource_type
 class edm_navigation_source
 {
 public:
-	edm_navigation_source(::utility::string_t name, container_resource_type resource_type) : m_name(std::move(name)), m_resource_type(resource_type)
+	edm_navigation_source(::odata::string_t name, container_resource_type resource_type) : m_name(std::move(name)), m_resource_type(resource_type)
 	{}
 
-	virtual ~edm_navigation_source()
-	{}
+	virtual ~edm_navigation_source() = default;
 
-	void add_navigation_source(const ::utility::string_t& property_path_name, const ::utility::string_t& target_name)
+	void add_navigation_source(const ::odata::string_t& property_path_name, const ::odata::string_t& target_name)
 	{
 		navigation_property_mapping[property_path_name] = target_name;
 	}
 
-	::utility::string_t get_navigation_source_name(const ::utility::string_t& property_path_name)
+	::odata::string_t get_navigation_source_name(const ::odata::string_t& property_path_name)
 	{
 		return navigation_property_mapping[property_path_name];
 	}
 
-	const std::unordered_map<::utility::string_t, ::utility::string_t>& get_navigation_sources() const
+	const std::unordered_map<::odata::string_t, ::odata::string_t>& get_navigation_sources() const
 	{
 		return navigation_property_mapping;
 	}
 
 
-    const ::utility::string_t& get_name() const 
-    {
-        return m_name;
-    }
+	const ::odata::string_t& get_name() const
+	{
+		return m_name;
+	}
 
 	container_resource_type get_resource_type() const
 	{
@@ -54,8 +53,8 @@ public:
 	}
 
 protected:
-	std::unordered_map<::utility::string_t, ::utility::string_t> navigation_property_mapping;
-    ::utility::string_t m_name;
+	std::unordered_map<::odata::string_t, ::odata::string_t> navigation_property_mapping;
+	::odata::string_t m_name;
 	container_resource_type m_resource_type;
 };
 

--- a/include/odata/edm/edm_operation_import.h
+++ b/include/odata/edm/edm_operation_import.h
@@ -15,7 +15,7 @@ namespace odata { namespace edm
 class edm_entity_container;
 
 /// <summary>
-/// 
+///
 /// </summary>
 enum OperationImportKind
 {
@@ -29,13 +29,13 @@ enum OperationImportKind
 class edm_operation_import
 {
 public:
-	edm_operation_import(::utility::string_t name, ::utility::string_t operation_name, ::utility::string_t entity_set_path, bool is_in_service_document, OperationImportKind operation_import_kind) :
+	edm_operation_import(::odata::string_t name, ::odata::string_t operation_name, ::odata::string_t entity_set_path, bool is_in_service_document, OperationImportKind operation_import_kind) :
 		m_name(std::move(name)), m_operation_name(std::move(operation_name)), m_entity_set_path(std::move(entity_set_path)), m_is_in_service_document(is_in_service_document), m_operation_import_kind(operation_import_kind)
 	{
 		m_operation_type = nullptr;
 	}
 
-	const ::utility::string_t get_name() const
+	const ::odata::string_t get_name() const
 	{
 		return m_name;
 	}
@@ -53,10 +53,10 @@ public:
 private:
 	friend class edm_entity_container;
 
-	::utility::string_t m_name;
-	::utility::string_t m_operation_name;
+	::odata::string_t m_name;
+	::odata::string_t m_operation_name;
 	std::shared_ptr<edm_operation_type> m_operation_type;
-	::utility::string_t m_entity_set_path;
+	::odata::string_t m_entity_set_path;
 	bool m_is_in_service_document;
 	OperationImportKind m_operation_import_kind;
 };

--- a/include/odata/edm/edm_schema.h
+++ b/include/odata/edm/edm_schema.h
@@ -15,141 +15,146 @@ namespace odata { namespace edm
 class edm_model_utility;
 
 /// <summary>
-/// 
+///
 /// </summary>
 class edm_schema
 {
 public:
-    /// <summary>
-    /// 
-    /// </summary>
-    edm_schema()
-    {
-    }
-
-    /// <summary>
-    /// 
-    /// </summary>
-    edm_schema(::utility::string_t namesp, ::utility::string_t alias) :
-        m_namespace(std::move(namesp)), m_alias(std::move(alias))
-    {
-    }
-
-    /// <summary>
-    /// Adds an entity type to the schema
-    /// </summary>
-    void add_entity_type(std::shared_ptr<edm_entity_type> et)
-    {
-        m_entity_types[et->get_name()] = et;
-    }
-
-    /// <summary>
-    /// Adds an complex type to the schema
-    /// </summary>
-    void add_complex_type(std::shared_ptr<edm_complex_type> et)
-    {
-        m_complex_types[et->get_name()] = et;
-    }
+	/// <summary>
+	///
+	/// </summary>
+	edm_schema()
+	{
+	}
 
 	/// <summary>
-    /// 
-    /// </summary>
-    void add_enum_type(std::shared_ptr<edm_enum_type> et)
-    {
-        m_enum_types[et->get_name()] = et;
-    }
+	///
+	/// </summary>
+	edm_schema(::odata::string_t namesp, ::odata::string_t alias) :
+		m_namespace(std::move(namesp)), m_alias(std::move(alias))
+	{
+	}
 
 	/// <summary>
-    /// 
-    /// </summary>
+	/// Adds an entity type to the schema
+	/// </summary>
+	void add_entity_type(std::shared_ptr<edm_entity_type> et)
+	{
+		m_entity_types[et->get_name()] = et;
+	}
+
+	/// <summary>
+	/// Adds an complex type to the schema
+	/// </summary>
+	void add_complex_type(std::shared_ptr<edm_complex_type> et)
+	{
+		m_complex_types[et->get_name()] = et;
+	}
+
+	/// <summary>
+	///
+	/// </summary>
+	void add_enum_type(std::shared_ptr<edm_enum_type> et)
+	{
+		m_enum_types[et->get_name()] = et;
+	}
+
+	/// <summary>
+	///
+	/// </summary>
 	void add_operation_type(std::shared_ptr<edm_operation_type> et)
-    {
-        m_operation_types[et->get_name()] = et;
-    }	
-
-    /// <summary>
-    /// 
-    /// </summary>
-    void add_container(std::shared_ptr<edm_entity_container> et)
-    {
-        m_entity_containers[et->get_name()] = et;
-    }
-
-    /// <summary>
-    /// Looks up an entity type of the schema by name.
-    /// </summary>
-    /// <param name="name">The qualified or unqualified name of the entity type.</param>
-    /// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
-    ODATACPP_CLIENT_API std::shared_ptr<edm_entity_type> find_entity_type(::utility::string_t name) const;
-
-    /// <summary>
-    /// Looks up a complex type of the schema by name.
-    /// </summary>
-    /// <param name="name">The qualified or unqualified name of the complex type.</param>
-    /// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
-    ODATACPP_CLIENT_API std::shared_ptr<edm_complex_type> find_complex_type(::utility::string_t name) const;
+	{
+		m_operation_types[et->get_name()] = et;
+	}
 
 	/// <summary>
-    /// Looks up an enum type of the schema by name.
-    /// </summary>
-    /// <param name="name">The qualified or unqualified name of the enum type.</param>
-    /// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
-	ODATACPP_CLIENT_API std::shared_ptr<edm_enum_type> find_enum_type(::utility::string_t name) const;
+	///
+	/// </summary>
+	void add_container(std::shared_ptr<edm_entity_container> et)
+	{
+		m_entity_containers[et->get_name()] = et;
+	}
 
 	/// <summary>
-    /// Looks up an operation type of the schema by name.
-    /// </summary>
-    /// <param name="name">The qualified or unqualified name of the entity type.</param>
-    /// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
-	ODATACPP_CLIENT_API std::shared_ptr<edm_operation_type> find_operation_type(::utility::string_t name) const;
+	/// Looks up an entity type of the schema by name.
+	/// </summary>
+	/// <param name="name">The qualified or unqualified name of the entity type.</param>
+	/// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
+	ODATACPP_CLIENT_API std::shared_ptr<edm_entity_type> find_entity_type(::odata::string_t name) const;
 
-    /// <summary>
-    /// Looks up an entity container of the schema by name.
-    /// </summary>
-    /// <param name="name">The qualified or unqualified name of the entity container; an empty string refers to the default container</param>
-    /// <returns>A pointer to the container if found, an empty pointer otherwise.</returns>
-    ODATACPP_CLIENT_API std::shared_ptr<edm_entity_container> find_container(::utility::string_t name = U("")) const;
+	/// <summary>
+	/// Looks up a complex type of the schema by name.
+	/// </summary>
+	/// <param name="name">The qualified or unqualified name of the complex type.</param>
+	/// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
+	ODATACPP_CLIENT_API std::shared_ptr<edm_complex_type> find_complex_type(::odata::string_t name) const;
 
-    const std::unordered_map<::utility::string_t, std::shared_ptr<edm_entity_type>>& get_entity_types() const
-    {
-        return m_entity_types;
-    }
+	/// <summary>
+	/// Looks up an enum type of the schema by name.
+	/// </summary>
+	/// <param name="name">The qualified or unqualified name of the enum type.</param>
+	/// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
+	ODATACPP_CLIENT_API std::shared_ptr<edm_enum_type> find_enum_type(::odata::string_t name) const;
 
-    const std::unordered_map<::utility::string_t, std::shared_ptr<edm_complex_type>>& get_complex_types() const
-    {
-        return m_complex_types;
-    }
+	/// <summary>
+	/// Looks up an operation type of the schema by name.
+	/// </summary>
+	/// <param name="name">The qualified or unqualified name of the entity type.</param>
+	/// <returns>A pointer to the type if found, an empty pointer otherwise.</returns>
+	ODATACPP_CLIENT_API std::shared_ptr<edm_operation_type> find_operation_type(::odata::string_t name) const;
 
-	const std::unordered_map<::utility::string_t, std::shared_ptr<edm_enum_type>>& get_enum_types() const
-    {
-        return m_enum_types;
-    }
+	/// <summary>
+	/// Looks up an entity container of the schema by name.
+	/// </summary>
+	/// <param name="name">The qualified or unqualified name of the entity container; an empty string refers to the default container</param>
+	/// <returns>A pointer to the container if found, an empty pointer otherwise.</returns>
+	ODATACPP_CLIENT_API std::shared_ptr<edm_entity_container> find_container(::odata::string_t name = _XPLATSTR("")) const;
 
-    const std::unordered_map<::utility::string_t, std::shared_ptr<edm_operation_type>>& get_operation_types() const
-    {
-        return m_operation_types;
-    }
+	const std::unordered_map<::odata::string_t, std::shared_ptr<edm_entity_type>>& get_entity_types() const
+	{
+		return m_entity_types;
+	}
 
-    const std::unordered_map<::utility::string_t, std::shared_ptr<edm_entity_container>>& get_containers() const
-    {
-        return m_entity_containers;
-    }
+	const std::unordered_map<::odata::string_t, std::shared_ptr<edm_complex_type>>& get_complex_types() const
+	{
+		return m_complex_types;
+	}
 
-    const ::utility::string_t& get_name() const
-    {
-        return m_namespace;
-    }
+	const std::unordered_map<::odata::string_t, std::shared_ptr<edm_enum_type>>& get_enum_types() const
+	{
+		return m_enum_types;
+	}
+
+	const std::unordered_map<::odata::string_t, std::shared_ptr<edm_operation_type>>& get_operation_types() const
+	{
+		return m_operation_types;
+	}
+
+	const std::unordered_map<::odata::string_t, std::shared_ptr<edm_entity_container>>& get_containers() const
+	{
+		return m_entity_containers;
+	}
+
+	const ::odata::string_t& get_name() const
+	{
+		return m_namespace;
+	}
+
+	const ::odata::string_t& get_alias() const
+	{
+		return m_alias;
+	}
 
 private:
 	friend class edm_model_utility;
 
-    ::utility::string_t m_namespace;
-    ::utility::string_t m_alias;
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_entity_type>> m_entity_types;
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_complex_type>> m_complex_types;
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_enum_type>> m_enum_types;
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_operation_type>> m_operation_types;
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_entity_container>> m_entity_containers;
+	::odata::string_t m_namespace;
+	::odata::string_t m_alias;
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_entity_type>> m_entity_types;
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_complex_type>> m_complex_types;
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_enum_type>> m_enum_types;
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_operation_type>> m_operation_types;
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_entity_container>> m_entity_containers;
 
 	std::vector<std::shared_ptr<edm_collection_type>> m_collection_navigation_types;
 };

--- a/include/odata/edm/edm_singleton.h
+++ b/include/odata/edm/edm_singleton.h
@@ -20,35 +20,35 @@ class edm_entity_container;
 class edm_singleton  : public edm_navigation_source
 {
 public:
-    /// <summary>
-    /// Constructor
-    /// </summary>
-    /// <param name="name">The name of the entity set.</param>
-    edm_singleton(::utility::string_t name, ::utility::string_t type) 
-		: m_type_name(std::move(type)), edm_navigation_source(std::move(name), container_resource_type::E_RESOURCE_SINGLETON)
-    {}
+	/// <summary>
+	/// Constructor
+	/// </summary>
+	/// <param name="name">The name of the entity set.</param>
+	edm_singleton(::odata::string_t name, ::odata::string_t type)
+	:	edm_navigation_source(std::move(name), container_resource_type::E_RESOURCE_SINGLETON), m_type_name(std::move(type)), m_entity_type()
+	{}
 
-	edm_singleton(::utility::string_t name, std::shared_ptr<edm_entity_type> type) 
-		: m_entity_type(std::move(type)), edm_navigation_source(std::move(name), container_resource_type::E_RESOURCE_SINGLETON)
-    {}
+	edm_singleton(::odata::string_t name, std::shared_ptr<edm_entity_type> type)
+	:	edm_navigation_source(std::move(name), container_resource_type::E_RESOURCE_SINGLETON), m_type_name(), m_entity_type(std::move(type))
+	{}
 
-    /// <summary>
-    /// Gets the name of the entity set
-    /// </summary>
-    /// <returns>The name of the entity set.</returns>
-    const ::utility::string_t& get_name() const 
-    {
-        return m_name;
-    }
+	/// <summary>
+	/// Gets the name of the entity set
+	/// </summary>
+	/// <returns>The name of the entity set.</returns>
+	const ::odata::string_t& get_name() const
+	{
+		return m_name;
+	}
 
-    /// <summary>
-    /// Gets the name of the type of the entity set
-    /// </summary>
-    /// <returns>The name of the type of the entity set.</returns>
-    const ::utility::string_t& get_entity_type_name() const 
-    {
-        return m_type_name;
-    }
+	/// <summary>
+	/// Gets the name of the type of the entity set
+	/// </summary>
+	/// <returns>The name of the type of the entity set.</returns>
+	const ::odata::string_t& get_entity_type_name() const
+	{
+		return m_type_name;
+	}
 
 	std::shared_ptr<edm_entity_type> get_entity_type() const
 	{
@@ -61,8 +61,8 @@ public:
 	}
 
 private:
-    friend class edm_entity_container;
-    ::utility::string_t m_type_name;
+	friend class edm_entity_container;
+	::odata::string_t m_type_name;
 	std::weak_ptr<edm_entity_type> m_entity_type;
 };
 

--- a/include/odata/edm/edm_type.h
+++ b/include/odata/edm/edm_type.h
@@ -8,7 +8,7 @@
 
 #include "odata/common/utility.h"
 
-namespace odata { namespace edm 
+namespace odata { namespace edm
 {
 
 #define undefined_value 0xffffffff
@@ -22,11 +22,11 @@ class edm_model_reader;
 enum edm_type_kind_t
 {
 	None,
-    Primitive,
-    Entity,
-    Complex,
-    Collection,
-    Enum,
+	Primitive,
+	Entity,
+	Complex,
+	Collection,
+	Enum,
 	Link,
 	Navigation,
 	Operation,
@@ -41,75 +41,71 @@ enum edm_primitive_type_kind_t
 {
 	NoneVal,
 	Binary,
-    Boolean,
+	Boolean,
 	Byte,
-    DateTimeOffset,
+	DateTimeOffset,
 	Duration,
-    Decimal,
-    Double,
-    Guid,
-    Int16,
-    Int32,
-    Int64,
-    SByte,
-    Single,
-    String,
-    Stream,
+	Decimal,
+	Double,
+	Guid,
+	Int16,
+	Int32,
+	Int64,
+	SByte,
+	Single,
+	String,
+	Stream,
 };
 
 class edm_named_type
 {
 public:
-	edm_named_type() :  m_type_kind(edm_type_kind_t::None), m_name(U("")), m_namespace(U(""))
+	edm_named_type() :  m_name(), m_namespace(), m_type_kind(edm_type_kind_t::None)
 	{
 	}
 
-	edm_named_type(edm_type_kind_t type_kind) :  m_type_kind(type_kind), m_name(U("")), m_namespace(U(""))
+	edm_named_type(edm_type_kind_t type_kind) :  m_name(), m_namespace(), m_type_kind(type_kind)
 	{
 	}
 
-	edm_named_type(::utility::string_t name, ::utility::string_t name_space, edm_type_kind_t type_kind)
-		: m_type_kind(type_kind), m_name(std::move(name)), m_namespace(std::move(name_space))
+	edm_named_type(::odata::string_t name, ::odata::string_t name_space, edm_type_kind_t type_kind)
+		: m_name(std::move(name)), m_namespace(std::move(name_space)), m_type_kind(type_kind)
 	{
 	}
 
-    virtual ~edm_named_type()
+	virtual ~edm_named_type() = default;
+
+	const ::odata::string_t& get_name() const
 	{
+		return m_name;
 	}
 
-    const ::utility::string_t& get_name() const 
-    {
-        return m_name;
-    }
-
-	::utility::string_t get_full_name()
+	::odata::string_t get_full_name() const
 	{
 		if (m_namespace.empty())
 		{
 			return m_name;
 		}
-		else
-		{
-		    return m_namespace + U(".") + m_name;
-		}
+
+		return m_namespace + _XPLATSTR(".") + m_name;
 	}
 
-	void set_name(::utility::string_t name)
+	void set_name(::odata::string_t name)
 	{
 		m_name = std::move(name);
 	}
 
-    const ::utility::string_t& get_namespace() const 
-    {
-        return m_namespace;
-    }
+	const ::odata::string_t& get_namespace() const
+	{
+		return m_namespace;
+	}
 
-	void set_namespace(::utility::string_t name_space)
+	void set_namespace(::odata::string_t name_space)
 	{
 		m_namespace = std::move(name_space);
 	}
 
-	const edm_type_kind_t& get_type_kind() const 
+	const edm_type_kind_t& get_type_kind() const
 	{
 		return m_type_kind;
 	}
@@ -125,10 +121,10 @@ protected:
 	static std::mutex &mutex();
 
 protected:
-    friend class edm_schema;
+	friend class edm_schema;
 
-	::utility::string_t m_name;
-	::utility::string_t m_namespace;
+	::odata::string_t m_name;
+	::odata::string_t m_namespace;
 	edm_type_kind_t m_type_kind;
 
 	static std::shared_ptr<edm_named_type> _EDM_UNKNOWN;
@@ -143,13 +139,8 @@ public:
 	}
 
 	bool type_equal(std::shared_ptr<edm_named_type> type) const
-    {
-        if (!type)
-		{
-			return false;
-		}
-
-		if (type->get_type_kind() == edm_type_kind_t::Primitive)
+	{
+		if (type && type->get_type_kind() == edm_type_kind_t::Primitive)
 		{
 			edm_primitive_type *p_primitive_type = (edm_primitive_type*)type.get();
 			if (p_primitive_type && p_primitive_type->m_primitive_kind == m_primitive_kind)
@@ -159,7 +150,7 @@ public:
 		}
 
 		return false;
-    }
+	}
 
 	ODATACPP_CLIENT_API static std::shared_ptr<edm_primitive_type> BINARY();
 	ODATACPP_CLIENT_API static std::shared_ptr<edm_primitive_type> BOOLEAN();
@@ -179,8 +170,8 @@ public:
 	ODATACPP_CLIENT_API static std::shared_ptr<edm_primitive_type> UNKNOWN();
 
 private:
-	edm_primitive_type(::utility::string_t name, edm_primitive_type_kind_t primitive_kind)
-		: edm_named_type(name, U(""), edm_type_kind_t::Primitive), m_primitive_kind(primitive_kind)
+	edm_primitive_type(::odata::string_t name, edm_primitive_type_kind_t primitive_kind)
+		: edm_named_type(name, _XPLATSTR(""), edm_type_kind_t::Primitive), m_primitive_kind(primitive_kind)
 	{
 	}
 
@@ -213,48 +204,53 @@ private:
 class edm_property_type
 {
 public:
-    /// <summary>
-    /// Constructor
-    /// </summary>
-    edm_property_type() : m_is_nullable(true), m_is_unicode(false), m_maxLength(undefined_value), m_scale(0), m_precision(undefined_value)
-    {
-    }
-
-	edm_property_type(const ::utility::string_t& name) : m_name(name), 
-		m_is_nullable(true), m_is_unicode(false), m_maxLength(undefined_value), m_scale(0), m_precision(undefined_value)
+	/// <summary>
+	/// Constructor
+	/// </summary>
+	edm_property_type()
+	:	m_is_nullable(true), m_is_unicode(false), m_name(), m_default(), m_maxLength(undefined_value), m_scale(0), m_precision(undefined_value), m_type()
 	{
 	}
 
-    edm_property_type(const ::utility::string_t& name, bool is_nullable, unsigned int max_length, bool is_unicode, unsigned int scale) : 
-        m_name(name), m_is_nullable(is_nullable), m_is_unicode(is_unicode), m_maxLength(max_length), m_scale(scale), m_precision(undefined_value)
-    {
-    }
+	edm_property_type(const ::odata::string_t& name)
+	:	m_is_nullable(true), m_is_unicode(false), m_name(name), m_default(), m_maxLength(undefined_value), m_scale(0), m_precision(undefined_value), m_type()
+	{
+	}
 
-    edm_property_type(const ::utility::string_t& name, bool is_nullable, std::shared_ptr<edm_named_type> type) : 
-        m_name(name), m_is_nullable(is_nullable), m_type(type), m_is_unicode(false), m_maxLength(undefined_value), m_scale(0), m_precision(undefined_value)
-    {
-    }
+	edm_property_type(const ::odata::string_t& name, bool is_nullable, unsigned int max_length, bool is_unicode, unsigned int scale) :
+		m_is_nullable(is_nullable), m_is_unicode(is_unicode), m_name(name), m_default(), m_maxLength(max_length), m_scale(scale), m_precision(undefined_value), m_type()
+	{
+	}
 
+	edm_property_type(const ::odata::string_t& name, bool is_nullable, std::shared_ptr<edm_named_type> type) :
+		m_is_nullable(is_nullable), m_is_unicode(false), m_name(name), m_default(), m_maxLength(undefined_value), m_scale(0), m_precision(undefined_value), m_type(type)
+	{
+	}
 
-    /// <summary>
-    /// Gets the (unqualified) name of the property.
-    /// </summary>
-    /// <returns>The name of the property.</returns>
-    const ::utility::string_t& get_name() const 
-    {
-        return m_name;
-    }
+	/// <summary>
+	/// Gets the (unqualified) name of the property.
+	/// </summary>
+	/// <returns>The name of the property.</returns>
+	const ::odata::string_t& get_name() const
+	{
+		return m_name;
+	}
 
-    /// <summary>
-    /// Gets the nullable property of the property
-    /// </summary>
-    /// <returns>true if the property can be absent in a entity, false otherwise</returns>
-    bool is_nullable() const
-    {
-        return m_is_nullable;
-    }
+	/// <summary>
+	/// Gets the nullable property of the property
+	/// </summary>
+	/// <returns>true if the property can be absent in a entity, false otherwise</returns>
+	bool is_nullable() const
+	{
+		return m_is_nullable;
+	}
 
 	std::shared_ptr<edm_named_type> get_property_type()
+	{
+		return m_type;
+	}
+
+	std::shared_ptr<edm_named_type const> const& get_property_type() const
 	{
 		return m_type;
 	}
@@ -264,27 +260,27 @@ public:
 		m_type = type;
 	}
 
-    void set_precision(unsigned int precision)
+	void set_precision(unsigned int precision)
 	{
 		m_precision = precision;
 	}
 
-    /// <summary>
-    /// Gets the default value of the property, as represented in the CSDL.
-    /// </summary>
-    /// <returns>A string representing the default value of the property.</returns>
-    const ::utility::string_t& default_value() const
-    {
-        return m_default;
-    }
+	/// <summary>
+	/// Gets the default value of the property, as represented in the CSDL.
+	/// </summary>
+	/// <returns>A string representing the default value of the property.</returns>
+	const ::odata::string_t& default_value() const
+	{
+		return m_default;
+	}
 
 private:
-    friend class edm_structured_type;
+	friend class edm_structured_type;
 
-    bool m_is_nullable;
+	bool m_is_nullable;
 	bool m_is_unicode;
-    ::utility::string_t m_name;
-    ::utility::string_t m_default;
+	::odata::string_t m_name;
+	::odata::string_t m_default;
 	unsigned int m_maxLength;
 	unsigned int m_scale;
 	unsigned int m_precision;
@@ -295,13 +291,13 @@ private:
 class edm_collection_type : public edm_named_type
 {
 public:
-	edm_collection_type(::utility::string_t name)
-		: edm_named_type(name, U(""), edm_type_kind_t::Collection)
+	edm_collection_type(::odata::string_t name)
+		: edm_named_type(name, _XPLATSTR(""), edm_type_kind_t::Collection)
 	{
 	}
 
-	edm_collection_type(::utility::string_t name, std::shared_ptr<edm_named_type> element_type)
-		: edm_named_type(name, U(""), edm_type_kind_t::Collection), m_element_type(element_type)
+	edm_collection_type(::odata::string_t name, std::shared_ptr<edm_named_type> element_type)
+		: edm_named_type(name, _XPLATSTR(""), edm_type_kind_t::Collection), m_element_type(element_type)
 	{
 	}
 
@@ -322,8 +318,8 @@ protected:
 class edm_payload_annotation_type : public edm_named_type
 {
 public:
-	edm_payload_annotation_type(::utility::string_t name) 
-		: edm_named_type(name, U(""), edm_type_kind_t::PayloadAnnotation)
+	edm_payload_annotation_type(::odata::string_t name)
+		: edm_named_type(name, _XPLATSTR(""), edm_type_kind_t::PayloadAnnotation)
 	{
 	}
 };
@@ -334,51 +330,52 @@ public:
 class edm_structured_type : public edm_named_type
 {
 public:
-    /// <summary>
-    /// Constructor
-    /// </summary>
-    /// <param name="name">The name of the type.</param>
-    edm_structured_type(::utility::string_t name, ::utility::string_t name_space, edm_type_kind_t type_kind, ::utility::string_t basetype, bool isAbstract, bool isOpenType)
-		: edm_named_type(name, name_space, type_kind) , m_baseTypeName(basetype), m_is_abstract(isAbstract), m_is_openType(isOpenType), m_base_type(nullptr)
-    {
-    }
+	/// <summary>
+	/// Constructor
+	/// </summary>
+	/// <param name="name">The name of the type.</param>
+	edm_structured_type(::odata::string_t name, ::odata::string_t name_space, edm_type_kind_t type_kind, ::odata::string_t basetype, bool isAbstract, bool isOpenType)
+		: edm_named_type(name, name_space, type_kind), m_baseTypeName(basetype), m_base_type(nullptr), m_is_abstract(isAbstract), m_is_openType(isOpenType), m_properties()
+	{
+	}
 
-    /// <summary>
-    /// Adds a property to the type.
-    /// </summary>
-    /// <param name="prop">A pointer to the property to add.</param>
-    void add_property(std::shared_ptr<edm_property_type> prop)
-    {
+	/// <summary>
+	/// Adds a property to the type.
+	/// </summary>
+	/// <param name="prop">A pointer to the property to add.</param>
+	void add_property(std::shared_ptr<edm_property_type> prop)
+	{
 		m_properties[prop->get_name()] = prop;
-    }
+	}
 
-    /// <summary>
-    /// Gets the beginning iterator of the properties of the type
-    /// </summary>
-    std::unordered_map<::utility::string_t, std::shared_ptr<edm_property_type>>::const_iterator begin() const
-    {
+	/// <summary>
+	/// Gets the beginning iterator of the properties of the type
+	/// </summary>
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_property_type>>::const_iterator begin() const
+	{
 		return m_properties.cbegin();
-    }
+	}
 
-    /// <summary>
-    /// Gets the end iterator of the properties of the type
-    /// </summary>
-    std::unordered_map<::utility::string_t, std::shared_ptr<edm_property_type>>::const_iterator end() const
-    {
-        return m_properties.cend();
-    }
+	/// <summary>
+	/// Gets the end iterator of the properties of the type
+	/// </summary>
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_property_type>>::const_iterator end() const
+	{
+		return m_properties.cend();
+	}
 
-    std::vector<std::shared_ptr<edm_property_type>> get_properties_vector() const
+	std::vector<std::shared_ptr<edm_property_type>> get_properties_vector() const
 	{
 		std::vector<std::shared_ptr<edm_property_type>> ret;
+		ret.reserve(m_properties.size());
 		for (auto it : m_properties)
 		{
-			ret.push_back(it.second);
+			ret.emplace_back(it.second);
 		}
 		return ret;
 	}
 
-	const ::utility::string_t get_base_type_name() const
+	const ::odata::string_t get_base_type_name() const
 	{
 		return m_baseTypeName;
 	}
@@ -393,49 +390,59 @@ public:
 		return m_base_type;
 	}
 
-    /// <summary>
-    /// Looks up a property of the type by name.
-    /// </summary>
-    /// <param name="name">The name of the property.</param>
-    /// <returns>A pointer to the property if found, an empty pointer otherwise.</returns>
-    ODATACPP_CLIENT_API std::shared_ptr<edm_property_type> find_property(::utility::string_t name) const;
+	bool is_abstract() const
+	{
+		return m_is_abstract;
+	}
+
+	bool is_open() const
+	{
+		return m_is_openType;
+	}
+
+	/// <summary>
+	/// Looks up a property of the type by name.
+	/// </summary>
+	/// <param name="name">The name of the property.</param>
+	/// <returns>A pointer to the property if found, an empty pointer otherwise.</returns>
+	ODATACPP_CLIENT_API std::shared_ptr<edm_property_type> find_property(::odata::string_t name) const;
 
 protected:
-    friend class edm_schema;
+	friend class edm_schema;
 
-	::utility::string_t m_baseTypeName;	
+	::odata::string_t m_baseTypeName;
 	std::shared_ptr<edm_structured_type> m_base_type;
 
 	bool m_is_abstract;
 	bool m_is_openType;
 
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_property_type>> m_properties;
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_property_type>> m_properties;
 };
 
 class edm_enum_member
 {
 public:
-    /// <summary>
-    /// Constructor
-    /// </summary>
-	edm_enum_member()
+	/// <summary>
+	/// Constructor
+	/// </summary>
+	edm_enum_member() : m_name(_XPLATSTR("")), m_value(0)
 	{
 	}
 
-
-    edm_enum_member(::utility::string_t name, unsigned long value) : m_name(name), m_value(value)
+	edm_enum_member(::odata::string_t name, unsigned long value) : m_name(name), m_value(value)
 	{
 	}
-	
-	const ::utility::string_t& get_enum_member_name() const
+
+	const ::odata::string_t& get_enum_member_name() const
 	{
 		return m_name;
 	}
-	void set_enum_member_name(const ::utility::string_t& name)
+
+	void set_enum_member_name(const ::odata::string_t& name)
 	{
 		m_name = name;
 	}
-	
+
 	unsigned long get_enum_member_value() const
 	{
 		return m_value;
@@ -449,31 +456,31 @@ public:
 private:
 	friend class edm_enum_type;
 
-	::utility::string_t m_name;
+	::odata::string_t m_name;
 	unsigned long m_value;
 };
 
 /// <summary>
-/// 
+///
 /// </summary>
 class edm_enum_type : public edm_named_type
 {
 public:
-    /// <summary>
-    /// Constructor
-    /// </summary>
-	edm_enum_type(::utility::string_t name, ::utility::string_t name_space, ::utility::string_t underlying_type, bool is_flag)
+	/// <summary>
+	/// Constructor
+	/// </summary>
+	edm_enum_type(::odata::string_t name, ::odata::string_t name_space, ::odata::string_t underlying_type, bool is_flag)
 		: edm_named_type(name, name_space, edm_type_kind_t::Enum), m_underlying_type(underlying_type), m_is_flag(is_flag)
 	{
 	}
 
 	/// <summary>
-    /// 
-    /// </summary>
-    void add_enum_member(std::shared_ptr<edm_enum_member> member)
-    {
-        m_members.push_back(member);
-    }
+	///
+	/// </summary>
+	void add_enum_member(std::shared_ptr<edm_enum_member> member)
+	{
+		m_members.emplace_back(member);
+	}
 
 	const std::vector<std::shared_ptr<edm_enum_member>>& get_enum_members()
 	{
@@ -486,46 +493,45 @@ public:
 	}
 
 private:
-    friend class edm_schema;
+	friend class edm_schema;
 
-	::utility::string_t m_underlying_type;
+	::odata::string_t m_underlying_type;
 	bool m_is_flag;
 
 	std::vector<std::shared_ptr<edm_enum_member>> m_members;
 };
 
 /// <summary>
-/// 
+///
 /// </summary>
 class edm_complex_type : public edm_structured_type
 {
 public:
-    /// <summary>
-    /// Constructor
-    /// </summary>
-    /// <param name="name">The name of the type.</param>
-    edm_complex_type(::utility::string_t name, ::utility::string_t name_space, 
-		::utility::string_t basetype = U(""), bool isAbstract = false, bool isOpenType = false) 
+	/// <summary>
+	/// Constructor
+	/// </summary>
+	/// <param name="name">The name of the type.</param>
+	edm_complex_type(::odata::string_t name, ::odata::string_t name_space, ::odata::string_t basetype = _XPLATSTR(""), bool isAbstract = false, bool isOpenType = false)
 		: edm_structured_type(name, name_space, edm_type_kind_t::Complex, basetype, isAbstract, isOpenType)
-    {
-    }
+	{
+	}
 
 private:
-    friend class edm_schema;
+	friend class edm_schema;
 };
 
 /// <summary>
-/// 
+///
 /// </summary>
 class edm_navigation_source;
 
 class edm_navigation_type : public edm_named_type
 {
 public:
-	edm_navigation_type(::utility::string_t naviagtion_type, ::utility::string_t partner_name, bool is_contained = false) 
-		: edm_named_type(naviagtion_type, U(""), edm_type_kind_t::Navigation), m_partner_name(partner_name), m_is_contained(is_contained)
+	edm_navigation_type(::odata::string_t naviagtion_type, ::odata::string_t partner_name, bool is_contained = false)
+		: edm_named_type(naviagtion_type, _XPLATSTR(""), edm_type_kind_t::Navigation), m_partner_name(partner_name), m_is_contained(is_contained)
 	{
-		m_naviagtion_type = std::make_shared<edm_named_type>(naviagtion_type, U(""), edm_type_kind_t::Unknown);
+		m_naviagtion_type = ::odata::make_shared<edm_named_type>(naviagtion_type, _XPLATSTR(""), edm_type_kind_t::Unknown);
 	}
 
 	std::shared_ptr<edm_named_type> get_navigation_type() const
@@ -560,14 +566,14 @@ private:
 	friend class edm_schema;
 
 	std::weak_ptr<edm_named_type> m_naviagtion_type;
-	::utility::string_t m_partner_name;
+	::odata::string_t m_partner_name;
 	bool m_is_contained;
 	// only works for navigation that has m_is_contained = false
 	std::weak_ptr<edm_navigation_source> m_binded_navigation_source;
 };
 
 /// <summary>
-/// 
+///
 /// </summary>
 enum EdmOperationKind
 {
@@ -576,20 +582,19 @@ enum EdmOperationKind
 };
 
 /// <summary>
-/// 
+///
 /// </summary>
 class edm_operation_parameter
 {
 public:
-	edm_operation_parameter()
+	edm_operation_parameter() :
+		m_param_name(_XPLATSTR("")), m_param_type(nullptr), m_is_nullable(false)
 	{
-		
 	}
 
-    edm_operation_parameter(::utility::string_t param_name, std::shared_ptr<edm_named_type> param_type) :
-        m_param_name(param_name), m_param_type(param_type)
+	edm_operation_parameter(::odata::string_t param_name, std::shared_ptr<edm_named_type> param_type) :
+		m_param_name(param_name), m_param_type(param_type), m_is_nullable(false)
 	{
-		
 	}
 
 	const std::shared_ptr<edm_named_type>& get_param_type() const
@@ -602,7 +607,7 @@ public:
 		m_param_type = type;
 	}
 
-	const ::utility::string_t& get_param_name() const
+	const ::odata::string_t& get_param_name() const
 	{
 		return m_param_name;
 	}
@@ -610,19 +615,19 @@ public:
 private:
 	friend class edm_operation_type;
 
-	::utility::string_t m_param_name;
+	::odata::string_t m_param_name;
 	std::shared_ptr<edm_named_type> m_param_type;
 	bool m_is_nullable;
 };
 
 /// <summary>
-/// 
+///
 /// </summary>
 class edm_operation_type : public edm_named_type
 {
 public:
-	edm_operation_type(::utility::string_t name, ::utility::string_t name_space, bool is_bound, ::utility::string_t path, EdmOperationKind operation_kind, bool is_composable) 
-		: edm_named_type(name, name_space, edm_type_kind_t::Operation), m_path(path), m_is_bound(is_bound), m_operation_kind(operation_kind), m_is_composable(is_composable)
+	edm_operation_type(::odata::string_t name, ::odata::string_t name_space, bool is_bound, ::odata::string_t path, EdmOperationKind operation_kind, bool is_composable)
+	:	edm_named_type(name, name_space, edm_type_kind_t::Operation), m_is_bound(is_bound), m_path(path), m_parameters(), m_return_type(), m_operation_kind(operation_kind), m_is_composable(is_composable)
 	{
 		if (operation_kind == EdmOperationKind::Action)
 		{
@@ -632,7 +637,7 @@ public:
 
 	void add_operation_parameter(std::shared_ptr<edm_operation_parameter> parameter)
 	{
-		m_parameters.push_back(parameter);
+		m_parameters.emplace_back(parameter);
 	}
 
 	void set_return_type(std::shared_ptr<edm_named_type> return_type)
@@ -645,12 +650,12 @@ public:
 		return m_parameters;
 	}
 
-	void set_return_type_name(const ::utility::string_t& return_type_name)
+	void set_return_type_name(const ::odata::string_t& return_type_name)
 	{
 		m_return_type_name = return_type_name;
 	}
 
-	const ::utility::string_t& get_return_type_name() const
+	const ::odata::string_t& get_return_type_name() const
 	{
 		return m_return_type_name;
 	}
@@ -660,25 +665,25 @@ public:
 		return m_return_type;
 	}
 
-	bool is_bound()
+	bool is_bound() const
 	{
 		return m_is_bound;
 	}
 
-	bool is_function()
+	bool is_function() const
 	{
 		return m_operation_kind == EdmOperationKind::Function;
 	}
 
 private:
-    friend class edm_schema;
+	friend class edm_schema;
 	friend class edm_model;
 
 	bool m_is_bound;
-	::utility::string_t m_path;
+	::odata::string_t m_path;
 	std::vector<std::shared_ptr<edm_operation_parameter>> m_parameters;
 	std::shared_ptr<edm_named_type> m_return_type;
-	::utility::string_t m_return_type_name;
+	::odata::string_t m_return_type_name;
 	EdmOperationKind m_operation_kind;
 	bool m_is_composable;
 };
@@ -690,42 +695,42 @@ private:
 class edm_entity_type : public edm_structured_type
 {
 public:
-    /// <summary>
-    /// Constructor
-    /// </summary>
-    /// <param name="name">The name of the type.</param>
-    edm_entity_type(::utility::string_t name, ::utility::string_t name_space, 
-		::utility::string_t basetype = U(""), bool isAbstract = false, bool isOpenType = false, bool hasStream = false) 
+	/// <summary>
+	/// Constructor
+	/// </summary>
+	/// <param name="name">The name of the type.</param>
+	edm_entity_type(::odata::string_t name, ::odata::string_t name_space, ::odata::string_t basetype = _XPLATSTR(""), bool isAbstract = false, bool isOpenType = false, bool hasStream = false)
 		: edm_structured_type(name, name_space, edm_type_kind_t::Entity, basetype, isAbstract, isOpenType), m_HasStream(hasStream)
-    {
-    }
-
-    /// <summary>
-    /// Adds a property name to the key of the entity type
-    /// </summary>
-    void add_key_property(const ::utility::string_t& property_ref)
-    {
-        m_key.push_back(property_ref);
-    }
-
-    /// <summary>
-    /// Gets the key, a collection of names of properties in the entity.
-    /// </summary>
-    const std::vector<::utility::string_t>& key() const
-    {
-        return m_key;
-    }
-
-	std::vector<::utility::string_t> get_key_with_parents() const
 	{
-		std::vector<::utility::string_t> ret = m_key;
+	}
+
+	/// <summary>
+	/// Adds a property name to the key of the entity type
+	/// </summary>
+	void add_key_property(const ::odata::string_t& property_ref)
+	{
+		m_key.emplace_back(property_ref);
+	}
+
+	/// <summary>
+	/// Gets the key, a collection of names of properties in the entity.
+	/// </summary>
+	const std::vector<::odata::string_t>& key() const
+	{
+		return m_key;
+	}
+
+	std::vector<::odata::string_t> get_key_with_parents() const
+	{
+		std::vector<::odata::string_t> ret = m_key;
 
 		if (m_base_type && std::dynamic_pointer_cast<edm_entity_type>(m_base_type))
 		{
-			auto parent_keys = (std::dynamic_pointer_cast<edm_entity_type>(m_base_type))->get_key_with_parents();
-			if (parent_keys.size() > 0)
+			auto parent_keys = std::dynamic_pointer_cast<edm_entity_type>(m_base_type)->get_key_with_parents();
+			if (!parent_keys.empty())
 			{
-				ret.insert(ret.end(), parent_keys.begin(), parent_keys.end());
+				ret.reserve(ret.size() + parent_keys.size());
+				std::copy(parent_keys.begin(), parent_keys.end(), std::back_inserter(ret));
 			}
 		}
 
@@ -733,9 +738,9 @@ public:
 	}
 
 private:
-    friend class edm_schema;
+	friend class edm_schema;
 
-    std::vector<::utility::string_t> m_key;
+	std::vector<::odata::string_t> m_key;
 	bool m_HasStream;
 };
 

--- a/samples/ios/TripPin/TripPin/trippin_service.cpp
+++ b/samples/ios/TripPin/TripPin/trippin_service.cpp
@@ -28,9 +28,9 @@ END_COMPLEX_CONSTRUCTOR(City, type_base)
 BEGIN_COMPLEX_DESTRUCTOR(City)
 END_COMPLEX_DESTRUCTOR(City)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(City, countryregion, CountryRegion, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(City, region, Region, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(City, name, Name, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(City, countryregion, CountryRegion, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(City, region, Region, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(City, name, Name, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(City, Microsoft.OData.SampleService.Models.TripPin, City)
 
@@ -53,7 +53,7 @@ BEGIN_COMPLEX_DESTRUCTOR(Location)
 END_COMPLEX_DESTRUCTOR(Location)
 
 IMPLEMENT_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(Location, city, City, City);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Location, address, Address, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Location, address, Address, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Location, Microsoft.OData.SampleService.Models.TripPin, Location)
 
@@ -75,7 +75,7 @@ BEGIN_COMPLEX_DESTRUCTOR(EventLocation)
     ON_PROPERTY_IN_COMPLEX_DESTRUCTOR(buildinginfo)
 END_COMPLEX_DESTRUCTOR(EventLocation)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(EventLocation, buildinginfo, BuildingInfo, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(EventLocation, buildinginfo, BuildingInfo, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(EventLocation, Microsoft.OData.SampleService.Models.TripPin, EventLocation)
 
@@ -113,13 +113,13 @@ BEGIN_ENTITY_DESTRUCTOR(Trip)
 END_ENTITY_DESTRUCTOR(Trip)
 
 IMPLEMENT_FUNCTION_P0(Trip, GetInvolvedPeople, odata_entityset_query_executor<Person>);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, description, Description, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, description, Description, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, budget, Budget, float);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, tripid, TripId, int32_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, endsat, EndsAt, ::utility::datetime);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, shareid, ShareId, ::utility::string_t);
-IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, tags, Tags, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, name, Name, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, shareid, ShareId, ::odata::string_t);
+IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, tags, Tags, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, name, Name, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, startsat, StartsAt, ::utility::datetime);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Trip, photos, Photos, Photo);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Trip, planitems, PlanItems, PlanItem);
@@ -156,8 +156,8 @@ END_ENTITY_CONSTRUCTOR(Airline, type_base)
 BEGIN_ENTITY_DESTRUCTOR(Airline)
 END_ENTITY_DESTRUCTOR(Airline)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airline, airlinecode, AirlineCode, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airline, name, Name, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airline, airlinecode, AirlineCode, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airline, name, Name, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Airline, Microsoft.OData.SampleService.Models.TripPin, Airline)
 
@@ -177,10 +177,10 @@ END_ENTITY_CONSTRUCTOR(Airport, type_base)
 BEGIN_ENTITY_DESTRUCTOR(Airport)
 END_ENTITY_DESTRUCTOR(Airport)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airport, name, Name, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airport, icaocode, IcaoCode, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airport, name, Name, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airport, icaocode, IcaoCode, ::odata::string_t);
 IMPLEMENT_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Airport, location, Location, AirportLocation);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airport, iatacode, IataCode, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airport, iatacode, IataCode, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Airport, Microsoft.OData.SampleService.Models.TripPin, Airport)
 
@@ -208,15 +208,15 @@ BEGIN_ENTITY_DESTRUCTOR(Person)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(gender)
 END_ENTITY_DESTRUCTOR(Person)
 
-IMPLEMENT_FUNCTION_P1(Person, GetFriendsTrips, odata_entityset_query_executor<Trip>, userName, ::utility::string_t, userName);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, lastname, LastName, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, username, UserName, ::utility::string_t);
+IMPLEMENT_FUNCTION_P1(Person, GetFriendsTrips, odata_entityset_query_executor<Trip>, userName, ::odata::string_t, userName);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, lastname, LastName, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, username, UserName, ::odata::string_t);
 IMPLEMENT_FUNCTION_P0(Person, GetFavoriteAirline, odata_entityset_query_executor<Airline>);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, concurrency, Concurrency, int64_t);
-IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, emails, Emails, ::utility::string_t);
+IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, emails, Emails, ::odata::string_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Person, trips, Trips, Trip);
-IMPLEMENT_ACTION_P2(Person, ShareTrip, odata_void_query_executor, userName, ::utility::string_t, userName, tripId, int32_t, tripId);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, firstname, FirstName, ::utility::string_t);
+IMPLEMENT_ACTION_P2(Person, ShareTrip, odata_void_query_executor, userName, ::odata::string_t, userName, tripId, int32_t, tripId);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, firstname, FirstName, ::odata::string_t);
 IMPLEMENT_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Person, addressinfo, AddressInfo, Location);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Person, friends, Friends, Person);
 IMPLEMENT_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(Person, gender, Gender, PersonGender);
@@ -257,7 +257,7 @@ BEGIN_ENTITY_DESTRUCTOR(Photo)
 END_ENTITY_DESTRUCTOR(Photo)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Photo, id, Id, int64_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Photo, name, Name, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Photo, name, Name, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Photo, Microsoft.OData.SampleService.Models.TripPin, Photo)
 
@@ -290,7 +290,7 @@ IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PlanItem, endsat, EndsAt
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PlanItem, planitemid, PlanItemId, int32_t);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PlanItem, duration, Duration, ::utility::seconds);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PlanItem, startsat, StartsAt, ::utility::datetime);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PlanItem, confirmationcode, ConfirmationCode, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PlanItem, confirmationcode, ConfirmationCode, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(PlanItem, Microsoft.OData.SampleService.Models.TripPin, PlanItem)
 
@@ -318,7 +318,7 @@ BEGIN_ENTITY_DESTRUCTOR(Event)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(description)
 END_ENTITY_DESTRUCTOR(Event)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Event, description, Description, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Event, description, Description, ::odata::string_t);
 IMPLEMENT_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Event, occursat, OccursAt, EventLocation);
 
 IMPLEMENT_EDM_INFO(Event, Microsoft.OData.SampleService.Models.TripPin, Event)
@@ -340,7 +340,7 @@ BEGIN_ENTITY_DESTRUCTOR(PublicTransportation)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(seatnumber)
 END_ENTITY_DESTRUCTOR(PublicTransportation)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PublicTransportation, seatnumber, SeatNumber, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PublicTransportation, seatnumber, SeatNumber, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(PublicTransportation, Microsoft.OData.SampleService.Models.TripPin, PublicTransportation)
 
@@ -357,7 +357,7 @@ END_ENTITY_CONSTRUCTOR(Flight, PublicTransportation)
 BEGIN_ENTITY_DESTRUCTOR(Flight)
 END_ENTITY_DESTRUCTOR(Flight)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Flight, flightnumber, FlightNumber, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Flight, flightnumber, FlightNumber, ::odata::string_t);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Flight, from, From, Airport);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Flight, to, To, Airport);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Flight, airline, Airline, Airline);

--- a/samples/ios/TripPin/TripPin/trippin_service.h
+++ b/samples/ios/TripPin/TripPin/trippin_service.h
@@ -64,9 +64,9 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(countryregion, CountryRegion, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(region, Region, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(countryregion, CountryRegion, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(region, Region, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(name, Name, ::odata::string_t);
 };
 
 class Location : public type_base
@@ -78,7 +78,7 @@ public:
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
     DECLARE_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(city, City, City);
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(address, Address, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(address, Address, ::odata::string_t);
 };
 
 class EventLocation : public Location
@@ -89,7 +89,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(buildinginfo, BuildingInfo, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(buildinginfo, BuildingInfo, ::odata::string_t);
 };
 
 class AirportLocation : public Location
@@ -111,13 +111,13 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_FUNCTION_P0(Trip, GetInvolvedPeople, odata_entityset_query_executor<Person>);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(description, Description, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(description, Description, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(budget, Budget, float);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(tripid, TripId, int32_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(endsat, EndsAt, ::utility::datetime);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(shareid, ShareId, ::utility::string_t);
-    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(tags, Tags, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(shareid, ShareId, ::odata::string_t);
+    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(tags, Tags, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(startsat, StartsAt, ::utility::datetime);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(photos, Photos, Photo);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(planitems, PlanItems, PlanItem);
@@ -133,8 +133,8 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(airlinecode, AirlineCode, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(airlinecode, AirlineCode, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, AirlineCode, airlinecode);
 };
@@ -147,10 +147,10 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(icaocode, IcaoCode, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(icaocode, IcaoCode, ::odata::string_t);
     DECLARE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(location, Location, AirportLocation);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(iatacode, IataCode, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(iatacode, IataCode, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, IcaoCode, icaocode);
 };
@@ -163,15 +163,15 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_FUNCTION_P1(Person, GetFriendsTrips, odata_entityset_query_executor<Trip>, userName, ::utility::string_t, userName);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(lastname, LastName, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(username, UserName, ::utility::string_t);
+    DECLARE_FUNCTION_P1(Person, GetFriendsTrips, odata_entityset_query_executor<Trip>, userName, ::odata::string_t, userName);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(lastname, LastName, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(username, UserName, ::odata::string_t);
     DECLARE_FUNCTION_P0(Person, GetFavoriteAirline, odata_entityset_query_executor<Airline>);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(concurrency, Concurrency, int64_t);
-    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(emails, Emails, ::utility::string_t);
+    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(emails, Emails, ::odata::string_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(trips, Trips, Trip);
-    DECLARE_ACTION_P2(Person, ShareTrip, odata_void_query_executor, userName, ::utility::string_t, userName, tripId, int32_t, tripId);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(firstname, FirstName, ::utility::string_t);
+    DECLARE_ACTION_P2(Person, ShareTrip, odata_void_query_executor, userName, ::odata::string_t, userName, tripId, int32_t, tripId);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(firstname, FirstName, ::odata::string_t);
     DECLARE_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(addressinfo, AddressInfo, Location);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(friends, Friends, Person);
     DECLARE_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(gender, Gender, PersonGender);
@@ -189,7 +189,7 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(id, Id, int64_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, Id, id);
 };
@@ -206,7 +206,7 @@ public:
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(planitemid, PlanItemId, int32_t);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(duration, Duration, ::utility::seconds);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(startsat, StartsAt, ::utility::datetime);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(confirmationcode, ConfirmationCode, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(confirmationcode, ConfirmationCode, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, PlanItemId, planitemid);
 };
@@ -219,7 +219,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(description, Description, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(description, Description, ::odata::string_t);
     DECLARE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(occursat, OccursAt, EventLocation);
 
     DECLARE_GET_KEY_PROPERTY_STRING_NO_PARAM(PlanItem);
@@ -233,7 +233,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(seatnumber, SeatNumber, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(seatnumber, SeatNumber, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_NO_PARAM(PlanItem);
 };
@@ -246,7 +246,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(flightnumber, FlightNumber, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(flightnumber, FlightNumber, ::odata::string_t);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(from, From, Airport);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(to, To, Airport);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(airline, Airline, Airline);
@@ -257,7 +257,7 @@ public:
 class DefaultContainer : public odata_service_context
 {
 public:
-    DefaultContainer(const ::utility::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)
+    DefaultContainer(const ::odata::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)
     {
     }
 
@@ -267,27 +267,27 @@ public:
 
     std::shared_ptr<odata_service_query<odata_singleton_query_executor<Person>, odata_query_builder>> create_me_query()
     {
-        return create_query<odata_singleton_query_executor<Person>, odata_query_builder>(U("Me"));
+        return create_query<odata_singleton_query_executor<Person>, odata_query_builder>(_XPLATSTR("Me"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Photo>, odata_query_builder>> create_photos_query()
     {
-        return create_query<odata_entityset_query_executor<Photo>, odata_query_builder>(U("Photos"));
+        return create_query<odata_entityset_query_executor<Photo>, odata_query_builder>(_XPLATSTR("Photos"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Person>, odata_query_builder>> create_people_query()
     {
-        return create_query<odata_entityset_query_executor<Person>, odata_query_builder>(U("People"));
+        return create_query<odata_entityset_query_executor<Person>, odata_query_builder>(_XPLATSTR("People"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Airline>, odata_query_builder>> create_airlines_query()
     {
-        return create_query<odata_entityset_query_executor<Airline>, odata_query_builder>(U("Airlines"));
+        return create_query<odata_entityset_query_executor<Airline>, odata_query_builder>(_XPLATSTR("Airlines"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Airport>, odata_query_builder>> create_airports_query()
     {
-        return create_query<odata_entityset_query_executor<Airport>, odata_query_builder>(U("Airports"));
+        return create_query<odata_entityset_query_executor<Airport>, odata_query_builder>(_XPLATSTR("Airports"));
     }
 
 };

--- a/samples/trippin_sample/trippin_sample.cpp
+++ b/samples/trippin_sample/trippin_sample.cpp
@@ -15,58 +15,58 @@ using namespace Microsoft_OData_SampleService_Models_TripPin;
 
 void RequestResources()
 {
-	auto service_context = std::make_shared<DefaultContainer>(U("http://services.odata.org/V4/(S(khax213ynjvk4pqdhdgcadvw))/TripPinServiceRW/"));
-	auto people = service_context->create_people_query()->execute_query().get();
+	auto service_context = ::odata::make_shared<DefaultContainer>(_XPLATSTR("http://services.odata.org/V4/(S(khax213ynjvk4pqdhdgcadvw))/TripPinServiceRW/"));
+	auto people = service_context->create_people_query()->execute_query().get().first;
 }
 
 void RequestIndividualResource()
 {
-	auto service_context = std::make_shared<DefaultContainer>(U("http://services.odata.org/V4/(S(khax213ynjvk4pqdhdgcadvw))/TripPinServiceRW/"));
-	auto people = service_context->create_people_query()->key(U("'russellwhyte'"))->execute_query().get();
+	auto service_context = ::odata::make_shared<DefaultContainer>(_XPLATSTR("http://services.odata.org/V4/(S(khax213ynjvk4pqdhdgcadvw))/TripPinServiceRW/"));
+	auto people = service_context->create_people_query()->key(_XPLATSTR("'russellwhyte'"))->execute_query().get().first;
 }
 
 void Queries()
 {
-	auto service_context = std::make_shared<DefaultContainer>(U("http://services.odata.org/V4/(S(khax213ynjvk4pqdhdgcadvw))/TripPinServiceRW/"));
-	auto people = service_context->create_people_query()->filter(U("Trips/any(d:d/Budget gt 3000)"))->select(U("FirstName, LastName"))->top(2)->execute_query().get();
+	auto service_context = ::odata::make_shared<DefaultContainer>(_XPLATSTR("http://services.odata.org/V4/(S(khax213ynjvk4pqdhdgcadvw))/TripPinServiceRW/"));
+	auto people = service_context->create_people_query()->filter(_XPLATSTR("Trips/any(d:d/Budget gt 3000)"))->select(_XPLATSTR("FirstName, LastName"))->top(2)->execute_query().get().first;
 }
 
 void CreateNewResource()
 {
-    auto service_context = std::make_shared<DefaultContainer>(U("http://services.odata.org/V4/(S(khax213ynjvk4pqdhdgcadvw))/TripPinServiceRW/"));
-    auto lewis = std::make_shared<Person>(service_context);
-    lewis->set_username(U("lewisblack"));
-    lewis->set_firstname(U("Lewis"));
-    lewis->set_lastname(U("Black"));
-    lewis->set_emails({ U("lewisblack@example.com") });
-    auto location = std::make_shared<Location>(service_context);
-    location->set_address(U("187 Suffolk Ln."));
-    auto city = std::make_shared<City>(service_context);
-    city->set_countryregion(U("United States"));
-    city->set_name(U("Boise"));
-    city->set_region(U("ID"));
+    auto service_context = ::odata::make_shared<DefaultContainer>(_XPLATSTR("http://services.odata.org/V4/(S(khax213ynjvk4pqdhdgcadvw))/TripPinServiceRW/"));
+    auto lewis = ::odata::make_shared<Person>(service_context);
+    lewis->set_username(_XPLATSTR("lewisblack"));
+    lewis->set_firstname(_XPLATSTR("Lewis"));
+    lewis->set_lastname(_XPLATSTR("Black"));
+    lewis->set_emails({ _XPLATSTR("lewisblack@example.com") });
+    auto location = ::odata::make_shared<Location>(service_context);
+    location->set_address(_XPLATSTR("187 Suffolk Ln."));
+    auto city = ::odata::make_shared<City>(service_context);
+    city->set_countryregion(_XPLATSTR("United States"));
+    city->set_name(_XPLATSTR("Boise"));
+    city->set_region(_XPLATSTR("ID"));
     location->set_city(city);
     lewis->set_addressinfo({ location });
     lewis->set_gender(PersonGender::Male);
     lewis->set_concurrency(635519729375200400);
-    service_context->add_object(U("People"), lewis).get();
+    service_context->add_object(_XPLATSTR("People"), lewis).get().first;
 }
 
 void RelateResource()
 {
-    auto service_context = std::make_shared<DefaultContainer>(U("http://services.odata.org/V4/(S(khax213ynjvk4pqdhdgcadvw))/TripPinServiceRW/"));
-    auto ronald = service_context->create_people_query()->key(U("'ronaldmundy'"))->execute_query().get()[0];
-    auto russell = service_context->create_people_query()->key(U("'russellwhyte'"))->expand(U("Trips"))->execute_query().get()[0];
+    auto service_context = ::odata::make_shared<DefaultContainer>(_XPLATSTR("http://services.odata.org/V4/(S(khax213ynjvk4pqdhdgcadvw))/TripPinServiceRW/"));
+    auto ronald = service_context->create_people_query()->key(_XPLATSTR("'ronaldmundy'"))->execute_query().get().first[0];
+    auto russell = service_context->create_people_query()->key(_XPLATSTR("'russellwhyte'"))->expand(_XPLATSTR("Trips"))->execute_query().get().first[0];
     auto trip = russell->get_trips()[0];
-    service_context->add_reference(ronald, U("Trips"), trip).get();
+    service_context->add_reference(ronald, _XPLATSTR("Trips"), trip).get().first;
 }
 
 void InvokeFunction()
 {
-    auto service_context = std::make_shared<DefaultContainer>(U("http://services.odata.org/V4/(S(khax213ynjvk4pqdhdgcadvw))/TripPinServiceRW/"));
-    auto russell = service_context->create_people_query()->key(U("'russellwhyte'"))->expand(U("Trips"))->execute_query().get()[0];
+    auto service_context = ::odata::make_shared<DefaultContainer>(_XPLATSTR("http://services.odata.org/V4/(S(khax213ynjvk4pqdhdgcadvw))/TripPinServiceRW/"));
+    auto russell = service_context->create_people_query()->key(_XPLATSTR("'russellwhyte'"))->expand(_XPLATSTR("Trips"))->execute_query().get().first[0];
     auto trip = russell->get_trips()[0];
-    auto people = trip->GetInvolvedPeople().get();
+    auto people = trip->GetInvolvedPeople().get().first;
 }
 
 int main()

--- a/samples/trippin_sample/trippin_service.cpp
+++ b/samples/trippin_sample/trippin_service.cpp
@@ -28,9 +28,9 @@ END_COMPLEX_CONSTRUCTOR(City, type_base)
 BEGIN_COMPLEX_DESTRUCTOR(City)
 END_COMPLEX_DESTRUCTOR(City)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(City, countryregion, CountryRegion, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(City, region, Region, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(City, name, Name, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(City, countryregion, CountryRegion, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(City, region, Region, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(City, name, Name, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(City, Microsoft.OData.SampleService.Models.TripPin, City)
 
@@ -52,7 +52,7 @@ END_COMPLEX_CONSTRUCTOR(Location, type_base)
 BEGIN_COMPLEX_DESTRUCTOR(Location)
 END_COMPLEX_DESTRUCTOR(Location)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Location, address, Address, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Location, address, Address, ::odata::string_t);
 IMPLEMENT_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(Location, city, City, City);
 
 IMPLEMENT_EDM_INFO(Location, Microsoft.OData.SampleService.Models.TripPin, Location)
@@ -74,7 +74,7 @@ BEGIN_COMPLEX_DESTRUCTOR(EventLocation)
     ON_PROPERTY_IN_COMPLEX_DESTRUCTOR(buildinginfo)
 END_COMPLEX_DESTRUCTOR(EventLocation)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(EventLocation, buildinginfo, BuildingInfo, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(EventLocation, buildinginfo, BuildingInfo, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(EventLocation, Microsoft.OData.SampleService.Models.TripPin, EventLocation)
 
@@ -107,19 +107,19 @@ BEGIN_ENTITY_DESTRUCTOR(Person)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(gender)
 END_ENTITY_DESTRUCTOR(Person)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, username, UserName, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, firstname, FirstName, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, lastname, LastName, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, username, UserName, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, firstname, FirstName, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, lastname, LastName, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, concurrency, Concurrency, int64_t);
-IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, emails, Emails, ::utility::string_t);
+IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, emails, Emails, ::odata::string_t);
 IMPLEMENT_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(Person, gender, Gender, PersonGender);
 IMPLEMENT_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Person, addressinfo, AddressInfo, Location);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Person, friends, Friends, Person);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Person, trips, Trips, Trip);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Person, photo, Photo, Photo);
 IMPLEMENT_FUNCTION_P0(Person, GetFavoriteAirline, odata_entityset_query_executor<Airline>);
-IMPLEMENT_FUNCTION_P1(Person, GetFriendsTrips, odata_entityset_query_executor<Trip>, userName, ::utility::string_t, userName);
-IMPLEMENT_ACTION_P2(Person, ShareTrip, odata_void_query_executor, userName, ::utility::string_t, userName, tripId, int32_t, tripId);
+IMPLEMENT_FUNCTION_P1(Person, GetFriendsTrips, odata_entityset_query_executor<Trip>, userName, ::odata::string_t, userName);
+IMPLEMENT_ACTION_P2(Person, ShareTrip, odata_void_query_executor, userName, ::odata::string_t, userName, tripId, int32_t, tripId);
 
 IMPLEMENT_EDM_INFO(Person, Microsoft.OData.SampleService.Models.TripPin, Person)
 
@@ -152,8 +152,8 @@ END_ENTITY_CONSTRUCTOR(Airline, type_base)
 BEGIN_ENTITY_DESTRUCTOR(Airline)
 END_ENTITY_DESTRUCTOR(Airline)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airline, airlinecode, AirlineCode, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airline, name, Name, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airline, airlinecode, AirlineCode, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airline, name, Name, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Airline, Microsoft.OData.SampleService.Models.TripPin, Airline)
 
@@ -176,7 +176,7 @@ BEGIN_ENTITY_DESTRUCTOR(Photo)
 END_ENTITY_DESTRUCTOR(Photo)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Photo, id, Id, int64_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Photo, name, Name, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Photo, name, Name, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Photo, Microsoft.OData.SampleService.Models.TripPin, Photo)
 
@@ -196,9 +196,9 @@ END_ENTITY_CONSTRUCTOR(Airport, type_base)
 BEGIN_ENTITY_DESTRUCTOR(Airport)
 END_ENTITY_DESTRUCTOR(Airport)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airport, icaocode, IcaoCode, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airport, name, Name, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airport, iatacode, IataCode, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airport, icaocode, IcaoCode, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airport, name, Name, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Airport, iatacode, IataCode, ::odata::string_t);
 IMPLEMENT_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Airport, location, Location, AirportLocation);
 
 IMPLEMENT_EDM_INFO(Airport, Microsoft.OData.SampleService.Models.TripPin, Airport)
@@ -229,7 +229,7 @@ BEGIN_ENTITY_DESTRUCTOR(PlanItem)
 END_ENTITY_DESTRUCTOR(PlanItem)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PlanItem, planitemid, PlanItemId, int32_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PlanItem, confirmationcode, ConfirmationCode, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PlanItem, confirmationcode, ConfirmationCode, ::odata::string_t);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PlanItem, startsat, StartsAt, ::utility::datetime);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PlanItem, duration, Duration, ::utility::seconds);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PlanItem, endsat, EndsAt, ::utility::datetime);
@@ -263,14 +263,14 @@ BEGIN_ENTITY_DESTRUCTOR(Trip)
 END_ENTITY_DESTRUCTOR(Trip)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, tripid, TripId, int32_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, shareid, ShareId, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, description, Description, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, shareid, ShareId, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, description, Description, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, startsat, StartsAt, ::utility::datetime);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, name, Name, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, name, Name, ::odata::string_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Trip, photos, Photos, Photo);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, budget, Budget, float);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, endsat, EndsAt, ::utility::datetime);
-IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, tags, Tags, ::utility::string_t);
+IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Trip, tags, Tags, ::odata::string_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Trip, planitems, PlanItems, PlanItem);
 IMPLEMENT_FUNCTION_P0(Trip, GetInvolvedPeople, odata_entityset_query_executor<Person>);
 
@@ -307,7 +307,7 @@ BEGIN_ENTITY_DESTRUCTOR(PublicTransportation)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(seatnumber)
 END_ENTITY_DESTRUCTOR(PublicTransportation)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PublicTransportation, seatnumber, SeatNumber, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PublicTransportation, seatnumber, SeatNumber, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(PublicTransportation, Microsoft.OData.SampleService.Models.TripPin, PublicTransportation)
 
@@ -324,7 +324,7 @@ END_ENTITY_CONSTRUCTOR(Flight, PublicTransportation)
 BEGIN_ENTITY_DESTRUCTOR(Flight)
 END_ENTITY_DESTRUCTOR(Flight)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Flight, flightnumber, FlightNumber, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Flight, flightnumber, FlightNumber, ::odata::string_t);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Flight, to, To, Airport);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Flight, from, From, Airport);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Flight, airline, Airline, Airline);
@@ -348,7 +348,7 @@ BEGIN_ENTITY_DESTRUCTOR(Event)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(description)
 END_ENTITY_DESTRUCTOR(Event)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Event, description, Description, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Event, description, Description, ::odata::string_t);
 IMPLEMENT_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Event, occursat, OccursAt, EventLocation);
 
 IMPLEMENT_EDM_INFO(Event, Microsoft.OData.SampleService.Models.TripPin, Event)

--- a/samples/trippin_sample/trippin_service.h
+++ b/samples/trippin_sample/trippin_service.h
@@ -65,9 +65,9 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(countryregion, CountryRegion, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(region, Region, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(countryregion, CountryRegion, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(region, Region, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(name, Name, ::odata::string_t);
 };
 
 class Location : public type_base
@@ -78,7 +78,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(address, Address, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(address, Address, ::odata::string_t);
     DECLARE_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(city, City, City);
 };
 
@@ -90,7 +90,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(buildinginfo, BuildingInfo, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(buildinginfo, BuildingInfo, ::odata::string_t);
 };
 
 class AirportLocation : public Location
@@ -111,19 +111,19 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(username, UserName, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(firstname, FirstName, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(lastname, LastName, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(username, UserName, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(firstname, FirstName, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(lastname, LastName, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(concurrency, Concurrency, int64_t);
-    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(emails, Emails, ::utility::string_t);
+    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(emails, Emails, ::odata::string_t);
     DECLARE_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(gender, Gender, PersonGender);
     DECLARE_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(addressinfo, AddressInfo, Location);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(friends, Friends, Person);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(trips, Trips, Trip);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(photo, Photo, Photo);
     DECLARE_FUNCTION_P0(Person, GetFavoriteAirline, odata_entityset_query_executor<Airline>);
-    DECLARE_FUNCTION_P1(Person, GetFriendsTrips, odata_entityset_query_executor<Trip>, userName, ::utility::string_t, userName);
-    DECLARE_ACTION_P2(Person, ShareTrip, odata_void_query_executor, userName, ::utility::string_t, userName, tripId, int32_t, tripId);
+    DECLARE_FUNCTION_P1(Person, GetFriendsTrips, odata_entityset_query_executor<Trip>, userName, ::odata::string_t, userName);
+    DECLARE_ACTION_P2(Person, ShareTrip, odata_void_query_executor, userName, ::odata::string_t, userName, tripId, int32_t, tripId);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, UserName, username);
 };
@@ -136,8 +136,8 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(airlinecode, AirlineCode, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(airlinecode, AirlineCode, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, AirlineCode, airlinecode);
 };
@@ -151,7 +151,7 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(id, Id, int64_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, Id, id);
 };
@@ -164,9 +164,9 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(icaocode, IcaoCode, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(iatacode, IataCode, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(icaocode, IcaoCode, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(iatacode, IataCode, ::odata::string_t);
     DECLARE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(location, Location, AirportLocation);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, IcaoCode, icaocode);
@@ -181,7 +181,7 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(planitemid, PlanItemId, int32_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(confirmationcode, ConfirmationCode, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(confirmationcode, ConfirmationCode, ::odata::string_t);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(startsat, StartsAt, ::utility::datetime);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(duration, Duration, ::utility::seconds);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(endsat, EndsAt, ::utility::datetime);
@@ -198,14 +198,14 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(tripid, TripId, int32_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(shareid, ShareId, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(description, Description, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(shareid, ShareId, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(description, Description, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(startsat, StartsAt, ::utility::datetime);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(photos, Photos, Photo);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(budget, Budget, float);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(endsat, EndsAt, ::utility::datetime);
-    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(tags, Tags, ::utility::string_t);
+    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(tags, Tags, ::odata::string_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(planitems, PlanItems, PlanItem);
     DECLARE_FUNCTION_P0(Trip, GetInvolvedPeople, odata_entityset_query_executor<Person>);
 
@@ -220,7 +220,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(seatnumber, SeatNumber, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(seatnumber, SeatNumber, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_NO_PARAM(PlanItem);
 };
@@ -233,7 +233,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(flightnumber, FlightNumber, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(flightnumber, FlightNumber, ::odata::string_t);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(to, To, Airport);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(from, From, Airport);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(airline, Airline, Airline);
@@ -249,7 +249,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(description, Description, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(description, Description, ::odata::string_t);
     DECLARE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(occursat, OccursAt, EventLocation);
 
     DECLARE_GET_KEY_PROPERTY_STRING_NO_PARAM(PlanItem);
@@ -258,7 +258,7 @@ public:
 class DefaultContainer : public odata_service_context
 {
 public:
-    DefaultContainer(const ::utility::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)
+    DefaultContainer(const ::odata::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)
     {
     }
 
@@ -266,29 +266,29 @@ public:
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Photo>, odata_query_builder>> create_photos_query()
     {
-        return create_query<odata_entityset_query_executor<Photo>, odata_query_builder>(U("Photos"));
+        return create_query<odata_entityset_query_executor<Photo>, odata_query_builder>(_XPLATSTR("Photos"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Airline>, odata_query_builder>> create_airlines_query()
     {
-        return create_query<odata_entityset_query_executor<Airline>, odata_query_builder>(U("Airlines"));
+        return create_query<odata_entityset_query_executor<Airline>, odata_query_builder>(_XPLATSTR("Airlines"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Person>, odata_query_builder>> create_people_query()
     {
-        return create_query<odata_entityset_query_executor<Person>, odata_query_builder>(U("People"));
+        return create_query<odata_entityset_query_executor<Person>, odata_query_builder>(_XPLATSTR("People"));
     }
 
     DECLARE_FUNCTION_IMPORT_P2(DefaultContainer, GetNearestAirport, odata_entityset_query_executor<Airport>, lat, double, lat, lon, double, lon);
 
     std::shared_ptr<odata_service_query<odata_singleton_query_executor<Person>, odata_query_builder>> create_me_query()
     {
-        return create_query<odata_singleton_query_executor<Person>, odata_query_builder>(U("Me"));
+        return create_query<odata_singleton_query_executor<Person>, odata_query_builder>(_XPLATSTR("Me"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Airport>, odata_query_builder>> create_airports_query()
     {
-        return create_query<odata_entityset_query_executor<Airport>, odata_query_builder>(U("Airports"));
+        return create_query<odata_entityset_query_executor<Airport>, odata_query_builder>(_XPLATSTR("Airports"));
     }
 
 };

--- a/src/codegen/code_generation_base.cpp
+++ b/src/codegen/code_generation_base.cpp
@@ -1,0 +1,19 @@
+#include "odata/codegen/code_generation_base.h"
+#include "odata/codegen/odata_service_context.h"
+
+namespace odata { namespace codegen {
+
+	web::http::http_headers const& type_base::get_model_response_header() const
+	{
+		return m_service_context->get_client()->get_model_response_header();
+	}
+	::odata::string_t type_base::match_model_response_header(const ::odata::string_t &name) const
+	{
+		return m_service_context->get_client()->match_model_response_header(name);
+	}
+	bool type_base::has_model_response_header(const ::odata::string_t &name) const
+	{
+		return m_service_context->get_client()->has_model_response_header(name);
+	}
+
+}}

--- a/src/common/xmlhelpers.cpp
+++ b/src/common/xmlhelpers.cpp
@@ -20,247 +20,244 @@ using namespace concurrency;
 
 namespace odata { namespace common {
 
-    void xml_reader::initialize(streams::istream stream)
-    {
-        remove_bom(stream);
+	void xml_reader::initialize(streams::istream stream)
+	{
+		remove_bom(stream);
 
 #ifdef WIN32
-        HRESULT hr;
-        CComPtr<IStream> pInputStream;
-        pInputStream.Attach(xmlstring_istream::create(stream));
+		HRESULT hr;
+		CComPtr<IStream> pInputStream;
+		pInputStream.Attach(xmlstring_istream::create(stream));
 
-        if (pInputStream == nullptr)
-        {
-            auto error = ERROR_NOT_ENOUGH_MEMORY;
-            log_error_message(U("XML reader IStream creation failed"), error);
-            throw utility::details::create_system_error(error);
-        }
+		if (pInputStream == nullptr)
+		{
+			auto error = ERROR_NOT_ENOUGH_MEMORY;
+			log_error_message(_XPLATSTR("XML reader IStream creation failed"), error);
+			throw utility::details::create_system_error(error);
+		}
 
-        if (FAILED(hr = CreateXmlReader(__uuidof(IXmlReader), (void**)&m_reader, NULL)))
-        {
+		if (FAILED(hr = CreateXmlReader(__uuidof(IXmlReader), (void**)&m_reader, nullptr)))
+		{
+			auto error = GetLastError();
+			log_error_message(_XPLATSTR("XML reader CreateXmlReader failed"), error);
+			throw utility::details::create_system_error(error);
+		}
 
-            auto error = GetLastError();
-            log_error_message(U("XML reader CreateXmlReader failed"), error);
-            throw utility::details::create_system_error(error);
-        }
+		if (FAILED(hr = m_reader->SetProperty(XmlReaderProperty_DtdProcessing, DtdProcessing_Prohibit)))
+		{
+			auto error = GetLastError();
+			log_error_message(_XPLATSTR("XML reader SetProperty failed"), error);
+			throw utility::details::create_system_error(error);
+		}
 
-        if (FAILED(hr = m_reader->SetProperty(XmlReaderProperty_DtdProcessing, DtdProcessing_Prohibit)))
-        {
-
-            auto error = GetLastError();
-            log_error_message(U("XML reader SetProperty failed"), error);
-            throw utility::details::create_system_error(error);
-        }
-
-        if (FAILED(hr = m_reader->SetInput(pInputStream)))
-        {
-
-            auto error = GetLastError();
-            log_error_message(U("XML reader SetInput failed"), error);
-            throw utility::details::create_system_error(error);
-        }
+		if (FAILED(hr = m_reader->SetInput(pInputStream)))
+		{
+			auto error = GetLastError();
+			log_error_message(_XPLATSTR("XML reader SetInput failed"), error);
+			throw utility::details::create_system_error(error);
+		}
 #else
-        concurrency::streams::stringstreambuf buffer;
-        stream.read_to_end(buffer).get();
-        m_data = buffer.collection();
-        const char* xmlBuffer = reinterpret_cast<const char*>(m_data.data());
-        unsigned int size = static_cast<unsigned int>(m_data.size());
-        xmlInitParser();
-        m_reader = xmlReaderForMemory(xmlBuffer, size, "", "", XML_PARSE_RECOVER);
+		concurrency::streams::stringstreambuf buffer;
+		stream.read_to_end(buffer).get();
+		m_data = buffer.collection();
+		const char* xmlBuffer = reinterpret_cast<const char*>(m_data.data());
+		unsigned int size = static_cast<unsigned int>(m_data.size());
+		xmlInitParser();
+		m_reader = xmlReaderForMemory(xmlBuffer, size, "", "", XML_PARSE_RECOVER);
 #endif
-    }
+	}
 
-    /// <summary>
-    /// Remove Byte Order Mark from the stream
-    /// </summary>
-    void xml_reader::remove_bom(streams::istream stream)
-    {
-        // Synchronous.
-        if (stream.peek().get() == 0xEF
-            && stream.peek().get() == 0xBB
-            && stream.peek().get() == 0xBF)
-        {
-            stream.read().get();
-            stream.read().get();
-            stream.read().get();
-            return;
-        }
-    }
+	/// <summary>
+	/// Remove Byte Order Mark from the stream
+	/// </summary>
+	void xml_reader::remove_bom(streams::istream stream)
+	{
+		// Synchronous.
+		if (stream.peek().get() == 0xEF
+			&& stream.peek().get() == 0xBB
+			&& stream.peek().get() == 0xBF)
+		{
+			stream.read().get();
+			stream.read().get();
+			stream.read().get();
+			return;
+		}
+	}
 
-    bool xml_reader::parse()
-    {
-        if (m_streamDone) return false;
-        // Set this to true each time the parse routine is invoked. Most derived readers will only invoke parse once.
-        m_continueParsing = true;
+	bool xml_reader::parse()
+	{
+		if (m_streamDone) return false;
+		// Set this to true each time the parse routine is invoked. Most derived readers will only invoke parse once.
+		m_continueParsing = true;
 
-        // read until there are no more nodes
+		// read until there are no more nodes
 #ifdef WIN32
-        HRESULT hr;
-        XmlNodeType nodeType;
-        while (m_continueParsing && S_OK == (hr = m_reader->Read(&nodeType)))
-        {
+		HRESULT hr;
+		XmlNodeType nodeType;
+		while (m_continueParsing && S_OK == (hr = m_reader->Read(&nodeType)))
+		{
 #else
-        if (m_reader == nullptr)
-            return !m_continueParsing; // no XML document to read
+		if (m_reader == nullptr)
+			return !m_continueParsing; // no XML document to read
 
-        while (m_continueParsing && xmlTextReaderRead(m_reader))
-        {
-            auto nodeType = xmlTextReaderNodeType(m_reader);
+		while (m_continueParsing && xmlTextReaderRead(m_reader))
+		{
+			auto nodeType = xmlTextReaderNodeType(m_reader);
 #endif
-            switch (nodeType)
-            {
-
-            case XmlNodeType_Element:
-            {
-                auto name = get_current_element_name();
+			switch (nodeType)
+			{
+				case XmlNodeType_Element:
+				{
+					auto name = get_current_element_name();
 #ifdef WIN32
-				BOOL is_empty_element = m_reader->IsEmptyElement();
+					BOOL is_empty_element = m_reader->IsEmptyElement();
 #else
-                bool is_empty_element = xmlTextReaderIsEmptyElement(m_reader);
+					bool is_empty_element = xmlTextReaderIsEmptyElement(m_reader);
 #endif
-                m_elementStack.push_back(name);
-                handle_begin_element(name);
+					m_elementStack.emplace_back(name);
+					handle_begin_element(name);
 
-                if (is_empty_element)
-                {
-                    handle_end_element(name);
-                    m_elementStack.pop_back();
-                }
-            }
-                break;
+					if (is_empty_element)
+					{
+						handle_end_element(name);
+						m_elementStack.pop_back();
+					}
+				}
+				break;
 
-            case XmlNodeType_Text:
-                handle_element(m_elementStack.back());
-                break;
+				case XmlNodeType_Text:
+					handle_element(m_elementStack.back());
+					break;
 
-            case XmlNodeType_EndElement:
-                handle_end_element(m_elementStack.back());
-                m_elementStack.pop_back();
-                break;
+				case XmlNodeType_EndElement:
+					handle_end_element(m_elementStack.back());
+					m_elementStack.pop_back();
+					break;
 
-            default:
-                break;
-            }
-        }
+				default:
+					break;
+			}
+		}
 
-        // If the loop was terminated because there was no more to read from the stream, set m_streamDone to true, so exit early
-        // the next time parse is invoked.
-        if (m_continueParsing) m_streamDone = true;
-        // Return false if the end of the stream was reached and true if parsing was paused. The return value indicates whether
-        // parsing can be resumed.
-        return !m_continueParsing;
-    }
+		// If the loop was terminated because there was no more to read from the stream, set m_streamDone to true, so exit early
+		// the next time parse is invoked.
+		if (m_continueParsing)
+			m_streamDone = true;
+		// Return false if the end of the stream was reached and true if parsing was paused. The return value indicates whether
+		// parsing can be resumed.
+		return !m_continueParsing;
+	}
 
-    ::utility::string_t xml_reader::get_parent_element_name(size_t pos)
-    {
-        if (m_elementStack.size() > pos + 1)
-        {
-            size_t currentDepth = m_elementStack.size() - 1;
-            size_t parentDepth = currentDepth - 1;
+	::odata::string_t xml_reader::get_parent_element_name(size_t pos)
+	{
+		if (m_elementStack.size() > pos + 1)
+		{
+			size_t currentDepth = m_elementStack.size() - 1;
+			size_t parentDepth = currentDepth - 1;
 
-            if (pos <= parentDepth)
-            {
-                return m_elementStack[parentDepth - pos];
-            }
-        }
+			if (pos <= parentDepth)
+			{
+				return m_elementStack[parentDepth - pos];
+			}
+		}
 
-        // return empty string
-        return ::utility::string_t();
-    }
+		// return empty string
+		return ::odata::string_t();
+	}
 
-    ::utility::string_t xml_reader::get_current_element_name()
-    {
+	::odata::string_t xml_reader::get_current_element_name()
+	{
 #ifdef WIN32
-        HRESULT hr;
-        const wchar_t * pwszLocalName = NULL;
+		HRESULT hr;
+		const wchar_t * pwszLocalName = NULL;
 
-        if (FAILED(hr = m_reader->GetLocalName(&pwszLocalName, NULL)))
-        {
-            auto error = GetLastError();
-            log_error_message(U("XML reader GetLocalName failed"), error);
-            throw utility::details::create_system_error(error);
-        }
-        return ::utility::string_t(pwszLocalName);
+		if (FAILED(hr = m_reader->GetLocalName(&pwszLocalName, NULL)))
+		{
+			auto error = GetLastError();
+			log_error_message(_XPLATSTR("XML reader GetLocalName failed"), error);
+			throw utility::details::create_system_error(error);
+		}
+		return ::odata::string_t(pwszLocalName);
 #else
-        xmlChar* valueXml = xmlTextReaderLocalName(m_reader);
-        std::string input((char*)valueXml);
-        ::utility::string_t stringt = ::utility::conversions::to_string_t(input);
-        xmlFree(valueXml);
-        return stringt;
+		xmlChar* valueXml = xmlTextReaderLocalName(m_reader);
+		std::string input((char*)valueXml);
+		::odata::string_t stringt = ::utility::conversions::to_string_t(input);
+		xmlFree(valueXml);
+		return stringt;
 #endif
-    }
+	}
 
-    ::utility::string_t xml_reader::get_current_element_name_with_prefix()
-    {
+	::odata::string_t xml_reader::get_current_element_name_with_prefix()
+	{
 #ifdef WIN32
-        HRESULT hr;
-        const wchar_t * pwszName = NULL;
+		HRESULT hr;
+		const wchar_t * pwszName = NULL;
 
-        if (FAILED(hr = m_reader->GetQualifiedName(&pwszName, NULL)))
-        {
-            auto error = GetLastError();
-            log_error_message(U("XML reader GetQualified failed"), error);
-            throw utility::details::create_system_error(error);
-        }
-        return ::utility::string_t(pwszName);
+		if (FAILED(hr = m_reader->GetQualifiedName(&pwszName, NULL)))
+		{
+			auto error = GetLastError();
+			log_error_message(_XPLATSTR("XML reader GetQualified failed"), error);
+			throw utility::details::create_system_error(error);
+		}
+		return ::odata::string_t(pwszName);
 #else
-        throw std::runtime_error("Not implemented");
+		throw std::runtime_error("Not implemented");
 #endif
-    }
+	}
 
-    ::utility::string_t xml_reader::get_current_element_text()
-    {
+	::odata::string_t xml_reader::get_current_element_text()
+	{
 #ifdef WIN32
-        HRESULT hr;
-        const wchar_t * pwszValue;
+		HRESULT hr;
+		const wchar_t * pwszValue;
 
-        if (FAILED(hr = m_reader->GetValue(&pwszValue, NULL)))
-        {
-            auto error = GetLastError();
-            log_error_message(U("XML reader GetValue failed"), error);
-            throw utility::details::create_system_error(error);
-        }
+		if (FAILED(hr = m_reader->GetValue(&pwszValue, NULL)))
+		{
+			auto error = GetLastError();
+			log_error_message(_XPLATSTR("XML reader GetValue failed"), error);
+			throw utility::details::create_system_error(error);
+		}
 
-        return ::utility::string_t(pwszValue);
+		return ::odata::string_t(pwszValue);
 #else
-        xmlChar* valueXml = xmlTextReaderValue(m_reader);
-        std::string input((char*)valueXml);
-        ::utility::string_t stringt = ::utility::conversions::to_string_t(input);
-        xmlFree(valueXml);
-        return stringt;
+		xmlChar* valueXml = xmlTextReaderValue(m_reader);
+		std::string input((char*)valueXml);
+		::odata::string_t stringt = ::utility::conversions::to_string_t(input);
+		xmlFree(valueXml);
+		return stringt;
 #endif
-    }
+	}
 
-    bool xml_reader::move_to_first_attribute()
-    {
+	bool xml_reader::move_to_first_attribute()
+	{
 #ifdef WIN32
-        HRESULT hr;
-        if (FAILED(hr = m_reader->MoveToFirstAttribute()))
-        {
-            auto error = GetLastError();
-            log_error_message(U("XML reader MoveToFirstAttribute failed"), error);
-            throw utility::details::create_system_error(error);
-        }
-        return (hr == S_OK);
+		HRESULT hr;
+		if (FAILED(hr = m_reader->MoveToFirstAttribute()))
+		{
+			auto error = GetLastError();
+			log_error_message(_XPLATSTR("XML reader MoveToFirstAttribute failed"), error);
+			throw utility::details::create_system_error(error);
+		}
+		return (hr == S_OK);
 #else
-        return xmlTextReaderMoveToFirstAttribute(m_reader) > 0;
+		return xmlTextReaderMoveToFirstAttribute(m_reader) > 0;
 #endif
-    }
+	}
 
-    bool xml_reader::move_to_next_attribute()
-    {
+	bool xml_reader::move_to_next_attribute()
+	{
 #ifdef WIN32
-        HRESULT hr;
-        if (FAILED(hr = m_reader->MoveToNextAttribute()))
-        {
-            auto error = GetLastError();
-            log_error_message(U("XML reader MoveToNextAttribute failed"), error);
-            throw utility::details::create_system_error(error);
-        }
-        return (hr == S_OK);
+		HRESULT hr;
+		if (FAILED(hr = m_reader->MoveToNextAttribute()))
+		{
+			auto error = GetLastError();
+			log_error_message(_XPLATSTR("XML reader MoveToNextAttribute failed"), error);
+			throw utility::details::create_system_error(error);
+		}
+		return (hr == S_OK);
 #else
-        return xmlTextReaderMoveToNextAttribute(m_reader) > 0;
+		return xmlTextReaderMoveToNextAttribute(m_reader) > 0;
 #endif
-    }
+	}
 }}
 // namespace odata::edm

--- a/src/core/odata_entity_model_builder.cpp
+++ b/src/core/odata_entity_model_builder.cpp
@@ -13,39 +13,35 @@ using namespace ::odata::edm;
 namespace odata { namespace core
 {
 
-::utility::string_t odata_entity_model_builder::compute_edit_link(
-		const ::utility::string_t& root_url, 
-		std::shared_ptr<odata_entity_value> entity_value, 
-		const ::utility::string_t& parent_edit_link, 
-		bool is_collection_navigation)
+::odata::string_t odata_entity_model_builder::compute_edit_link(const ::odata::string_t& root_url, std::shared_ptr<odata_entity_value> entity_value, const ::odata::string_t& parent_edit_link, bool is_collection_navigation)
 {
-	::utility::string_t edit_link;
+	::odata::string_t edit_link;
 
 	if (entity_value)
 	{
-	    std::shared_ptr<odata_value> edit_link_value;
-        if (entity_value->get_property_value(odata_json_constants::PAYLOAD_ANNOTATION_EDITLINK, edit_link_value))
-	    { 
+		std::shared_ptr<odata_value> edit_link_value;
+		if (entity_value->get_property_value(odata_json_constants::PAYLOAD_ANNOTATION_EDITLINK, edit_link_value))
+		{
 			auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(edit_link_value);
 
 			if (!primitive_value)
 			{
-				return edit_link;
+				return std::move(edit_link);
 			}
 
 			edit_link = primitive_value->to_string();
 
 			if (::odata::common::is_relative_path(root_url, edit_link))
 			{
-				edit_link = root_url + U("/") + edit_link;
+				edit_link = root_url + _XPLATSTR("/") + edit_link;
 			}
 		}
 		else
 		{
 			if (is_collection_navigation)
 			{
-				::utility::string_t key_string = get_entity_key_value_string(entity_value);
-				edit_link = parent_edit_link + U("(") + key_string + U(")");
+				::odata::string_t key_string = get_entity_key_value_string(entity_value);
+				edit_link = parent_edit_link + _XPLATSTR("(") + key_string + _XPLATSTR(")");
 			}
 			else
 			{
@@ -54,28 +50,29 @@ namespace odata { namespace core
 		}
 	}
 
-	return edit_link;
+	return std::move(edit_link);
 }
 
-::utility::string_t odata_entity_model_builder::get_entity_key_value_string(const std::shared_ptr<odata_entity_value>& entity_value)
+::odata::string_t odata_entity_model_builder::get_entity_key_value_string(const std::shared_ptr<odata_entity_value>& entity_value)
 {
-	::utility::string_t key_string;
+	::odata::string_t key_string;
 
 	if (!entity_value)
 	{
-		return key_string;
+		return std::move(key_string);
 	}
 
-	std::vector<::utility::string_t> keys;
+	std::vector<::odata::string_t> keys;
 
 	auto parent_type = std::dynamic_pointer_cast<edm_entity_type>(entity_value->get_value_type());
 	while (parent_type)
 	{
+		keys.reserve(keys.size() + parent_type->key().size());
 		keys.insert(keys.end(), parent_type->key().cbegin(), parent_type->key().cend());
 		parent_type = std::dynamic_pointer_cast<edm_entity_type>(parent_type->get_base_type());
 	}
 
-	for (size_t i = 0; i < keys.size(); i++)
+	for (size_t i = 0; i < keys.size(); ++i)
 	{
 		std::shared_ptr<odata_value> property_value;
 		entity_value->get_property_value(keys[i], property_value);
@@ -89,7 +86,7 @@ namespace odata { namespace core
 				{
 					if (i != 0)
 					{
-						key_string += U(",");
+						key_string += _XPLATSTR(",");
 					}
 
 					key_string += primitive_property_value->to_string();
@@ -98,7 +95,7 @@ namespace odata { namespace core
 		}
 	}
 
-	return key_string;
+	return std::move(key_string);
 }
 
 }}

--- a/src/core/odata_entity_value.cpp
+++ b/src/core/odata_entity_value.cpp
@@ -13,18 +13,18 @@ using namespace ::web;
 namespace odata { namespace core
 {
 
-::utility::string_t odata_entity_value::get_entity_key_string()
+::odata::string_t odata_entity_value::get_entity_key_string()
 {
-	::utility::string_t key;
+	::odata::string_t key;
 
 	auto entitytype = std::dynamic_pointer_cast<edm_entity_type>(get_value_type());
 
 	if (entitytype)
 	{
-		key += U("(");
+		key += _XPLATSTR("(");
 
-		std::vector<::utility::string_t> key_property_names = entitytype->get_key_with_parents();
-		for (size_t i = 0; i < key_property_names.size(); i++)
+		std::vector<::odata::string_t> key_property_names(entitytype->get_key_with_parents());
+		for (size_t i = 0; i < key_property_names.size(); ++i)
 		{
 			std::shared_ptr<odata_value> property_value;
 			get_property_value(key_property_names[i], property_value);
@@ -35,45 +35,45 @@ namespace odata { namespace core
 				{
 					if (i != 0)
 					{
-						key += U(",");
+						key += _XPLATSTR(",");
 					}
 
 					auto primitive_property_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value);
 					if (primitive_property_value)
-					{				   
+					{
 						if (key_property_names.size() == 1)
 						{
-                            key += to_key(primitive_property_value);
+							key += to_key(primitive_property_value);
 						}
 						else
 						{
-                            key += key_property_names[i] + U("=") + to_key(primitive_property_value);
+							key += key_property_names[i] + _XPLATSTR("=") + to_key(primitive_property_value);
 						}
 					}
 				}
 				else
 				{
-					throw std::runtime_error("entity key type error!"); 
+					throw std::runtime_error("entity key type error!");
 				}
 			}
 		}
 
-		key += U(")");
+		key += _XPLATSTR(")");
 	}
 
 	return key;
 }
 
-::utility::string_t odata_entity_value::to_key(std::shared_ptr<odata_primitive_value> value)
+::odata::string_t odata_entity_value::to_key(std::shared_ptr<odata_primitive_value> value)
 {
-    if (value->get_primitive_type()->get_primitive_kind() == edm_primitive_type_kind_t::String)
-    {
-        return U("'") + value->to_string() + U("'"); 
-    }
-    else
-    {
-        return value->to_string(); 
-    }
+	if (value->get_primitive_type()->get_primitive_kind() == edm_primitive_type_kind_t::String)
+	{
+		return _XPLATSTR("'") + value->to_string() + _XPLATSTR("'");
+	}
+	else
+	{
+		return value->to_string();
+	}
 }
 
 }}

--- a/src/core/odata_json_constants.cpp
+++ b/src/core/odata_json_constants.cpp
@@ -5,12 +5,14 @@
 //---------------------------------------------------------------------
 
 #include "odata/core/odata_json_constants.h"
+#include "odata/common/utility.h"
 
 namespace odata { namespace core
 {
-    const ::utility::string_t odata_json_constants::PAYLOAD_ANNOTATION_NAVIGATIONLINK = U("@odata.navigationLink");
-    const ::utility::string_t odata_json_constants::PAYLOAD_ANNOTATION_READLINK(U("@odata.readLink"));
-    const ::utility::string_t odata_json_constants::PAYLOAD_ANNOTATION_EDITLINK(U("@odata.editLink"));
-    const ::utility::string_t odata_json_constants::PAYLOAD_ANNOTATION_TYPE(U("@odata.type"));
-    const ::utility::string_t odata_json_constants::PAYLOAD_ANNOTATION_ID(U("@odata.id"));
+	const ::odata::string_t odata_json_constants::PAYLOAD_ANNOTATION_NAVIGATIONLINK = _XPLATSTR("@odata.navigationLink");
+	const ::odata::string_t odata_json_constants::PAYLOAD_ANNOTATION_READLINK(_XPLATSTR("@odata.readLink"));
+	const ::odata::string_t odata_json_constants::PAYLOAD_ANNOTATION_EDITLINK(_XPLATSTR("@odata.editLink"));
+	const ::odata::string_t odata_json_constants::PAYLOAD_ANNOTATION_TYPE(_XPLATSTR("@odata.type"));
+	const ::odata::string_t odata_json_constants::PAYLOAD_ANNOTATION_ID(_XPLATSTR("@odata.id"));
+	const ::odata::string_t odata_json_constants::PAYLOAD_ANNOTATION_BIND(_XPLATSTR("@odata.bind"));
 }}

--- a/src/core/odata_json_operation_url_parameter_writer.cpp
+++ b/src/core/odata_json_operation_url_parameter_writer.cpp
@@ -11,32 +11,31 @@ using namespace ::odata::edm;
 namespace odata { namespace core
 {
 
-::utility::string_t odata_json_operation_url_parameter_writer::serialize(std::vector<std::shared_ptr<odata_parameter>> parameters)
+::odata::string_t odata_json_operation_url_parameter_writer::serialize(std::vector<std::shared_ptr<odata_parameter>> parameters)
 {
 	if (parameters.empty())
 	{
-		return U("()");
+		return _XPLATSTR("()");
 	}
 
 	::utility::stringstream_t ss;
-	ss << U("(");
+	ss << _XPLATSTR("(");
 
 	auto iter = parameters.cbegin();
-	handle_serialize_odata_parameter(ss, *iter, U('\0'), U('='));
-	iter++;
-	for(; iter != parameters.cend(); iter++)
+	handle_serialize_odata_parameter(ss, *iter, _XPLATSTR('\0'), _XPLATSTR('='));
+	++iter;
+	for(; iter != parameters.cend(); ++iter)
 	{
 		ss << ",";
-		handle_serialize_odata_parameter(ss, *iter, U('\0'), U('='));
+		handle_serialize_odata_parameter(ss, *iter, _XPLATSTR('\0'), _XPLATSTR('='));
 	}
 
-	ss << U(")");
+	ss << _XPLATSTR(")");
 
 	return ss.str();
 }
 
-void odata_json_operation_url_parameter_writer::handle_serialize_odata_parameter(
-	::utility::stringstream_t& ss, const std::shared_ptr<::odata::core::odata_parameter>& parameter, ::utility::char_t mark, ::utility::char_t separator)
+void odata_json_operation_url_parameter_writer::handle_serialize_odata_parameter(::utility::stringstream_t& ss, const std::shared_ptr<::odata::core::odata_parameter>& parameter, ::utility::char_t mark, ::utility::char_t separator)
 {
 	if (parameter && parameter->get_value() && !parameter->get_name().empty())
 	{
@@ -55,9 +54,9 @@ void odata_json_operation_url_parameter_writer::handle_serialize_odata_parameter
 	}
 }
 
-void odata_json_operation_url_parameter_writer::handle_serialize_odata_value(
-	::utility::stringstream_t& ss, const std::shared_ptr<::odata::edm::edm_named_type>& property_type, const std::shared_ptr<odata_value>& property_value)
+void odata_json_operation_url_parameter_writer::handle_serialize_odata_value(::utility::stringstream_t& ss, const std::shared_ptr<::odata::edm::edm_named_type>& property_type, const std::shared_ptr<odata_value>& property_value)
 {
+	// @TODO: Check if this is really needed! Cnsider that odata_enum_value is again handled below but depends on what get_type_kind() returned! Dealing with odata_enum_value twice appears illogical and inconsistent!
 	auto p_value = std::dynamic_pointer_cast<odata_enum_value>(property_value);
 	if (p_value)
 	{
@@ -68,10 +67,10 @@ void odata_json_operation_url_parameter_writer::handle_serialize_odata_value(
 	{
 		ss << "null";
 
-		return ;
+		return;
 	}
 
-    switch(property_type->get_type_kind())
+	switch(property_type->get_type_kind())
 	{
 	case edm_type_kind_t::Primitive:
 		{
@@ -91,7 +90,7 @@ void odata_json_operation_url_parameter_writer::handle_serialize_odata_value(
 	case edm_type_kind_t::Enum:
 		{
 			auto p_value = std::dynamic_pointer_cast<odata_enum_value>(property_value);
-			
+
 			if (p_value)
 			{
 				handle_serialize_enum_value(ss, p_value);
@@ -104,33 +103,32 @@ void odata_json_operation_url_parameter_writer::handle_serialize_odata_value(
 		break;
 	case edm_type_kind_t::Complex:
 		{
-			throw std::runtime_error("writer unsupported type!");  
+			throw std::runtime_error("writer unsupported type!");
 		}
 		break;
 	case edm_type_kind_t::Collection:
 		{
-			throw std::runtime_error("writer unsupported type!");  
+			throw std::runtime_error("writer unsupported type!");
 		}
 		break;
 	case edm_type_kind_t::Entity:
 		{
-			throw std::runtime_error("writer unsupported type!");  
+			throw std::runtime_error("writer unsupported type!");
 		}
 		break;
 	default:
 		{
-			throw std::runtime_error("writer unsupported type!");  
+			throw std::runtime_error("writer unsupported type!");
 		}
 		break;
 	}
 }
 
-void odata_json_operation_url_parameter_writer::handle_serialize_primitive_value(
-	::utility::stringstream_t& ss, const std::shared_ptr<::odata::edm::edm_primitive_type>& p_primitive_type, const std::shared_ptr<odata_primitive_value>& p_value)
+void odata_json_operation_url_parameter_writer::handle_serialize_primitive_value(::utility::stringstream_t& ss, const std::shared_ptr<::odata::edm::edm_primitive_type>& p_primitive_type, const std::shared_ptr<odata_primitive_value>& p_value)
 {
 	if (!p_primitive_type || !p_value)
 	{
-		return ;
+		return;
 	}
 
 	switch(p_primitive_type->get_primitive_kind())
@@ -139,11 +137,11 @@ void odata_json_operation_url_parameter_writer::handle_serialize_primitive_value
 		{
 			if (p_value->as<bool>())
 			{
-				ss << U("true");
+				ss << _XPLATSTR("true");
 			}
 			else
 			{
-				ss << U("false");
+				ss << _XPLATSTR("false");
 			}
 		}
 		break;
@@ -158,24 +156,24 @@ void odata_json_operation_url_parameter_writer::handle_serialize_primitive_value
 		{
 			ss << p_value->to_string();
 		}
-	    break;
+		break;
 	case edm_primitive_type_kind_t::Guid:
 	case edm_primitive_type_kind_t::String:
 	case edm_primitive_type_kind_t::Binary:
 	case edm_primitive_type_kind_t::DateTimeOffset:
 	case edm_primitive_type_kind_t::Duration:
 		{
-			ss << U('\'') << p_value->to_string() << U('\'');
+			ss << _XPLATSTR('\'') << p_value->to_string() << _XPLATSTR('\'');
 		}
 		break;
 	case edm_primitive_type_kind_t::Stream:
 		{
-			throw std::runtime_error("stream primitive value not implemented!");  
+			throw std::runtime_error("stream primitive value not implemented!");
 		}
 		break;
 	default:
 		{
-			throw std::runtime_error("unknown value not implemented!");  
+			throw std::runtime_error("unknown value not implemented!");
 		}
 		break;
 	}
@@ -185,7 +183,7 @@ void odata_json_operation_url_parameter_writer::handle_serialize_enum_value(::ut
 {
 	if (!p_value)
 	{
-		return ;
+		return;
 	}
 
 	ss << p_value->to_string();

--- a/src/core/odata_json_writer.cpp
+++ b/src/core/odata_json_writer.cpp
@@ -33,18 +33,18 @@ web::json::value odata_json_writer::serialize(std::shared_ptr<odata_value> value
 	}
 
 	::utility::stringstream_t ss;
-	ss << U("{");
-	
+	ss << _XPLATSTR("{");
+
 	auto iter = parameters.cbegin();
-	handle_serialize_odata_parameter(ss, *iter, U('"'), U(':'));
-	iter++;
-	for(; iter != parameters.cend(); iter++)
+	handle_serialize_odata_parameter(ss, *iter, _XPLATSTR('"'), _XPLATSTR(':'));
+	++iter;
+	for(; iter != parameters.cend(); ++iter)
 	{
 		ss << ",";
-		handle_serialize_odata_parameter(ss, *iter, U('"'), U(':'));
+		handle_serialize_odata_parameter(ss, *iter, _XPLATSTR('"'), _XPLATSTR(':'));
 	}
-	
-	ss << U("}");
+
+	ss << _XPLATSTR("}");
 
 	return web::json::value::parse(ss);
 }
@@ -69,29 +69,29 @@ void odata_json_writer::handle_serialize_odata_parameter(::utility::stringstream
 	}
 }
 
-void odata_json_writer::handle_serialize_odata_properties(::utility::stringstream_t& ss, const odata_property_map& properties)
+void odata_json_writer::handle_serialize_odata_properties(::utility::stringstream_t& ss, const std::pair<odata_property_map, odata_property_map>& properties)
 {
-	if (properties.size() <= 0)
+	if (properties.first.empty() && properties.second.empty())
 	{
 		ss << "null";
 
-		return ;
+		return;
 	}
 
-	ss << U("{");
+	ss << _XPLATSTR("{");
 
 	bool first = true;
 
-	for (auto iter = properties.cbegin(); iter != properties.cend(); iter++)
-	{	
+	for (auto iter = properties.first.cbegin(); iter != properties.first.cend(); ++iter)
+	{
 		if (!iter->second)
 		{
 			if (!first)
 			{
-				ss << U(",");
+				ss << _XPLATSTR(",");
 			}
 
-			ss << U('"') << iter->first << U('"') << U(":") << U("null");
+			ss << _XPLATSTR('"') << iter->first << _XPLATSTR('"') << _XPLATSTR(":") << _XPLATSTR("null");
 
 			first = false;
 		}
@@ -106,32 +106,65 @@ void odata_json_writer::handle_serialize_odata_properties(::utility::stringstrea
 
 			if (!first)
 			{
-				ss << U(",");
+				ss << _XPLATSTR(",");
 			}
 
-			ss << U('"') << iter->first << U('"') << U(":");
+			ss << _XPLATSTR('"') << iter->first << _XPLATSTR('"') << _XPLATSTR(":");
 
 			handle_serialize_odata_value(ss, property_type, iter->second);
 
 			first = false;
 		}
-		
 	}
 
-	ss << U("}");
+	for (auto iter = properties.second.cbegin(); iter != properties.second.cend(); ++iter)
+	{
+		if (!iter->second)
+		{
+			if (!first)
+			{
+				ss << _XPLATSTR(",");
+			}
+
+			ss << _XPLATSTR('"') << iter->first << _XPLATSTR('"') << _XPLATSTR(":") << _XPLATSTR("null");
+
+			first = false;
+		}
+		else
+		{
+			auto property_type = iter->second->get_value_type();
+
+			if (!is_type_serializable(property_type))
+			{
+				continue;
+			}
+
+			if (!first)
+			{
+				ss << _XPLATSTR(",");
+			}
+
+			ss << _XPLATSTR('"') << iter->first << _XPLATSTR('"') << _XPLATSTR(":");
+
+			handle_serialize_odata_value(ss, property_type, iter->second);
+
+			first = false;
+		}
+	}
+
+	ss << _XPLATSTR("}");
 }
 
-void odata_json_writer::handle_serialize_odata_value(::utility::stringstream_t& ss, 
-    const std::shared_ptr<edm_named_type>& property_type, const std::shared_ptr<odata_value>& property_value)
+void odata_json_writer::handle_serialize_odata_value(::utility::stringstream_t& ss, const std::shared_ptr<edm_named_type>& property_type, const std::shared_ptr<odata_value>& property_value)
 {
 	if (!property_type || !property_value)
 	{
 		ss << "null";
 
-		return ;
+		return;
 	}
 
-    switch(property_type->get_type_kind())
+	switch(property_type->get_type_kind())
 	{
 	case edm_type_kind_t::Primitive:
 		{
@@ -151,7 +184,7 @@ void odata_json_writer::handle_serialize_odata_value(::utility::stringstream_t& 
 	case edm_type_kind_t::Enum:
 		{
 			auto p_value = std::dynamic_pointer_cast<odata_enum_value>(property_value);
-			
+
 			if (p_value)
 			{
 				handle_serialize_enum_value(ss, p_value);
@@ -168,7 +201,7 @@ void odata_json_writer::handle_serialize_odata_value(::utility::stringstream_t& 
 
 			if (p_value)
 			{
-				ss << U('"') << p_value->to_string() << U('"');
+				ss << _XPLATSTR('"') << p_value->to_string() << _XPLATSTR('"');
 			}
 			else
 			{
@@ -182,18 +215,17 @@ void odata_json_writer::handle_serialize_odata_value(::utility::stringstream_t& 
 
 			if (p_value)
 			{
-				::utility::string_t type_link;
+				::odata::string_t type_link;
 				if (p_value->try_get(odata_json_constants::PAYLOAD_ANNOTATION_TYPE, type_link) && !type_link.empty())
 				{
-					if (type_link.find(U("#")) != 0)
+					if (type_link.front() != _XPLATSTR('#'))
 					{
-						type_link = U("#") + type_link;
-						p_value->set_value(odata_json_constants::PAYLOAD_ANNOTATION_TYPE, 
-							std::make_shared<odata_primitive_value>(std::make_shared<edm_payload_annotation_type>(odata_json_constants::PAYLOAD_ANNOTATION_TYPE), type_link));
+						type_link.insert(type_link.begin(), _XPLATSTR('#'));
+						p_value->set_value(odata_json_constants::PAYLOAD_ANNOTATION_TYPE, ::odata::make_shared<odata_primitive_value>(::odata::make_shared<edm_payload_annotation_type>(odata_json_constants::PAYLOAD_ANNOTATION_TYPE), type_link));
 					}
 				}
 
-				handle_serialize_odata_properties(ss, p_value->properties());
+				handle_serialize_odata_properties(ss, p_value->all_properties());
 			}
 			else
 			{
@@ -221,18 +253,17 @@ void odata_json_writer::handle_serialize_odata_value(::utility::stringstream_t& 
 
 			if (p_value)
 			{
-				::utility::string_t type_link;
+				::odata::string_t type_link;
 				if (p_value->try_get(odata_json_constants::PAYLOAD_ANNOTATION_TYPE, type_link) && !type_link.empty())
 				{
-					if (type_link.find(U("#")) != 0)
+					if (type_link.front() != _XPLATSTR('#'))
 					{
-						type_link = U("#") + type_link;
-						p_value->set_value(odata_json_constants::PAYLOAD_ANNOTATION_TYPE, 
-							std::make_shared<odata_primitive_value>(std::make_shared<edm_payload_annotation_type>(odata_json_constants::PAYLOAD_ANNOTATION_TYPE), type_link));
+						type_link.insert(type_link.begin(), _XPLATSTR('#'));
+						p_value->set_value(odata_json_constants::PAYLOAD_ANNOTATION_TYPE, ::odata::make_shared<odata_primitive_value>(::odata::make_shared<edm_payload_annotation_type>(odata_json_constants::PAYLOAD_ANNOTATION_TYPE), type_link));
 					}
 				}
 
-				handle_serialize_odata_properties(ss, p_value->properties());
+				handle_serialize_odata_properties(ss, p_value->all_properties());
 			}
 			else
 			{
@@ -242,18 +273,17 @@ void odata_json_writer::handle_serialize_odata_value(::utility::stringstream_t& 
 		break;
 	default:
 		{
-			throw std::runtime_error("write unsupported property type!");  
+			throw std::runtime_error("write unsupported property type!");
 		}
 		break;
 	}
 }
 
-void odata_json_writer::handle_serialize_primitive_value(::utility::stringstream_t& ss, 
-    const std::shared_ptr<edm_primitive_type>& p_primitive_type, const std::shared_ptr<odata_primitive_value>& p_value)
+void odata_json_writer::handle_serialize_primitive_value(::utility::stringstream_t& ss, const std::shared_ptr<edm_primitive_type>& p_primitive_type, const std::shared_ptr<odata_primitive_value>& p_value)
 {
 	if (!p_primitive_type || !p_value)
 	{
-		return ;
+		return;
 	}
 
 	switch(p_primitive_type->get_primitive_kind())
@@ -262,11 +292,11 @@ void odata_json_writer::handle_serialize_primitive_value(::utility::stringstream
 		{
 			if (p_value->as<bool>())
 			{
-				ss << U("true");
+				ss << _XPLATSTR("true");
 			}
 			else
 			{
-				ss << U("false");
+				ss << _XPLATSTR("false");
 			}
 		}
 		break;
@@ -281,28 +311,28 @@ void odata_json_writer::handle_serialize_primitive_value(::utility::stringstream
 		{
 			ss << p_value->to_string();
 		}
-	    break;
+		break;
 	case edm_primitive_type_kind_t::Guid:
 	case edm_primitive_type_kind_t::Binary:
 	case edm_primitive_type_kind_t::DateTimeOffset:
 	case edm_primitive_type_kind_t::Duration:
 		{
-			ss << U('"') << p_value->to_string() << U('"');
+			ss << _XPLATSTR('"') << p_value->to_string() << _XPLATSTR('"');
 		}
 		break;
 	case edm_primitive_type_kind_t::String:
 		{
-			ss << U('"') << p_value->to_string() << U('"');
+			ss << _XPLATSTR('"') << p_value->to_string() << _XPLATSTR('"');
 		}
 		break;
 	case edm_primitive_type_kind_t::Stream:
 		{
-			throw std::runtime_error("stream primitive value not implemented!");  
+			throw std::runtime_error("stream primitive value not implemented!");
 		}
 		break;
 	default:
 		{
-			throw std::runtime_error("unknown value not implemented!");  
+			throw std::runtime_error("unknown value not implemented!");
 		}
 		break;
 	}
@@ -313,33 +343,33 @@ void odata_json_writer::handle_serialize_enum_value(::utility::stringstream_t& s
 {
 	if (!p_value)
 	{
-		return ;
+		return;
 	}
 
-	ss << U('"') << p_value->to_string() << U('"');
+	ss << _XPLATSTR('"') << p_value->to_string() << _XPLATSTR('"');
 }
 
 void odata_json_writer::handle_serialize_collection_value(::utility::stringstream_t& ss, const std::shared_ptr<odata_collection_value>& p_value)
 {
 	if (!p_value)
 	{
-		return ;
+		return;
 	}
 
-	if (p_value->get_collection_values().size() == 0)
+	if (p_value->get_collection_values().empty())
 	{
-		ss << U("[]");
+		ss << _XPLATSTR("[]");
 
-		return ;
+		return;
 	}
 
-	ss << U("[");
+	ss << _XPLATSTR("[");
 
 	bool first = true;
 
-	auto element_type = p_value->get_collection_values()[0]->get_value_type();
+	auto element_type = p_value->get_collection_values().front()->get_value_type();
 
-	for (auto iter = p_value->get_collection_values().cbegin(); iter != p_value->get_collection_values().cend(); iter++)
+	for (auto iter = p_value->get_collection_values().cbegin(); iter != p_value->get_collection_values().cend(); ++iter)
 	{
 		if (!is_type_serializable(element_type))
 		{
@@ -348,7 +378,7 @@ void odata_json_writer::handle_serialize_collection_value(::utility::stringstrea
 
 		if (!first)
 		{
-			ss << U(",");
+			ss << _XPLATSTR(",");
 		}
 
 		handle_serialize_odata_value(ss, element_type, *iter);
@@ -356,26 +386,40 @@ void odata_json_writer::handle_serialize_collection_value(::utility::stringstrea
 		first = false;
 	}
 
-	ss << U("]");
+	ss << _XPLATSTR("]");
 }
 
 bool odata_json_writer::is_type_serializable(const std::shared_ptr<edm_named_type>& property_type)
 {
-	if (property_type)
+	if (!property_type)
 	{
-		if (property_type->get_type_kind() == edm_type_kind_t::Collection
-			|| property_type->get_type_kind() == edm_type_kind_t::Entity
-			|| property_type->get_type_kind() == edm_type_kind_t::Complex
-			|| property_type->get_type_kind() == edm_type_kind_t::Primitive
-			|| property_type->get_type_kind() == edm_type_kind_t::Enum
-	        || (property_type->get_type_kind() == edm_type_kind_t::PayloadAnnotation) 
-			&& (property_type->get_name() == odata_json_constants::PAYLOAD_ANNOTATION_TYPE || property_type->get_name() == odata_json_constants::PAYLOAD_ANNOTATION_ID))
-		{
-			return true;
-		}
+		return false;
 	}
 
-	return false;
+	// These are always serializable
+	if ((property_type->get_type_kind() == edm_type_kind_t::Collection) ||
+	    (property_type->get_type_kind() == edm_type_kind_t::Entity)     ||
+	    (property_type->get_type_kind() == edm_type_kind_t::Complex)    ||
+	    (property_type->get_type_kind() == edm_type_kind_t::Primitive)  ||
+	    (property_type->get_type_kind() == edm_type_kind_t::Enum))
+	{
+		return true;
+	}
+
+	// Everything except PayloadAnnotation is never serializable
+	if ((property_type->get_type_kind() != edm_type_kind_t::PayloadAnnotation))
+	{
+		return false;
+	}
+
+	// PAYLOAD_ANNOTATION_ID is always serializable
+	if (property_type->get_name() == odata_json_constants::PAYLOAD_ANNOTATION_ID)
+	{
+		return true;
+	}
+
+	// Serialize PAYLOAD_ANNOTATION_TYPE only if it shall not be suppressed
+	return !m_options.get_suppress_odata_type() && (property_type->get_name() == odata_json_constants::PAYLOAD_ANNOTATION_TYPE);
 }
 
 }}

--- a/src/core/odata_primitive_value.cpp
+++ b/src/core/odata_primitive_value.cpp
@@ -7,7 +7,7 @@
 #include "odata/core/odata_core.h"
 #include "odata/edm/edm_model_utility.h"
 #include "cpprest/http_msg.h"
-#include "cpprest/http_helpers.h"
+#include "cpprest/details/http_helpers.h"
 
 using namespace ::pplx;
 using namespace ::web;
@@ -18,8 +18,7 @@ namespace odata { namespace core
 
 void odata_primitive_value::_try_get(std::vector<unsigned char>& value) const
 {
-	std::vector<unsigned char> temp(::utility::conversions::from_base64(to_string()));
-    value.swap(temp);
+	value = ::utility::conversions::from_base64(to_string());
 }
 
 void odata_primitive_value::_try_get(unsigned char& value) const
@@ -27,7 +26,7 @@ void odata_primitive_value::_try_get(unsigned char& value) const
 	const auto& propValue = to_string();
 
 	int16_t v;
-    http::bind(propValue, v);
+	http::bind(propValue, v);
 	value = (unsigned char)v;
 }
 
@@ -36,66 +35,65 @@ void odata_primitive_value::_try_get(char& value) const
 	const auto& propValue = to_string();
 
 	int32_t v;
-    http::bind(propValue, v);
+	http::bind(propValue, v);
 	value = (char)v;
 }
 
 void odata_primitive_value::_try_get(bool& value) const
 {
-    const auto& propValue = to_string();
-    if (propValue == U("false") || propValue == U("0")) value = false;
-    else value = true;
+	const auto& propValue = to_string();
+	value = (propValue != _XPLATSTR("false")) && (propValue != _XPLATSTR("0"));
 }
 
 void odata_primitive_value::_try_get(::utility::datetime& value) const
 {
-    value = ::utility::datetime::from_string(to_string(), ::utility::datetime::ISO_8601);
+	value = ::utility::datetime::from_string(to_string(), ::utility::datetime::ISO_8601);
 }
 
 void odata_primitive_value::_try_get(::utility::seconds& value) const
 {
-    value = ::utility::timespan::xml_duration_to_seconds(to_string());
+	value = ::utility::timespan::xml_duration_to_seconds(to_string());
 }
 
 void odata_primitive_value::_try_get(double& value) const
 {
-    const auto& propValue = to_string();
-    http::bind(propValue, value);
+	const auto& propValue = to_string();
+	http::bind(propValue, value);
 }
 
 void odata_primitive_value::_try_get(float& value) const
 {
-    const auto& propValue = to_string();
-    http::bind(propValue, value);
+	const auto& propValue = to_string();
+	http::bind(propValue, value);
 }
 
 void odata_primitive_value::_try_get(int16_t& value) const
 {
-    const auto& propValue = to_string();
-    http::bind(propValue, value);
+	const auto& propValue = to_string();
+	http::bind(propValue, value);
 }
 
 void odata_primitive_value::_try_get(int32_t& value) const
 {
-    const auto& propValue = to_string();
-    http::bind(propValue, value);
+	const auto& propValue = to_string();
+	http::bind(propValue, value);
 }
 
 void odata_primitive_value::_try_get(int64_t& value) const
 {
-    const auto& propValue = to_string();
-    http::bind(propValue, value);
+	const auto& propValue = to_string();
+	http::bind(propValue, value);
 }
 
 void odata_primitive_value::_try_get(uint64_t& value) const
 {
-    const auto& propValue = to_string();
-    http::bind(propValue, value);
+	const auto& propValue = to_string();
+	http::bind(propValue, value);
 }
 
-void odata_primitive_value::_try_get(::utility::string_t& value) const
+void odata_primitive_value::_try_get(::odata::string_t& value) const
 {
-    value = to_string();
+	value = to_string();
 }
 
 }}

--- a/src/core/odata_property_map.cpp
+++ b/src/core/odata_property_map.cpp
@@ -7,7 +7,7 @@
 #include "odata/core/odata_core.h"
 #include "odata/edm/edm_model_utility.h"
 #include "cpprest/http_msg.h"
-#include "cpprest/http_helpers.h"
+#include "cpprest/details/http_helpers.h"
 
 using namespace ::pplx;
 using namespace ::web;
@@ -16,306 +16,298 @@ using namespace ::odata::edm;
 namespace odata { namespace core
 {
 
-bool odata_property_map::try_get(const ::utility::string_t& property_name, char& value) const
-{
-    auto found = find_property(property_name);
-    if (found.first)
-    {
-	    auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
-		if (primitive_value)
-		{
-            const auto& propValue = primitive_value->to_string();
-#ifdef _UTF16_STRINGS
-            std::istringstream iss(::utility::conversions::utf16_to_utf8(propValue));
-#else
-            std::istringstream iss(propValue);
-#endif
-            iss >> value;
-
-            return true;
-		}
-    }
-    return false;
-}
-
-bool odata_property_map::try_get(const ::utility::string_t& property_name, unsigned char& value) const
-{
-    auto found = find_property(property_name);
-    if (found.first)
-    {
-	    auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
-		if (primitive_value)
-		{
-            const auto& propValue = primitive_value->to_string();
-#ifdef _UTF16_STRINGS
-            std::istringstream iss(::utility::conversions::utf16_to_utf8(propValue));
-#else
-            std::istringstream iss(propValue);
-#endif
-            iss >> value;
-
-            return true;
-		}
-    }
-    return false;
-}
-
-bool odata_property_map::try_get(const ::utility::string_t& property_name, std::vector<unsigned char>& value) const
+bool odata_property_map::try_get(const ::odata::string_t& property_name, char& value) const
 {
 	auto found = find_property(property_name);
-    if (found.first)
-    {
+	if (found.first)
+	{
 		auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
 		if (primitive_value)
 		{
-		    std::vector<unsigned char> temp(::utility::conversions::from_base64(primitive_value->to_string()));
-            value.swap(temp);
-		    return true;
+			const auto& propValue = primitive_value->to_string();
+#ifdef _UTF16_STRINGS
+			std::istringstream iss(::utility::conversions::utf16_to_utf8(propValue));
+#else
+			std::istringstream iss(propValue);
+#endif
+			iss >> value;
+
+			return true;
 		}
-    }
-    return false;
+	}
+	return false;
 }
 
-bool odata_property_map::try_get(const ::utility::string_t& property_name, bool& value) const
+bool odata_property_map::try_get(const ::odata::string_t& property_name, unsigned char& value) const
 {
-    auto found = find_property(property_name);
-    if (found.first)
-    {
-	    auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
+	auto found = find_property(property_name);
+	if (found.first)
+	{
+		auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
 		if (primitive_value)
 		{
-            const auto& propValue = primitive_value->to_string();
-            if (propValue == U("true") || propValue == U("1")) value = true;
-            else value = false;
-            return true;
+			const auto& propValue = primitive_value->to_string();
+#ifdef _UTF16_STRINGS
+			std::istringstream iss(::utility::conversions::utf16_to_utf8(propValue));
+#else
+			std::istringstream iss(propValue);
+#endif
+			iss >> value;
+
+			return true;
 		}
-    }
-    return false;
+	}
+	return false;
 }
 
-bool odata_property_map::try_get(const ::utility::string_t& property_name, ::utility::datetime& value) const
+bool odata_property_map::try_get(const ::odata::string_t& property_name, std::vector<unsigned char>& value) const
 {
-   auto found = find_property(property_name);
-    if (found.first)
-    {
-	    auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
+	auto found = find_property(property_name);
+	if (found.first)
+	{
+		auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
 		if (primitive_value)
 		{
-            value = ::utility::datetime::from_string(primitive_value->to_string(), ::utility::datetime::ISO_8601);
-            return true;
+			value = ::utility::conversions::from_base64(primitive_value->to_string());
+			return true;
 		}
-    }
-    return false;
+	}
+	return false;
 }
 
-bool odata_property_map::try_get(const ::utility::string_t& property_name, ::utility::seconds& value) const
+bool odata_property_map::try_get(const ::odata::string_t& property_name, bool& value) const
 {
-   auto found = find_property(property_name);
-    if (found.first)
-    {
-	    auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
+	auto found = find_property(property_name);
+	if (found.first)
+	{
+		auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
+		if (primitive_value)
+		{
+			const auto& propValue = primitive_value->to_string();
+			value = (propValue == _XPLATSTR("true")) || (propValue == _XPLATSTR("1"));
+			return true;
+		}
+	}
+	return false;
+}
+
+bool odata_property_map::try_get(const ::odata::string_t& property_name, ::utility::datetime& value) const
+{
+	auto found = find_property(property_name);
+	if (found.first)
+	{
+		auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
+		if (primitive_value)
+		{
+			value = ::utility::datetime::from_string(primitive_value->to_string(), ::utility::datetime::ISO_8601);
+			return true;
+		}
+	}
+	return false;
+}
+
+bool odata_property_map::try_get(const ::odata::string_t& property_name, ::utility::seconds& value) const
+{
+	auto found = find_property(property_name);
+	if (found.first)
+	{
+		auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
 		if (primitive_value)
 		{
 			value = ::utility::timespan::xml_duration_to_seconds(primitive_value->to_string());
-            return true;
+			return true;
 		}
-    }
-    return false;
+	}
+	return false;
 }
 
-bool odata_property_map::try_get(const ::utility::string_t& property_name, double& value) const
-{
-    auto found = find_property(property_name);
-    if (found.first)
-    {
-	    auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
-		if (primitive_value)
-		{
-            const auto& propValue = primitive_value->to_string();
-            http::bind(propValue, value);
-            return true;
-		}
-    }
-    return false;
-}
-
-bool odata_property_map::try_get(const ::utility::string_t& property_name, float& value) const
-{
-    auto found = find_property(property_name);
-    if (found.first)
-    {
-	    auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
-		if (primitive_value)
-		{
-            const auto& propValue = primitive_value->to_string();
-            http::bind(propValue, value);
-            return true;
-		}
-    }
-    return false;
-}
-
-bool odata_property_map::try_get(const ::utility::string_t& property_name, int16_t& value) const
-{
-    auto found = find_property(property_name);
-    if (found.first)
-    {
-	    auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
-		if (primitive_value)
-		{
-            const auto& propValue = primitive_value->to_string();
-            http::bind(propValue, value);
-            return true;
-		}
-    }
-    return false;
-}
-
-bool odata_property_map::try_get(const ::utility::string_t& property_name, int32_t& value) const
-{
-    auto found = find_property(property_name);
-    if (found.first)
-    {
-	    auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
-		if (primitive_value)
-		{
-            const auto& propValue = primitive_value->to_string();
-            http::bind(propValue, value);
-            return true;
-		}
-    }
-    return false;
-}
-
-bool odata_property_map::try_get(const ::utility::string_t& property_name, int64_t& value) const
-{
-    auto found = find_property(property_name);
-    if (found.first)
-    {
-	    auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
-		if (primitive_value)
-		{
-            const auto& propValue = primitive_value->to_string();
-            http::bind(propValue, value);
-            return true;
-		}
-    }
-    return false;
-}
-
-bool odata_property_map::try_get(const ::utility::string_t& property_name, ::utility::string_t& value) const
-{
-    auto found = find_property(property_name);
-    if (found.first)
-    {
-	    auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
-		if (primitive_value)
-		{
-            value = primitive_value->to_string();
-            return true;
-		}
-    }
-    return false;
-}
-
-bool odata_property_map::try_get(const ::utility::string_t& property_name, odata_property_map& value) const
+bool odata_property_map::try_get(const ::odata::string_t& property_name, double& value) const
 {
 	auto found = find_property(property_name);
-    if (found.first)
-    {
+	if (found.first)
+	{
+		auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
+		if (primitive_value)
+		{
+			const auto& propValue = primitive_value->to_string();
+			http::bind(propValue, value);
+			return true;
+		}
+	}
+	return false;
+}
+
+bool odata_property_map::try_get(const ::odata::string_t& property_name, float& value) const
+{
+	auto found = find_property(property_name);
+	if (found.first)
+	{
+		auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
+		if (primitive_value)
+		{
+			const auto& propValue = primitive_value->to_string();
+			http::bind(propValue, value);
+			return true;
+		}
+	}
+	return false;
+}
+
+bool odata_property_map::try_get(const ::odata::string_t& property_name, int16_t& value) const
+{
+	auto found = find_property(property_name);
+	if (found.first)
+	{
+		auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
+		if (primitive_value)
+		{
+			const auto& propValue = primitive_value->to_string();
+			http::bind(propValue, value);
+			return true;
+		}
+	}
+	return false;
+}
+
+bool odata_property_map::try_get(const ::odata::string_t& property_name, int32_t& value) const
+{
+	auto found = find_property(property_name);
+	if (found.first)
+	{
+		auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
+		if (primitive_value)
+		{
+			const auto& propValue = primitive_value->to_string();
+			http::bind(propValue, value);
+			return true;
+		}
+	}
+	return false;
+}
+
+bool odata_property_map::try_get(const ::odata::string_t& property_name, int64_t& value) const
+{
+	auto found = find_property(property_name);
+	if (found.first)
+	{
+		auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
+		if (primitive_value)
+		{
+			const auto& propValue = primitive_value->to_string();
+			http::bind(propValue, value);
+			return true;
+		}
+	}
+	return false;
+}
+
+bool odata_property_map::try_get(const ::odata::string_t& property_name, ::odata::string_t& value) const
+{
+	auto found = find_property(property_name);
+	if (found.first)
+	{
+		auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
+		if (primitive_value)
+		{
+			value = primitive_value->to_string();
+			return true;
+		}
+	}
+	return false;
+}
+
+bool odata_property_map::try_get(const ::odata::string_t& property_name, odata_property_map& value) const
+{
+	auto found = find_property(property_name);
+	if (found.first)
+	{
 		std::shared_ptr<odata_complex_value> p_complex_value = std::dynamic_pointer_cast<odata_complex_value>(found.second);
 		if (p_complex_value)
 		{
-		    value = p_complex_value->properties();
-            return true;
+			value = p_complex_value->properties();
+			return true;
 		}
-    }
-    return false;
+	}
+	return false;
 }
 
-bool odata_property_map::try_get(const ::utility::string_t& property_name, std::shared_ptr<odata_value>& value) const
+bool odata_property_map::try_get(const ::odata::string_t& property_name, std::shared_ptr<odata_value>& value) const
 {
-    auto found = find_property(property_name);
-    if (found.first)
-    {
-        value = found.second;
-        return true;
-    }
-    return false;
+	auto found = find_property(property_name);
+	if (found.first)
+	{
+		value = found.second;
+		return true;
+	}
+	return false;
 }
 
-bool odata_property_map::try_get(const ::utility::string_t& property_name, std::shared_ptr<odata_complex_value>& value) const
+bool odata_property_map::try_get(const ::odata::string_t& property_name, std::shared_ptr<odata_complex_value>& value) const
 {
-    auto found = find_property(property_name);
-    if (found.first)
-    {
+	auto found = find_property(property_name);
+	if (found.first)
+	{
 		value = std::dynamic_pointer_cast<odata_complex_value>(found.second);
-        return true;
-    }
-    return false;
+		return true;
+	}
+	return false;
 }
 
-bool odata_property_map::try_get(const ::utility::string_t& property_name, std::shared_ptr<odata_primitive_value>& value) const
+bool odata_property_map::try_get(const ::odata::string_t& property_name, std::shared_ptr<odata_primitive_value>& value) const
 {
-    auto found = find_property(property_name);
-    if (found.first)
-    {
-        value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
-        return true;
-    }
-    return false;
+	auto found = find_property(property_name);
+	if (found.first)
+	{
+		value = std::dynamic_pointer_cast<odata_primitive_value>(found.second);
+		return true;
+	}
+	return false;
 }
 
-bool odata_property_map::try_get(const ::utility::string_t& property_name, std::shared_ptr<odata_entity_value>& value) const
+bool odata_property_map::try_get(const ::odata::string_t& property_name, std::shared_ptr<odata_entity_value>& value) const
 {
-    auto found = find_property(property_name);
-    if (found.first)
-    {
-        value = std::dynamic_pointer_cast<odata_entity_value>(found.second);
-        return true;
-    }
-    return false;
+	auto found = find_property(property_name);
+	if (found.first)
+	{
+		value = std::dynamic_pointer_cast<odata_entity_value>(found.second);
+		return true;
+	}
+	return false;
 }
 
-bool odata_property_map::try_get(const ::utility::string_t& property_name, std::shared_ptr<odata_enum_value>& value) const
+bool odata_property_map::try_get(const ::odata::string_t& property_name, std::shared_ptr<odata_enum_value>& value) const
 {
-    auto found = find_property(property_name);
-    if (found.first)
-    {
-        value = std::dynamic_pointer_cast<odata_enum_value>(found.second);
-        return true;
-    }
-    return false;
+	auto found = find_property(property_name);
+	if (found.first)
+	{
+		value = std::dynamic_pointer_cast<odata_enum_value>(found.second);
+		return true;
+	}
+	return false;
 }
 
-bool odata_property_map::try_get(const ::utility::string_t& property_name, std::shared_ptr<odata_collection_value>& value) const
+bool odata_property_map::try_get(const ::odata::string_t& property_name, std::shared_ptr<odata_collection_value>& value) const
 {
-    auto found = find_property(property_name);
-    if (found.first)
-    {
-        value = std::dynamic_pointer_cast<odata_collection_value>(found.second);
-        return true;
-    }
-    return false;
+	auto found = find_property(property_name);
+	if (found.first)
+	{
+		value = std::dynamic_pointer_cast<odata_collection_value>(found.second);
+		return true;
+	}
+	return false;
 }
 
-std::pair<bool, std::shared_ptr<odata_value>> odata_property_map::find_property(const ::utility::string_t& property_name) const
- {
-    const auto& findIt = m_properties.find(property_name);
-    bool found = (findIt != m_properties.end());
+std::pair<bool, std::shared_ptr<odata_value>> odata_property_map::find_property(const ::odata::string_t& property_name) const
+{
+	const auto& findIt = m_properties.find(property_name);
+	bool found = (findIt != m_properties.end());
 
-    if (found)
-    {
-        const auto& propDetails = findIt->second;
+	if (found)
+	{
+		return make_pair(found, findIt->second);
+	}
 
-		if (!propDetails)
-		{
-			return make_pair(found, propDetails);
-		}
+	return make_pair(found, std::shared_ptr<odata_value>());
+}
 
-        return make_pair(found, propDetails);	 
-    }
-
-    return make_pair(found, std::shared_ptr<odata_value>());	 
- }
 }}

--- a/src/core/odata_structured_value.cpp
+++ b/src/core/odata_structured_value.cpp
@@ -17,7 +17,7 @@ using namespace odata::edm;
 namespace odata { namespace core
 {
 
-void odata_structured_value::set_value(const ::utility::string_t& property_name, const ::utility::string_t& string_value)
+void odata_structured_value::set_value(const ::odata::string_t& property_name, const ::odata::string_t& string_value)
 {
 	bool setted = false;
 	std::shared_ptr<odata_value> property_value;
@@ -27,39 +27,59 @@ void odata_structured_value::set_value(const ::utility::string_t& property_name,
 		if (property_type && (property_type->get_type_kind() == edm_type_kind_t::Primitive))
 		{
 			setted = true;
-			m_properties[property_name] = std::make_shared<odata_primitive_value>(std::dynamic_pointer_cast<edm_primitive_type>(property_type), string_value);
+			m_properties.first[property_name] = ::odata::make_shared<odata_primitive_value>(std::dynamic_pointer_cast<edm_primitive_type>(property_type), string_value);
 		}
 	}
-		
+
 	if (!setted)
 	{
-		m_properties[property_name] = std::make_shared<odata_primitive_value>(edm_primitive_type::STRING(), string_value);
+		m_properties.first[property_name] = ::odata::make_shared<odata_primitive_value>(edm_primitive_type::STRING(), string_value);
 	}
 }
 
-void odata_structured_value::set_value(const ::utility::string_t& property_name, std::shared_ptr<odata_primitive_value> property_value)
+void odata_structured_value::set_value(const ::odata::string_t& property_name, std::shared_ptr<odata_primitive_value> property_value)
 {
-    m_properties[property_name] = property_value;
+	m_properties.first[property_name] = property_value;
 }
 
-void odata_structured_value::set_value(const ::utility::string_t& property_name, std::shared_ptr<odata_complex_value> property_value)
+void odata_structured_value::set_value(const ::odata::string_t& property_name, std::shared_ptr<odata_complex_value> property_value)
 {
-	m_properties[property_name] = property_value;
+	m_properties.first[property_name] = property_value;
 }
 
-void odata_structured_value::set_value(const ::utility::string_t& property_name, std::shared_ptr<odata_entity_value> property_value)
+void odata_structured_value::set_value(const ::odata::string_t& property_name, std::shared_ptr<odata_entity_value> property_value)
 {
-	m_properties[property_name] = property_value;
+	m_properties.first[property_name] = property_value;
 }
 
-void odata_structured_value::set_value(const ::utility::string_t& property_name, std::shared_ptr<odata_enum_value> property_value)
+void odata_structured_value::set_value(const ::odata::string_t& property_name, std::shared_ptr<odata_enum_value> property_value)
 {
-	m_properties[property_name] = property_value;
+	m_properties.first[property_name] = property_value;
 }
 
-void odata_structured_value::set_value(const ::utility::string_t& property_name, std::shared_ptr<odata_collection_value> property_value)
+void odata_structured_value::set_value(const ::odata::string_t& property_name, std::shared_ptr<odata_collection_value> property_value)
 {
-	m_properties[property_name] = property_value;
+	m_properties.first[property_name] = property_value;
+}
+
+void odata_structured_value::set_open_value(const ::odata::string_t& property_name, const ::odata::string_t& string_value)
+{
+	bool setted = false;
+	std::shared_ptr<odata_value> property_value;
+	if (get_open_property_value(property_name, property_value))
+	{
+		std::shared_ptr<edm_named_type> property_type = property_value->get_value_type();
+		if (property_type && (property_type->get_type_kind() == edm_type_kind_t::Primitive))
+		{
+			setted = true;
+			m_properties.second[property_name] = ::odata::make_shared<odata_primitive_value>(std::dynamic_pointer_cast<edm_primitive_type>(property_type), string_value);
+		}
+	}
+
+	if (!setted)
+	{
+		m_properties.second[property_name] = ::odata::make_shared<odata_primitive_value>(edm_primitive_type::STRING(), string_value);
+	}
 }
 
 }}

--- a/src/edm/edm_entity_container.cpp
+++ b/src/edm/edm_entity_container.cpp
@@ -9,31 +9,31 @@
 namespace odata { namespace edm
 {
 
-std::shared_ptr<edm_entity_set> edm_entity_container::find_entity_set(::utility::string_t name) const
+std::shared_ptr<edm_entity_set> edm_entity_container::find_entity_set(::odata::string_t name) const
 {
-    auto find_iter = m_entity_sets.find(name);
+	auto find_iter = m_entity_sets.find(name);
 	if (find_iter != m_entity_sets.end())
 	{
 		return find_iter->second;
 	}
 
-    return nullptr;
+	return nullptr;
 }
 
-std::shared_ptr<edm_singleton> edm_entity_container::find_singleton(::utility::string_t name) const
+std::shared_ptr<edm_singleton> edm_entity_container::find_singleton(::odata::string_t name) const
 {
-    auto find_iter = m_singletons.find(name);
+	auto find_iter = m_singletons.find(name);
 	if (find_iter != m_singletons.end())
 	{
 		return find_iter->second;
 	}
 
-    return nullptr;
+	return nullptr;
 }
 
-std::shared_ptr<edm_operation_import> edm_entity_container::find_operation_import(::utility::string_t name) const
+std::shared_ptr<edm_operation_import> edm_entity_container::find_operation_import(::odata::string_t name) const
 {
-    auto find_iter = m_operation_imports.find(name);
+	auto find_iter = m_operation_imports.find(name);
 	if (find_iter != m_operation_imports.end())
 	{
 		return find_iter->second;

--- a/src/edm/edm_model.cpp
+++ b/src/edm/edm_model.cpp
@@ -9,99 +9,100 @@
 namespace odata { namespace edm
 {
 
-std::shared_ptr<edm_entity_container> edm_schema::find_container(::utility::string_t name) const
+std::shared_ptr<edm_entity_container> edm_schema::find_container(::odata::string_t name) const
 {
-    if (name.empty())
-    {
-        for (auto ent = m_entity_containers.begin(); ent != m_entity_containers.end(); ++ent)
-        {
+	if (name.empty())
+	{
+		for (auto ent = m_entity_containers.begin(); ent != m_entity_containers.end(); ++ent)
+		{
 			if (ent->second->is_default_container())
 			{
 				return ent->second;
 			}
-        }
-    }
-    else
-    {
-        for (auto ent = m_entity_containers.begin(); ent != m_entity_containers.end(); ++ent)
-        {
+		}
+	}
+	else
+	{
+		for (auto ent = m_entity_containers.begin(); ent != m_entity_containers.end(); ++ent)
+		{
 			if (ent->second->get_name() == name)
 			{
 				return ent->second;
 			}
-        }
-    }
-
-    return nullptr;
-}
-
-std::shared_ptr<edm_entity_type> edm_model::find_entity_type(::utility::string_t name) const
-{
-    for (auto sc = m_schemata.cbegin(); sc != m_schemata.cend(); ++sc)
-    {
-        auto et_ptr = (*sc)->find_entity_type(name);
-        if (et_ptr)
-		{
-            return et_ptr;
 		}
-    }
+	}
 
-    return nullptr;
+	return nullptr;
 }
 
-std::shared_ptr<edm_complex_type> edm_model::find_complex_type(::utility::string_t name) const
+std::shared_ptr<edm_entity_type> edm_model::find_entity_type(::odata::string_t name) const
 {
-    for (auto sc = m_schemata.cbegin(); sc != m_schemata.cend(); ++sc)
-    {
-        auto cp_ptr = (*sc)->find_complex_type(name);
-        if (cp_ptr)
+	for (auto sc = m_schemata.cbegin(); sc != m_schemata.cend(); ++sc)
+	{
+		auto et_ptr = (*sc)->find_entity_type(name);
+		if (et_ptr)
 		{
-            return cp_ptr;
+			return et_ptr;
 		}
-    }
+	}
 
-    return nullptr;
+	return nullptr;
 }
 
-std::shared_ptr<edm_enum_type> edm_model::find_enum_type(::utility::string_t name) const
+std::shared_ptr<edm_complex_type> edm_model::find_complex_type(::odata::string_t name) const
 {
-    for (auto sc = m_schemata.cbegin(); sc != m_schemata.cend(); ++sc)
-    {
-        auto en_ptr = (*sc)->find_enum_type(name);
-        if (en_ptr)
+	for (auto sc = m_schemata.cbegin(); sc != m_schemata.cend(); ++sc)
+	{
+		auto cp_ptr = (*sc)->find_complex_type(name);
+		if (cp_ptr)
 		{
-            return en_ptr;
+			return cp_ptr;
 		}
-    }
+	}
 
-    return nullptr;
+	return nullptr;
 }
 
-std::shared_ptr<edm_operation_type> edm_model::find_operation_type(::utility::string_t name) const
+std::shared_ptr<edm_enum_type> edm_model::find_enum_type(::odata::string_t name) const
 {
-    for (auto sc = m_schemata.cbegin(); sc != m_schemata.cend(); ++sc)
-    {
-        auto op_ptr = (*sc)->find_operation_type(name);
-        if (op_ptr)
+	for (auto sc = m_schemata.cbegin(); sc != m_schemata.cend(); ++sc)
+	{
+		auto en_ptr = (*sc)->find_enum_type(name);
+		if (en_ptr)
 		{
-            return op_ptr;
+			return en_ptr;
 		}
-    }
+	}
 
-    return nullptr;
+	return nullptr;
 }
 
-std::shared_ptr<edm_entity_container> edm_model::find_container(::utility::string_t name) const
+std::shared_ptr<edm_operation_type> edm_model::find_operation_type(::odata::string_t name) const
 {
-    for (auto sc = m_schemata.cbegin(); sc != m_schemata.cend(); ++sc)
-    {
-        auto cn_ptr = (*sc)->find_container(name);
-        if (cn_ptr)
+	for (auto sc = m_schemata.cbegin(); sc != m_schemata.cend(); ++sc)
+	{
+		auto op_ptr = (*sc)->find_operation_type(name);
+		if (op_ptr)
 		{
-            return cn_ptr;
+			return op_ptr;
 		}
-    }
+	}
 
-    return nullptr;
+	return nullptr;
 }
+
+std::shared_ptr<edm_entity_container> edm_model::find_container(::odata::string_t name) const
+{
+	for (auto sc = m_schemata.cbegin(); sc != m_schemata.cend(); ++sc)
+	{
+		auto cn_ptr = (*sc)->find_container(name);
+		if (cn_ptr)
+		{
+			return cn_ptr;
+		}
+	}
+
+	return nullptr;
+}
+
 }}

--- a/src/edm/edm_model_reader.cpp
+++ b/src/edm/edm_model_reader.cpp
@@ -18,338 +18,337 @@ bool edm_model_reader::parse()
 	return ret;
 }
 
-void edm_model_reader::handle_begin_element(const ::utility::string_t& elementName)
+void edm_model_reader::handle_begin_element(const ::odata::string_t& elementName)
 {
-	if (elementName == U("Edmx"))
+	if (elementName == _XPLATSTR("Edmx"))
 	{
 		while (move_to_next_attribute())
 		{
-			if(get_current_element_name() == U("Version"))
+			if(get_current_element_name() == _XPLATSTR("Version"))
 			{
 				m_model->set_version(get_current_element_text());
 			}
 		}
 	}
-    else if (elementName == U("Schema"))
-    {
-        ::utility::string_t namesp;
-        ::utility::string_t alias;
+	else if (elementName == _XPLATSTR("Schema"))
+	{
+		::odata::string_t namesp;
+		::odata::string_t alias;
 
-        while (move_to_next_attribute())
-        {
-            if(get_current_element_name() == U("Namespace"))
-            {
-                namesp = get_current_element_text();
-            }
+		while (move_to_next_attribute())
+		{
+			if(get_current_element_name() == _XPLATSTR("Namespace"))
+			{
+				namesp = get_current_element_text();
+			}
 
-            if(get_current_element_name() == U("Alias"))
-            {
-                alias = get_current_element_text();
-            }
-        }
+			if(get_current_element_name() == _XPLATSTR("Alias"))
+			{
+				alias = get_current_element_text();
+			}
+		}
 
-        m_current_schema = m_model->add_schema(namesp, alias);
-    }
-    else if (elementName == U("EntityContainer"))
-    {
-        ::utility::string_t name;
-		::utility::string_t extends;
-        bool is_default = true;
+		m_current_schema = m_model->add_schema(namesp, alias);
+	}
+	else if (elementName == _XPLATSTR("EntityContainer"))
+	{
+		::odata::string_t name;
+		::odata::string_t extends;
+		bool is_default = true;
 
-        while (move_to_next_attribute())
-        {
-            if (get_current_element_name() == U("Name"))
-            {
-                name = get_current_element_text();
-            }
-			else if (get_current_element_name() == U("Extends"))
+		while (move_to_next_attribute())
+		{
+			if (get_current_element_name() == _XPLATSTR("Name"))
+			{
+				name = get_current_element_text();
+			}
+			else if (get_current_element_name() == _XPLATSTR("Extends"))
 			{
 				extends = get_current_element_text();
 			}
-        }
+		}
 
-        m_current_container = std::make_shared<edm_entity_container>(name, is_default);
-    }
-    else if (elementName == U("EntitySet"))
-    {
-        ::utility::string_t name;
-        ::utility::string_t type;
-
-        while (move_to_next_attribute())
-        {
-            if(get_current_element_name() == U("Name"))
-            {
-                name = get_current_element_text();
-            }
-            else if (get_current_element_name() == U("EntityType"))
-            {
-                type = get_current_element_text();
-            }
-        }
-
-        m_current_entity_set = std::make_shared<edm_entity_set>(name, type);
-    }
-    else if (elementName == U("Singleton"))
-    {
-        ::utility::string_t name;
-        ::utility::string_t type;
-
-        while (move_to_next_attribute())
-        {
-            if(get_current_element_name() == U("Name"))
-            {
-                name = get_current_element_text();
-            }
-            else if (get_current_element_name() == U("Type"))
-            {
-                type = get_current_element_text();
-            }
-        }
-
-		m_current_singleton = std::make_shared<edm_singleton>(name, type);
-    }
-	else if (elementName == U("FunctionImport") || elementName == U("ActionImport"))
+		m_current_container = ::odata::make_shared<edm_entity_container>(name, is_default);
+	}
+	else if (elementName == _XPLATSTR("EntitySet"))
 	{
-		::utility::string_t name;
-		::utility::string_t entity_set_path;
-		bool is_in_service_document;
-		OperationImportKind operation_import_kind = elementName == U("FunctionImport") ? OperationImportKind::FunctionImport : OperationImportKind::ActionImport;
-		::utility::string_t operation_name;
+		::odata::string_t name;
+		::odata::string_t type;
 
-        while (move_to_next_attribute())
-        {
-            if(get_current_element_name() == U("Name"))
-            {
-                name = get_current_element_text();
-            }
-            else if (get_current_element_name() == U("EntitySet"))
-            {
-                entity_set_path = get_current_element_text();
-            }
-            else if (get_current_element_name() == U("IncludeInServiceDocument"))
-            {
-                is_in_service_document = get_current_element_text()  == U("true") ? true : false;;
-            }
-            else if (get_current_element_name() == U("Function") || get_current_element_name() == U("Action"))
-            {
-                operation_name = get_current_element_text();
-            }
-        }
-
-        if (m_current_container)
+		while (move_to_next_attribute())
 		{
-			m_current_container->add_operation_import(std::make_shared<edm_operation_import>(name, operation_name, entity_set_path, is_in_service_document, operation_import_kind));
+			if(get_current_element_name() == _XPLATSTR("Name"))
+			{
+				name = get_current_element_text();
+			}
+			else if (get_current_element_name() == _XPLATSTR("EntityType"))
+			{
+				type = get_current_element_text();
+			}
+		}
+
+		m_current_entity_set = ::odata::make_shared<edm_entity_set>(name, type);
+	}
+	else if (elementName == _XPLATSTR("Singleton"))
+	{
+		::odata::string_t name;
+		::odata::string_t type;
+
+		while (move_to_next_attribute())
+		{
+			if(get_current_element_name() == _XPLATSTR("Name"))
+			{
+				name = get_current_element_text();
+			}
+			else if (get_current_element_name() == _XPLATSTR("Type"))
+			{
+				type = get_current_element_text();
+			}
+		}
+
+		m_current_singleton = ::odata::make_shared<edm_singleton>(name, type);
+	}
+	else if (elementName == _XPLATSTR("FunctionImport") || elementName == _XPLATSTR("ActionImport"))
+	{
+		::odata::string_t name;
+		::odata::string_t entity_set_path;
+		bool is_in_service_document;
+		OperationImportKind operation_import_kind = elementName == _XPLATSTR("FunctionImport") ? OperationImportKind::FunctionImport : OperationImportKind::ActionImport;
+		::odata::string_t operation_name;
+
+		while (move_to_next_attribute())
+		{
+			if(get_current_element_name() == _XPLATSTR("Name"))
+			{
+				name = get_current_element_text();
+			}
+			else if (get_current_element_name() == _XPLATSTR("EntitySet"))
+			{
+				entity_set_path = get_current_element_text();
+			}
+			else if (get_current_element_name() == _XPLATSTR("IncludeInServiceDocument"))
+			{
+				is_in_service_document = get_current_element_text() == _XPLATSTR("true");
+			}
+			else if (get_current_element_name() == _XPLATSTR("Function") || get_current_element_name() == _XPLATSTR("Action"))
+			{
+				operation_name = get_current_element_text();
+			}
+		}
+
+		if (m_current_container)
+		{
+			m_current_container->add_operation_import(::odata::make_shared<edm_operation_import>(name, operation_name, entity_set_path, is_in_service_document, operation_import_kind));
 		}
 	}
-    else if (elementName == U("EntityType"))
-    {
-        ::utility::string_t name;
-		::utility::string_t baseType;
+	else if (elementName == _XPLATSTR("EntityType"))
+	{
+		::odata::string_t name;
+		::odata::string_t baseType;
 		bool isAbstract = false;
 		bool isOpenType = false;
 		bool hasStream = false;
 
-        while (move_to_next_attribute())
-        {
-            if (get_current_element_name() == U("Name"))
-            {
-                name = get_current_element_text();
-            }
-			else if (get_current_element_name() == U("BaseType"))
-            {
-                baseType = get_current_element_text();
-            }
-			else if (get_current_element_name() == U("Abstract"))
-            {
-                isAbstract = get_current_element_text() == U("true") ? true : false;
-            }
-			else if (get_current_element_name() == U("OpenType"))
-            {
-                isOpenType = get_current_element_text() == U("true") ? true : false;
-            }
-			else if (get_current_element_name() == U("HasStream"))
-            {
-                hasStream = get_current_element_text() == U("true") ? true : false;
-            }
-        }
+		while (move_to_next_attribute())
+		{
+			if (get_current_element_name() == _XPLATSTR("Name"))
+			{
+				name = get_current_element_text();
+			}
+			else if (get_current_element_name() == _XPLATSTR("BaseType"))
+			{
+				baseType = get_current_element_text();
+			}
+			else if (get_current_element_name() == _XPLATSTR("Abstract"))
+			{
+				isAbstract = get_current_element_text() == _XPLATSTR("true");
+			}
+			else if (get_current_element_name() == _XPLATSTR("OpenType"))
+			{
+				isOpenType = get_current_element_text() == _XPLATSTR("true");
+			}
+			else if (get_current_element_name() == _XPLATSTR("HasStream"))
+			{
+				hasStream = get_current_element_text() == _XPLATSTR("true");
+			}
+		}
 
 		m_current_st = new edm_entity_type(name, m_current_schema->get_name(), baseType, isAbstract, isOpenType, hasStream);
-    }
-    else if (elementName == U("ComplexType"))
+	}
+	else if (elementName == _XPLATSTR("ComplexType"))
 	{
-        ::utility::string_t name;
-		::utility::string_t baseType;
+		::odata::string_t name;
+		::odata::string_t baseType;
 		bool isAbstract = false;
 		bool isOpenType = false;
 
-        while (move_to_next_attribute())
-        {
-            if (get_current_element_name() == U("Name"))
-            {
-                name = get_current_element_text();
-            }
-			else if (get_current_element_name() == U("BaseType"))
-            {
-                baseType = get_current_element_text();
-            }
-			else if (get_current_element_name() == U("Abstract"))
-            {
-                isAbstract = get_current_element_text() == U("true") ? true : false;
-            }
-			else if (get_current_element_name() == U("OpenType"))
-            {
-                isOpenType = get_current_element_text() == U("true") ? true : false;
-            }
-        }
+		while (move_to_next_attribute())
+		{
+			if (get_current_element_name() == _XPLATSTR("Name"))
+			{
+				name = get_current_element_text();
+			}
+			else if (get_current_element_name() == _XPLATSTR("BaseType"))
+			{
+				baseType = get_current_element_text();
+			}
+			else if (get_current_element_name() == _XPLATSTR("Abstract"))
+			{
+				isAbstract = get_current_element_text() == _XPLATSTR("true");
+			}
+			else if (get_current_element_name() == _XPLATSTR("OpenType"))
+			{
+				isOpenType = get_current_element_text() == _XPLATSTR("true");
+			}
+		}
 
-        m_current_st = new edm_complex_type(name, m_current_schema->get_name(), baseType, isAbstract, isOpenType);
-    }
-	else if (elementName == U("EnumType"))
+		m_current_st = new edm_complex_type(name, m_current_schema->get_name(), baseType, isAbstract, isOpenType);
+	}
+	else if (elementName == _XPLATSTR("EnumType"))
 	{
-		::utility::string_t name;
-		::utility::string_t underlying_type = U("Edm.Int32");
+		::odata::string_t name;
+		::odata::string_t underlying_type = _XPLATSTR("Edm.Int32");
 		bool is_flag = false;
 
-        while (move_to_next_attribute())
-        {
-            if (get_current_element_name() == U("Name"))
-            {
-                name = get_current_element_text();
-            }
-			else if (get_current_element_name() == U("UnderlyingType"))
-            {
-                underlying_type = get_current_element_text();
-            }
-			else if (get_current_element_name() == U("IsFlags"))
-            {
-                is_flag = get_current_element_text() == U("true") ? true : false;
-            }
-        }
+		while (move_to_next_attribute())
+		{
+			if (get_current_element_name() == _XPLATSTR("Name"))
+			{
+				name = get_current_element_text();
+			}
+			else if (get_current_element_name() == _XPLATSTR("UnderlyingType"))
+			{
+				underlying_type = get_current_element_text();
+			}
+			else if (get_current_element_name() == _XPLATSTR("IsFlags"))
+			{
+				is_flag = get_current_element_text() == _XPLATSTR("true");
+			}
+		}
 
 		m_current_enum = new edm_enum_type(name, m_current_schema->get_name(), underlying_type, is_flag);
 	}
-	else if (elementName == U("Function") || elementName == U("Action"))
+	else if (elementName == _XPLATSTR("Function") || elementName == _XPLATSTR("Action"))
 	{
-		::utility::string_t name;
-		::utility::string_t path;
+		::odata::string_t name;
+		::odata::string_t path;
 		bool is_bound = false;
 		bool is_composable = false;
-		EdmOperationKind operation_kind = elementName == U("Function") ? EdmOperationKind::Function : EdmOperationKind::Action;
+		EdmOperationKind operation_kind = elementName == _XPLATSTR("Function") ? EdmOperationKind::Function : EdmOperationKind::Action;
 
-        while (move_to_next_attribute())
-        {
-            if (get_current_element_name() == U("Name"))
-            {
-                name = get_current_element_text();
-            }
-			else if (get_current_element_name() == U("EntitySetPath"))
-            {
-                path = get_current_element_text();
-            }
-			else if (get_current_element_name() == U("IsBound"))
-            {
-                is_bound = get_current_element_text() == U("true") ? true : false;
-            }
-			else if (get_current_element_name() == U("IsComposable"))
-            {
-                is_composable = get_current_element_text() == U("true") ? true : false;
-            }
-        }
+		while (move_to_next_attribute())
+		{
+			if (get_current_element_name() == _XPLATSTR("Name"))
+			{
+				name = get_current_element_text();
+			}
+			else if (get_current_element_name() == _XPLATSTR("EntitySetPath"))
+			{
+				path = get_current_element_text();
+			}
+			else if (get_current_element_name() == _XPLATSTR("IsBound"))
+			{
+				is_bound = get_current_element_text() == _XPLATSTR("true");
+			}
+			else if (get_current_element_name() == _XPLATSTR("IsComposable"))
+			{
+				is_composable = get_current_element_text() == _XPLATSTR("true");
+			}
+		}
 
 		m_current_operation = new edm_operation_type(name, m_current_schema->get_name(),  is_bound, path, operation_kind, is_composable);
 	}
-    else if (elementName == U("Property") || elementName == U("Member"))
-    {
-        _process_property();
-    }
-    else if (elementName == U("NavigationPropertyBinding"))
-    {
-        _process_navigation_property_binding();
-    }
-    else if (elementName == U("NavigationProperty"))
-    {
-        _process_navigation_property();
-    }
-	else if (elementName == U("Parameter"))
+	else if (elementName == _XPLATSTR("Property") || elementName == _XPLATSTR("Member"))
+	{
+		_process_property();
+	}
+	else if (elementName == _XPLATSTR("NavigationPropertyBinding"))
+	{
+		_process_navigation_property_binding();
+	}
+	else if (elementName == _XPLATSTR("NavigationProperty"))
+	{
+		_process_navigation_property();
+	}
+	else if (elementName == _XPLATSTR("Parameter"))
 	{
 		_process_operation_parameter();
 	}
-	else if (elementName == U("ReturnType"))
+	else if (elementName == _XPLATSTR("ReturnType"))
 	{
 		_process_operation_return_type();
 	}
-    else if (m_parsing_key && elementName == U("PropertyRef"))
-    {
-        while (move_to_next_attribute())
-        {
-            if (get_current_element_name() == U("Name"))
-            {
-                dynamic_cast<edm_entity_type*>(m_current_st)->add_key_property(get_current_element_text());
-                break;
-            }
-        }
-        
-    }
-    else if (elementName == U("Key"))
-    {
-        m_parsing_key = true;
-    }
+	else if (m_parsing_key && elementName == _XPLATSTR("PropertyRef"))
+	{
+		while (move_to_next_attribute())
+		{
+			if (get_current_element_name() == _XPLATSTR("Name"))
+			{
+				dynamic_cast<edm_entity_type*>(m_current_st)->add_key_property(get_current_element_text());
+				break;
+			}
+		}
+	}
+	else if (elementName == _XPLATSTR("Key"))
+	{
+		m_parsing_key = true;
+	}
 #ifdef WIN32
-    m_reader->MoveToElement();
+	m_reader->MoveToElement();
 #endif
-	
+
 }
 
-void edm_model_reader::handle_end_element(const ::utility::string_t& elementName)
+void edm_model_reader::handle_end_element(const ::odata::string_t& elementName)
 {
-    if (elementName == U("EntityContainer"))
-    {
-        m_current_schema->add_container(m_current_container);
-        m_current_container.reset();
-    }
-
-    if (elementName == U("EntityType"))
-    {
-        m_current_schema->add_entity_type(std::shared_ptr<edm_entity_type>(static_cast<edm_entity_type*>(m_current_st)));
-        m_current_st = nullptr;
-    }
-
-    if (elementName == U("ComplexType"))
-    {
-        m_current_schema->add_complex_type(std::shared_ptr<edm_complex_type>(static_cast<edm_complex_type*>(m_current_st)));
-        m_current_st = nullptr;
-    }
-
-    if (elementName == U("Key"))
-    {
-        m_parsing_key = false;
-    }
-
-	if (elementName == U("EnumType"))
+	if (elementName == _XPLATSTR("EntityContainer"))
 	{
-		m_current_schema->add_enum_type(std::shared_ptr<edm_enum_type>(static_cast<edm_enum_type*>(m_current_enum)));
-        m_current_enum = nullptr;
+		m_current_schema->add_container(m_current_container);
+		m_current_container.reset();
 	}
 
-	if (elementName == U("Function") || elementName == U("Action"))
+	if (elementName == _XPLATSTR("EntityType"))
+	{
+		m_current_schema->add_entity_type(std::shared_ptr<edm_entity_type>(static_cast<edm_entity_type*>(m_current_st)));
+		m_current_st = nullptr;
+	}
+
+	if (elementName == _XPLATSTR("ComplexType"))
+	{
+		m_current_schema->add_complex_type(std::shared_ptr<edm_complex_type>(static_cast<edm_complex_type*>(m_current_st)));
+		m_current_st = nullptr;
+	}
+
+	if (elementName == _XPLATSTR("Key"))
+	{
+		m_parsing_key = false;
+	}
+
+	if (elementName == _XPLATSTR("EnumType"))
+	{
+		m_current_schema->add_enum_type(std::shared_ptr<edm_enum_type>(static_cast<edm_enum_type*>(m_current_enum)));
+		m_current_enum = nullptr;
+	}
+
+	if (elementName == _XPLATSTR("Function") || elementName == _XPLATSTR("Action"))
 	{
 		m_current_schema->add_operation_type(std::shared_ptr<edm_operation_type>(static_cast<edm_operation_type*>(m_current_operation)));
 		m_current_operation = nullptr;
 	}
 
-	if (elementName == U("EntitySet"))
+	if (elementName == _XPLATSTR("EntitySet"))
 	{
-        if (m_current_container)
+		if (m_current_container)
 		{
 			m_current_container->add_entity_set(m_current_entity_set);
 		}
 
-		m_current_entity_set = nullptr;		
+		m_current_entity_set = nullptr;
 	}
 
-	if (elementName == U("Singleton"))
+	if (elementName == _XPLATSTR("Singleton"))
 	{
-        if (m_current_container)
+		if (m_current_container)
 		{
 			m_current_container->add_singleton(m_current_singleton);
 		}
@@ -358,7 +357,7 @@ void edm_model_reader::handle_end_element(const ::utility::string_t& elementName
 	}
 }
 
-void edm_model_reader::handle_element(const ::utility::string_t&)
+void edm_model_reader::handle_element(const ::odata::string_t&)
 {
 }
 
@@ -366,81 +365,81 @@ void edm_model_reader::_process_property()
 {
 	if (m_current_st)
 	{
-        ::utility::string_t property_name;
-        bool is_nullable = false;
-        std::shared_ptr<edm_named_type> type;
-        unsigned int max_length = undefined_value;
-        bool is_unicode = false;
-	    unsigned int scale = undefined_value;
-	    unsigned int precision = undefined_value;
+		::odata::string_t property_name;
+		bool is_nullable = false;
+		std::shared_ptr<edm_named_type> type;
+		unsigned int max_length = undefined_value;
+		bool is_unicode = false;
+		unsigned int scale = undefined_value;
+		unsigned int precision = undefined_value;
 
 		while (move_to_next_attribute())
 		{
 			auto name  = get_current_element_name();
 			auto value = get_current_element_text();
 
-			if (name == U("Name"))
+			if (name == _XPLATSTR("Name"))
 			{
 				property_name = value;
 			}
-			else if (name == U("Nullable"))
+			else if (name == _XPLATSTR("Nullable"))
 			{
-				is_nullable = (value == U("true"));
+				is_nullable = (value == _XPLATSTR("true"));
 			}
-			else if (name == U("Type"))
-			{           
+			else if (name == _XPLATSTR("Type"))
+			{
 				type = edm_model_utility::get_edm_type_from_name(value);
-				
+
 				if (!type)
 				{
 					// we have to parse the real type after first round parsing
-				    type = std::make_shared<edm_named_type>(value, U(""), edm_type_kind_t::Unknown);
+					type = ::odata::make_shared<edm_named_type>(value, _XPLATSTR(""), edm_type_kind_t::Unknown);
 				}
 			}
-			else if (name == U("MaxLength"))
+			else if (name == _XPLATSTR("MaxLength"))
 			{
 				web::http::bind(value.c_str(), max_length);
 			}
-			else if (name == U("Unicode"))
+			else if (name == _XPLATSTR("Unicode"))
 			{
-				is_unicode = (value == U("true"));
+				is_unicode = (value == _XPLATSTR("true"));
 			}
-			else if (name == U("Scale"))
+			else if (name == _XPLATSTR("Scale"))
 			{
 				web::http::bind(value.c_str(), scale);
 			}
-			else if (name == U("Precision"))
+			else if (name == _XPLATSTR("Precision"))
 			{
 				web::http::bind(value.c_str(), precision);
 			}
 		}
 
-        auto prop = std::make_shared<edm_property_type>(property_name, is_nullable, max_length, is_unicode, scale);
-        prop->set_property_type(type);
-        prop->set_precision(precision);
+		auto prop = ::odata::make_shared<edm_property_type>(property_name, is_nullable, max_length, is_unicode, scale);
+		prop->set_property_type(type);
+		prop->set_precision(precision);
 		m_current_st->add_property(prop);
 	}
 	else if (m_current_enum)
 	{
-        ::utility::string_t enum_name;
-        unsigned long enum_value;
+		::odata::string_t enum_name;
+		unsigned long enum_value = (std::numeric_limits<unsigned long>::max)(); // max signifies that no explicit value was specified!
 
 		while (move_to_next_attribute())
 		{
 			auto name  = get_current_element_name();
 			auto value = get_current_element_text();
 
-			if (name == U("Name"))
+			if (name == _XPLATSTR("Name"))
 			{
 				enum_name = value;
 			}
-			else if (name == U("Value"))
+			else if (name == _XPLATSTR("Value"))
 			{
 				web::http::bind(value.c_str(), enum_value);
 			}
 		}
 
-        auto prop = std::make_shared<edm_enum_member>(enum_name, enum_value);
+		auto prop = ::odata::make_shared<edm_enum_member>(enum_name, enum_value);
 		m_current_enum->add_enum_member(prop);
 	}
 }
@@ -449,67 +448,66 @@ void edm_model_reader::_process_navigation_property()
 {
 	if (m_current_st)
 	{
-        ::utility::string_t property_name;
-		::utility::string_t partner_name;
-		::utility::string_t type_name;
+		::odata::string_t property_name;
+		::odata::string_t partner_name;
+		::odata::string_t type_name;
 		bool is_contained = false;
-        bool is_nullable = false;
+		bool is_nullable = false;
 
 		while (move_to_next_attribute())
 		{
 			auto name  = get_current_element_name();
 			auto value = get_current_element_text();
 
-			if (name == U("Name"))
+			if (name == _XPLATSTR("Name"))
 			{
 				property_name = value;
 			}
-			else if (name == U("Nullable"))
+			else if (name == _XPLATSTR("Nullable"))
 			{
-				is_nullable = (value == U("true"));
+				is_nullable = (value == _XPLATSTR("true"));
 			}
-			else if (name == U("Partner"))
+			else if (name == _XPLATSTR("Partner"))
 			{
 				partner_name = value;
 			}
-			else if (name == U("Type"))
+			else if (name == _XPLATSTR("Type"))
 			{
 				type_name = value;
 			}
-			else if (name == U("ContainsTarget"))
+			else if (name == _XPLATSTR("ContainsTarget"))
 			{
-				is_contained = (value == U("true"));
+				is_contained = (value == _XPLATSTR("true"));
 			}
 		}
 
-        
-		auto type = std::make_shared<edm_navigation_type>(type_name, partner_name, is_contained); 
-        auto prop = std::make_shared<edm_property_type>(property_name, is_nullable, type);
+		auto type = ::odata::make_shared<edm_navigation_type>(type_name, partner_name, is_contained);
+		auto prop = ::odata::make_shared<edm_property_type>(property_name, is_nullable, type);
 		m_current_st->add_property(prop);
 	}
 }
 
 void edm_model_reader::_process_navigation_property_binding()
 {
-	::utility::string_t property_path_name;
-	::utility::string_t target_name;
+	::odata::string_t property_path_name;
+	::odata::string_t target_name;
 
 	while (move_to_next_attribute())
 	{
 		auto name  = get_current_element_name();
 		auto value = get_current_element_text();
 
-		if (name == U("Path"))
+		if (name == _XPLATSTR("Path"))
 		{
 			property_path_name = value;
 		}
-		else if (name == U("Target"))
+		else if (name == _XPLATSTR("Target"))
 		{
 			target_name = value;
 		}
 	}
 
-    if (m_current_entity_set)
+	if (m_current_entity_set)
 	{
 		m_current_entity_set->add_navigation_source(property_path_name, target_name);
 	}
@@ -523,25 +521,25 @@ void edm_model_reader::_process_operation_parameter()
 {
 	if (m_current_operation)
 	{
-        ::utility::string_t param_name;
-        std::shared_ptr<edm_named_type> param_type;
+		::odata::string_t param_name;
+		std::shared_ptr<edm_named_type> param_type;
 
 		while (move_to_next_attribute())
 		{
 			auto name  = get_current_element_name();
 			auto value = get_current_element_text();
 
-			if (name == U("Name"))
+			if (name == _XPLATSTR("Name"))
 			{
 				param_name = value;
 			}
-			else if (name == U("Type"))
+			else if (name == _XPLATSTR("Type"))
 			{
-				param_type = std::make_shared<edm_named_type>(value, U(""), edm_type_kind_t::Unknown);
+				param_type = ::odata::make_shared<edm_named_type>(value, _XPLATSTR(""), edm_type_kind_t::Unknown);
 			}
 		}
 
-        auto param = std::make_shared<edm_operation_parameter>(param_name, param_type);
+		auto param = ::odata::make_shared<edm_operation_parameter>(param_name, param_type);
 
 		m_current_operation->add_operation_parameter(param);
 	}
@@ -551,18 +549,18 @@ void edm_model_reader::_process_operation_return_type()
 {
 	if (m_current_operation)
 	{
-		auto return_type = std::make_shared<edm_named_type>();
+		auto return_type = ::odata::make_shared<edm_named_type>();
 
 		while (move_to_next_attribute())
 		{
 			auto name  = get_current_element_name();
 			auto value = get_current_element_text();
 
-			if (name == U("Type"))
+			if (name == _XPLATSTR("Type"))
 			{
-				return_type = std::make_shared<edm_named_type>(value, U(""), edm_type_kind_t::Unknown);
+				return_type = ::odata::make_shared<edm_named_type>(value, _XPLATSTR(""), edm_type_kind_t::Unknown);
 			}
-		}		
+		}
 
 		m_current_operation->set_return_type(return_type);
 	}

--- a/src/edm/edm_model_utility.cpp
+++ b/src/edm/edm_model_utility.cpp
@@ -9,71 +9,70 @@
 namespace odata { namespace edm
 {
 
-const std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>>::value_type init_name_to_prmitive_value[] = 
+const std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>>::value_type init_name_to_prmitive_value[] =
 {
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>>::value_type(U("Edm.Binary"), edm_primitive_type::BINARY()),
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>>::value_type(U("Edm.Boolean"), edm_primitive_type::BOOLEAN()),
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>>::value_type(U("Edm.Byte"), edm_primitive_type::BYTE()),
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>>::value_type(U("Edm.Duration"), edm_primitive_type::DURATION()),
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>>::value_type(U("Edm.DateTimeOffset"), edm_primitive_type::DATETIMEOFFSET()),
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>>::value_type(U("Edm.Double"), edm_primitive_type::DOUBLE()),
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>>::value_type(U("Edm.Decimal"), edm_primitive_type::DECIMAL()),
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>>::value_type(U("Edm.Guid"), edm_primitive_type::GUID()),
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>>::value_type(U("Edm.Int16"), edm_primitive_type::INT16()),
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>>::value_type(U("Edm.Int32"), edm_primitive_type::INT32()),
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>>::value_type(U("Edm.Int64"), edm_primitive_type::INT64()),
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>>::value_type(U("Edm.SByte"), edm_primitive_type::SBYTE()),
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>>::value_type(U("Edm.Single"), edm_primitive_type::SINGLE()),
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>>::value_type(U("Edm.Stream"), edm_primitive_type::STREAM()),
-	std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>>::value_type(U("Edm.String"), edm_primitive_type::STRING()),
-
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>>::value_type(_XPLATSTR("Edm.Binary"), edm_primitive_type::BINARY()),
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>>::value_type(_XPLATSTR("Edm.Boolean"), edm_primitive_type::BOOLEAN()),
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>>::value_type(_XPLATSTR("Edm.Byte"), edm_primitive_type::BYTE()),
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>>::value_type(_XPLATSTR("Edm.Duration"), edm_primitive_type::DURATION()),
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>>::value_type(_XPLATSTR("Edm.DateTimeOffset"), edm_primitive_type::DATETIMEOFFSET()),
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>>::value_type(_XPLATSTR("Edm.Double"), edm_primitive_type::DOUBLE()),
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>>::value_type(_XPLATSTR("Edm.Decimal"), edm_primitive_type::DECIMAL()),
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>>::value_type(_XPLATSTR("Edm.Guid"), edm_primitive_type::GUID()),
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>>::value_type(_XPLATSTR("Edm.Int16"), edm_primitive_type::INT16()),
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>>::value_type(_XPLATSTR("Edm.Int32"), edm_primitive_type::INT32()),
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>>::value_type(_XPLATSTR("Edm.Int64"), edm_primitive_type::INT64()),
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>>::value_type(_XPLATSTR("Edm.SByte"), edm_primitive_type::SBYTE()),
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>>::value_type(_XPLATSTR("Edm.Single"), edm_primitive_type::SINGLE()),
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>>::value_type(_XPLATSTR("Edm.Stream"), edm_primitive_type::STREAM()),
+	std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>>::value_type(_XPLATSTR("Edm.String"), edm_primitive_type::STRING()),
 };
 
-const static std::unordered_map<::utility::string_t, std::shared_ptr<edm_named_type>> name_to_edm_primitive_type_map(init_name_to_prmitive_value, init_name_to_prmitive_value + 15);
+const static std::unordered_map<::odata::string_t, std::shared_ptr<edm_named_type>> name_to_edm_primitive_type_map(init_name_to_prmitive_value, init_name_to_prmitive_value + 15);
 
-const std::unordered_map<::utility::string_t, ::utility::string_t>::value_type init_edm_prmitive_type_name_to_strong_type_name[] = 
+const std::unordered_map<::odata::string_t, ::odata::string_t>::value_type init_edm_primitive_type_name_to_strong_type_name[] =
 {
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Binary"), U("std::vector<unsigned char>")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Boolean"), U("bool")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Byte"), U("uint8_t")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Duration"), U("::utility::seconds")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.DateTimeOffset"), U("::utility::datetime")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Double"), U("double")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Decimal"), U("long double")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Guid"), U("::utility::string_t")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Int16"), U("int16_t")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Int32"), U("int32_t")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Int64"), U("int64_t")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.SByte"), U("int8_t")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Single"), U("float")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.String"), U("::utility::string_t")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Binary"), _XPLATSTR("std::vector<unsigned char>")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Boolean"), _XPLATSTR("bool")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Byte"), _XPLATSTR("uint8_t")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Duration"), _XPLATSTR("::utility::seconds")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.DateTimeOffset"), _XPLATSTR("::utility::datetime")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Double"), _XPLATSTR("double")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Decimal"), _XPLATSTR("long double")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Guid"), _XPLATSTR("::odata::string_t")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Int16"), _XPLATSTR("int16_t")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Int32"), _XPLATSTR("int32_t")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Int64"), _XPLATSTR("int64_t")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.SByte"), _XPLATSTR("int8_t")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Single"), _XPLATSTR("float")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.String"), _XPLATSTR("::odata::string_t")),
 };
 
-const static std::unordered_map<::utility::string_t, ::utility::string_t> edm_prmitive_type_name_to_strong_type_name_map(init_edm_prmitive_type_name_to_strong_type_name, init_edm_prmitive_type_name_to_strong_type_name + 14);
+const static std::unordered_map<::odata::string_t, ::odata::string_t> edm_primitive_type_name_to_strong_type_name_map(init_edm_primitive_type_name_to_strong_type_name, init_edm_primitive_type_name_to_strong_type_name + 14);
 
-const std::unordered_map<::utility::string_t, ::utility::string_t>::value_type init_edm_prmitive_type_name_to_strong_type_default_value[] = 
+const std::unordered_map<::odata::string_t, ::odata::string_t>::value_type init_edm_primitive_type_name_to_strong_type_default_value[] =
 {
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Binary"), U("")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Boolean"), U("false")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Byte"), U("0")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Duration"), U("")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.DateTimeOffset"), U("")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Double"), U("0.0")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Decimal"), U("0.0")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Guid"), U("")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Int16"), U("0")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Int32"), U("0")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Int64"), U("0")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.SByte"), U("0")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.Single"), U("0.0")),
-	std::unordered_map<::utility::string_t, ::utility::string_t>::value_type(U("Edm.String"), U("")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Binary"), _XPLATSTR("")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Boolean"), _XPLATSTR("false")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Byte"), _XPLATSTR("0")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Duration"), _XPLATSTR("")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.DateTimeOffset"), _XPLATSTR("")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Double"), _XPLATSTR("0.0")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Decimal"), _XPLATSTR("0.0")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Guid"), _XPLATSTR("")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Int16"), _XPLATSTR("0")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Int32"), _XPLATSTR("0")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Int64"), _XPLATSTR("0")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.SByte"), _XPLATSTR("0")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.Single"), _XPLATSTR("0.0")),
+	std::unordered_map<::odata::string_t, ::odata::string_t>::value_type(_XPLATSTR("Edm.String"), _XPLATSTR("")),
 };
 
-const static std::unordered_map<::utility::string_t, ::utility::string_t> edm_prmitive_type_name_to_strong_type_default_value_map(init_edm_prmitive_type_name_to_strong_type_default_value, init_edm_prmitive_type_name_to_strong_type_default_value + 14);
+const static std::unordered_map<::odata::string_t, ::odata::string_t> edm_primitive_type_name_to_strong_type_default_value_map(init_edm_primitive_type_name_to_strong_type_default_value, init_edm_primitive_type_name_to_strong_type_default_value + 14);
 
-std::shared_ptr<edm_named_type> edm_model_utility::get_edm_primitive_type_from_name(const ::utility::string_t& type_name)
+std::shared_ptr<edm_named_type> edm_model_utility::get_edm_primitive_type_from_name(const ::odata::string_t& type_name)
 {
-	if (type_name.substr(0, 4) == U("Edm."))
+	if (type_name.compare(0, 4, _XPLATSTR("Edm.")) == 0)
 	{
 		auto find_iter = name_to_edm_primitive_type_map.find(type_name);
 		if (find_iter != name_to_edm_primitive_type_map.end())
@@ -85,12 +84,12 @@ std::shared_ptr<edm_named_type> edm_model_utility::get_edm_primitive_type_from_n
 	return nullptr;
 }
 
-::utility::string_t edm_model_utility::get_strong_type_name_from_edm_type_name(const std::shared_ptr<edm_primitive_type>& primitive_type)
+::odata::string_t edm_model_utility::get_strong_type_name_from_edm_type_name(const std::shared_ptr<edm_primitive_type>& primitive_type)
 {
-	::utility::string_t ret;
+	::odata::string_t ret;
 
-	auto find_iter = edm_prmitive_type_name_to_strong_type_name_map.find(primitive_type->get_name());
-	if (find_iter != edm_prmitive_type_name_to_strong_type_name_map.end())
+	auto find_iter = edm_primitive_type_name_to_strong_type_name_map.find(primitive_type->get_name());
+	if (find_iter != edm_primitive_type_name_to_strong_type_name_map.end())
 	{
 		ret = find_iter->second;
 	}
@@ -98,12 +97,12 @@ std::shared_ptr<edm_named_type> edm_model_utility::get_edm_primitive_type_from_n
 	return ret;
 }
 
-::utility::string_t edm_model_utility::get_strong_type_default_value_from_edm_type_name(const std::shared_ptr<edm_primitive_type>& primitive_type)
+::odata::string_t edm_model_utility::get_strong_type_default_value_from_edm_type_name(const std::shared_ptr<edm_primitive_type>& primitive_type)
 {
-	::utility::string_t ret;
-	
-	auto find_iter = edm_prmitive_type_name_to_strong_type_default_value_map.find(primitive_type->get_name());
-	if (find_iter != edm_prmitive_type_name_to_strong_type_default_value_map.end())
+	::odata::string_t ret;
+
+	auto find_iter = edm_primitive_type_name_to_strong_type_default_value_map.find(primitive_type->get_name());
+	if (find_iter != edm_primitive_type_name_to_strong_type_default_value_map.end())
 	{
 		ret = find_iter->second;
 	}
@@ -111,29 +110,29 @@ std::shared_ptr<edm_named_type> edm_model_utility::get_edm_primitive_type_from_n
 	return ret;
 }
 
-std::shared_ptr<edm_named_type> edm_model_utility::get_edm_type_from_name(const ::utility::string_t& type_name)
+std::shared_ptr<edm_named_type> edm_model_utility::get_edm_type_from_name(const ::odata::string_t& type_name)
 {
-	if (type_name.substr(0, 4) == U("Edm."))
+	if (type_name.compare(0, 4, _XPLATSTR("Edm.")) == 0)
 	{
 		return edm_model_utility::get_edm_primitive_type_from_name(type_name);
 	}
-	else if (type_name.substr(0, 10) == U("Collection"))
+	else if (type_name.compare(0, 10, _XPLATSTR("Collection")) == 0)
 	{
-		int index_first = type_name.find_first_of('(') + 1;
-		int index_last = type_name.find_last_of(')');
-		::utility::string_t element_name = type_name.substr(index_first, index_last - index_first);
+		size_t index_first = type_name.find_first_of('(') + 1;
+		size_t index_last = type_name.find_last_of(')');
+		::odata::string_t element_name(type_name, index_first, index_last - index_first);
 
-		auto collection = std::make_shared<edm_collection_type>(type_name);
+		auto collection = ::odata::make_shared<edm_collection_type>(type_name);
 
 		if (collection)
 		{
 			auto element_type = edm_model_utility::get_edm_type_from_name(element_name);
 			if (!element_type)
 			{
-				element_type = std::make_shared<edm_named_type>(element_name, U(""), edm_type_kind_t::Unknown);
+				element_type = ::odata::make_shared<edm_named_type>(element_name, _XPLATSTR(""), edm_type_kind_t::Unknown);
 			}
 
-		    collection->set_element_type(element_type);
+			collection->set_element_type(element_type);
 		}
 
 		return collection;
@@ -144,27 +143,27 @@ std::shared_ptr<edm_named_type> edm_model_utility::get_edm_type_from_name(const 
 	}
 }
 
-::utility::string_t edm_model_utility::get_type_kind_name_from_edm_type(const std::shared_ptr<edm_named_type>& ptype)
+::odata::string_t edm_model_utility::get_type_kind_name_from_edm_type(const std::shared_ptr<edm_named_type>& ptype)
 {
-    switch(ptype->get_type_kind())
-    {
+	switch(ptype->get_type_kind())
+	{
 	case edm_type_kind_t::Primitive:
-        return ::utility::string_t(U("Primitive Type."));
+		return ::odata::string_t(_XPLATSTR("Primitive Type."));
 	case edm_type_kind_t::Collection:
-        return ::utility::string_t(U("Collection Type."));
+		return ::odata::string_t(_XPLATSTR("Collection Type."));
 	case edm_type_kind_t::Complex:
-        return ::utility::string_t(U("Complex Type."));
+		return ::odata::string_t(_XPLATSTR("Complex Type."));
 	case edm_type_kind_t::Enum:
-        return ::utility::string_t(U("Enum Type."));
+		return ::odata::string_t(_XPLATSTR("Enum Type."));
 	case edm_type_kind_t::Entity:
-        return ::utility::string_t(U("Entity Type."));
+		return ::odata::string_t(_XPLATSTR("Entity Type."));
 	case edm_type_kind_t::Navigation:
-        return ::utility::string_t(U("Navigation Type."));
+		return ::odata::string_t(_XPLATSTR("Navigation Type."));
 	case edm_type_kind_t::Operation:
-        return ::utility::string_t(U("Operation Type."));
-    default:
-        return ::utility::string_t(U("Unknown Type."));
-    }
+		return ::odata::string_t(_XPLATSTR("Operation Type."));
+	default:
+		return ::odata::string_t(_XPLATSTR("Unknown Type."));
+	}
 }
 
 bool edm_model_utility::get_primitive_kind_from_edm_type(const std::shared_ptr<edm_named_type>& edm_type, edm_primitive_type_kind_t& primitive_kind)
@@ -187,12 +186,12 @@ void edm_model_utility::resolve_edm_types_after_parsing(const std::shared_ptr<ed
 {
 	if (!model)
 	{
-		return ;
+		return;
 	}
 
 	for (auto sc = model->get_schema().cbegin(); sc != model->get_schema().cend(); ++sc)
 	{
-		std::unordered_map<::utility::string_t, std::shared_ptr<edm_entity_type>> entity_types = (*sc)->get_entity_types();
+		std::unordered_map<::odata::string_t, std::shared_ptr<edm_entity_type>> entity_types = (*sc)->get_entity_types();
 		for (auto entity_type_iter = entity_types.cbegin(); entity_type_iter != entity_types.cend(); ++entity_type_iter)
 		{
 			resolve_type_under_structured_type(model, entity_type_iter->second);
@@ -200,7 +199,7 @@ void edm_model_utility::resolve_edm_types_after_parsing(const std::shared_ptr<ed
 			resovle_entity_base_type(model, entity_type_iter->second);
 		}
 
-		std::unordered_map<::utility::string_t, std::shared_ptr<edm_complex_type>> complex_types = (*sc)->get_complex_types();
+		std::unordered_map<::odata::string_t, std::shared_ptr<edm_complex_type>> complex_types = (*sc)->get_complex_types();
 		for (auto complex_type_iter = complex_types.cbegin(); complex_type_iter != complex_types.cend(); ++complex_type_iter)
 		{
 			resolve_type_under_structured_type(model, complex_type_iter->second);
@@ -208,13 +207,13 @@ void edm_model_utility::resolve_edm_types_after_parsing(const std::shared_ptr<ed
 			resovle_complex_base_type(model, complex_type_iter->second);
 		}
 
-		std::unordered_map<::utility::string_t, std::shared_ptr<edm_operation_type>> operation_types = (*sc)->get_operation_types();
+		std::unordered_map<::odata::string_t, std::shared_ptr<edm_operation_type>> operation_types = (*sc)->get_operation_types();
 		for (auto operation_type_iter = operation_types.cbegin(); operation_type_iter != operation_types.cend(); ++operation_type_iter)
 		{
 			resolve_type_under_operation_type(model, operation_type_iter->second);
 		}
 
-		std::unordered_map<::utility::string_t, std::shared_ptr<edm_entity_container>> entity_containers = (*sc)->get_containers();
+		std::unordered_map<::odata::string_t, std::shared_ptr<edm_entity_container>> entity_containers = (*sc)->get_containers();
 		for (auto entity_container_iter = entity_containers.cbegin(); entity_container_iter != entity_containers.cend(); ++entity_container_iter)
 		{
 			resolve_type_under_entity_container(model, entity_container_iter->second);
@@ -225,7 +224,7 @@ void edm_model_utility::resolve_edm_types_after_parsing(const std::shared_ptr<ed
 }
 
 
-std::shared_ptr<edm_named_type> edm_model_utility::resolve_type_from_name(const std::shared_ptr<edm_model>& model, ::utility::string_t qualified_name)
+std::shared_ptr<edm_named_type> edm_model_utility::resolve_type_from_name(const std::shared_ptr<edm_model>& model, ::odata::string_t qualified_name)
 {
 	if (!model)
 	{
@@ -243,7 +242,7 @@ std::shared_ptr<edm_named_type> edm_model_utility::resolve_type_from_name(const 
 	{
 		return complex_type;
 	}
-	
+
 	auto entity_type = model->find_entity_type(qualified_name);
 	if (entity_type)
 	{
@@ -256,21 +255,21 @@ std::shared_ptr<edm_named_type> edm_model_utility::resolve_type_from_name(const 
 		return operation_type;
 	}
 
-	if (qualified_name.substr(0, 4) == U("Edm."))
+	if (qualified_name.compare(0, 4, _XPLATSTR("Edm.")) == 0)
 	{
-		auto prmitive_type = edm_model_utility::get_edm_primitive_type_from_name(qualified_name);
+		auto primitive_type = edm_model_utility::get_edm_primitive_type_from_name(qualified_name);
 
-		if (!prmitive_type)
+		if (!primitive_type)
 		{
 			return edm_named_type::EDM_UNKNOWN();
 		}
 
-		return prmitive_type;
+		return primitive_type;
 	}
-	else if (qualified_name.substr(0, 10) == U("Collection"))
+	else if (qualified_name.compare(0, 10, _XPLATSTR("Collection")) == 0)
 	{
-		int index_first = qualified_name.find_first_of('(') + 1;
-		int index_last = qualified_name.find_last_of(')');
+		size_t index_first = qualified_name.find_first_of('(') + 1;
+		size_t index_last = qualified_name.find_last_of(')');
 
 		if (index_first >= index_last)
 		{
@@ -278,9 +277,9 @@ std::shared_ptr<edm_named_type> edm_model_utility::resolve_type_from_name(const 
 			throw std::invalid_argument(err);
 		}
 
-		::utility::string_t element_name = qualified_name.substr(index_first, index_last - index_first);
+		::odata::string_t element_name(qualified_name, index_first, index_last - index_first);
 
-		auto collection = std::make_shared<edm_collection_type>(qualified_name);
+		auto collection = ::odata::make_shared<edm_collection_type>(qualified_name);
 
 		if (collection)
 		{
@@ -293,14 +292,14 @@ std::shared_ptr<edm_named_type> edm_model_utility::resolve_type_from_name(const 
 	return nullptr;
 }
 
-::utility::string_t edm_model_utility::get_collection_element_name(const ::utility::string_t& collection_full_name)
+::odata::string_t edm_model_utility::get_collection_element_name(const ::odata::string_t& collection_full_name)
 {
-	::utility::string_t element_name;
+	::odata::string_t element_name;
 
-	if (collection_full_name.substr(0, 10) == U("Collection"))
+	if (collection_full_name.compare(0, 10, _XPLATSTR("Collection")) == 0)
 	{
-		int index_first = collection_full_name.find_first_of('(') + 1;
-		int index_last = collection_full_name.find_last_of(')');
+		size_t index_first = collection_full_name.find_first_of('(') + 1;
+		size_t index_last = collection_full_name.find_last_of(')');
 
 		if (index_first >= index_last)
 		{
@@ -308,7 +307,7 @@ std::shared_ptr<edm_named_type> edm_model_utility::resolve_type_from_name(const 
 			throw std::invalid_argument(err);
 		}
 
-		element_name = collection_full_name.substr(index_first, index_last - index_first);
+		element_name.assign(collection_full_name, index_first, index_last - index_first);
 	}
 
 	return element_name;
@@ -318,14 +317,14 @@ void edm_model_utility::resolve_type_under_structured_type(const std::shared_ptr
 {
 	if (!model)
 	{
-		return ;
+		return;
 	}
 
 	if (structyred_type)
 	{
 		for (auto propery_iter = structyred_type->begin(); propery_iter != structyred_type->end(); ++propery_iter)
 		{
-			auto prop = propery_iter->second;
+			auto &prop = propery_iter->second;
 
 			auto property_type = prop->get_property_type();
 			if (!property_type)
@@ -335,7 +334,7 @@ void edm_model_utility::resolve_type_under_structured_type(const std::shared_ptr
 
 			if (property_type->get_type_kind() == edm_type_kind_t::Unknown)
 			{
-				::utility::string_t type_name = property_type->get_name();
+				::odata::string_t type_name = property_type->get_name();
 
 				auto resolved_type = resolve_type_from_name(model, type_name);
 				if (resolved_type)
@@ -348,7 +347,7 @@ void edm_model_utility::resolve_type_under_structured_type(const std::shared_ptr
 				auto collection_type = std::dynamic_pointer_cast<edm_collection_type>(property_type);
 				if (collection_type)
 				{
-					::utility::string_t type_name = get_collection_element_name(collection_type->get_full_name());
+					::odata::string_t type_name = get_collection_element_name(collection_type->get_full_name());
 
 					auto resolved_type = resolve_type_from_name(model, type_name);
 					if (resolved_type)
@@ -359,15 +358,18 @@ void edm_model_utility::resolve_type_under_structured_type(const std::shared_ptr
 			}
 			else if (property_type->get_type_kind() == edm_type_kind_t::Navigation)
 			{
-                auto navigation_type = std::dynamic_pointer_cast<edm_navigation_type>(property_type);
+				auto navigation_type = std::dynamic_pointer_cast<edm_navigation_type>(property_type);
 				if (navigation_type)
 				{
 					auto resolved_type = resolve_type_from_name(model, navigation_type->get_name());
-					if (resolved_type->get_type_kind() == edm_type_kind_t::Collection)
+					if (resolved_type)
 					{
-						model->get_schema()[0]->m_collection_navigation_types.push_back(std::dynamic_pointer_cast<edm_collection_type>(resolved_type));
+						if (resolved_type->get_type_kind() == edm_type_kind_t::Collection)
+						{
+							model->get_schema().front()->m_collection_navigation_types.emplace_back(std::dynamic_pointer_cast<edm_collection_type>(resolved_type));
+						}
+						navigation_type->set_navigation_type(resolved_type);
 					}
-					navigation_type->set_navigation_type(resolved_type);
 				}
 			}
 		}
@@ -378,7 +380,7 @@ void edm_model_utility::resolve_type_under_operation_type(const std::shared_ptr<
 {
 	if (!model)
 	{
-		return ;
+		return;
 	}
 
 	if (operationType)
@@ -409,18 +411,18 @@ std::shared_ptr<edm_named_type> edm_model_utility::resolve_undetermined_type(con
 
 	if (undeterminedType)
 	{
-	    auto resolved_type = std::make_shared<edm_named_type>(undeterminedType->get_name(), U(""), edm_type_kind_t::None);
+		auto resolved_type = ::odata::make_shared<edm_named_type>(undeterminedType->get_name(), _XPLATSTR(""), edm_type_kind_t::None);
 
 		if (undeterminedType->get_type_kind() == edm_type_kind_t::Unknown)
 		{
-			::utility::string_t type_name = undeterminedType->get_name();
-			if (type_name.substr(0, 10) == U("Collection"))
+			::odata::string_t type_name = undeterminedType->get_name();
+			if (type_name.compare(0, 10, _XPLATSTR("Collection")) == 0)
 			{
-				resolved_type = std::make_shared<edm_collection_type>(type_name);
+				resolved_type = ::odata::make_shared<edm_collection_type>(type_name);
 				if (resolved_type)
 				{
-				    int index_first = type_name.find_first_of('(') + 1;
-		            int index_last = type_name.find_last_of(')');
+					size_t index_first = type_name.find_first_of('(') + 1;
+					size_t index_last = type_name.find_last_of(')');
 
 					if (index_first >= index_last)
 					{
@@ -428,8 +430,8 @@ std::shared_ptr<edm_named_type> edm_model_utility::resolve_undetermined_type(con
 						throw std::invalid_argument(err);
 					}
 
-		            ::utility::string_t element_name = type_name.substr(index_first, index_last - index_first);
-					auto element_type = resolve_undetermined_type(model, std::make_shared<edm_named_type>(element_name, U(""), edm_type_kind_t::Unknown));
+					::odata::string_t element_name(type_name, index_first, index_last - index_first);
+					auto element_type = resolve_undetermined_type(model, ::odata::make_shared<edm_named_type>(element_name, _XPLATSTR(""), edm_type_kind_t::Unknown));
 
 					auto collection_type = std::dynamic_pointer_cast<edm_collection_type>(resolved_type);
 					if (collection_type)
@@ -451,7 +453,7 @@ std::shared_ptr<edm_named_type> edm_model_utility::resolve_undetermined_type(con
 				auto baseTypeOfColloection = collection_type->get_element_type();
 				if (baseTypeOfColloection && baseTypeOfColloection->get_type_kind() == edm_type_kind_t::Unknown)
 				{
-					auto element_type = resolve_undetermined_type(model, std::make_shared<edm_named_type>(baseTypeOfColloection->get_name(), U(""), edm_type_kind_t::Unknown));
+					auto element_type = resolve_undetermined_type(model, ::odata::make_shared<edm_named_type>(baseTypeOfColloection->get_name(), _XPLATSTR(""), edm_type_kind_t::Unknown));
 					if (element_type)
 					{
 						collection_type->set_element_type(element_type);
@@ -470,24 +472,24 @@ void edm_model_utility::resolve_type_under_entity_container(const std::shared_pt
 {
 	if (!model || !entity_container)
 	{
-		return ;
+		return;
 	}
 
-	auto operation_imports = entity_container->get_operation_imports();
+	auto &operation_imports = entity_container->get_operation_imports();
 	for (auto operation_import_iter = operation_imports.cbegin(); operation_import_iter != operation_imports.cend(); ++operation_import_iter)
 	{
-		auto op = operation_import_iter->second;
+		auto &op = operation_import_iter->second;
 		if (op)
 		{
-			::utility::string_t operation_name = op->get_name();
+			::odata::string_t operation_name = op->get_name();
 			op->set_operation_type(model->find_operation_type(operation_name));
 		}
 	}
 
-	auto singletons = entity_container->get_singletons();
+	auto &singletons = entity_container->get_singletons();
 	for (auto singleton_iter = singletons.cbegin(); singleton_iter != singletons.cend(); ++singleton_iter)
 	{
-		auto singleton = singleton_iter->second;
+		auto &singleton = singleton_iter->second;
 		if (!singleton)
 		{
 			continue;
@@ -498,7 +500,7 @@ void edm_model_utility::resolve_type_under_entity_container(const std::shared_pt
 
 	for (auto entity_set_iter = entity_container->begin(); entity_set_iter != entity_container->end(); ++entity_set_iter)
 	{
-		auto entity_set = entity_set_iter->second;
+		auto &entity_set = entity_set_iter->second;
 		if (!entity_set)
 		{
 			continue;
@@ -512,18 +514,18 @@ void edm_model_utility::resolve_navigation_path_for_non_contained_navigation(con
 {
 	if (!model || !entity_container)
 	{
-		return ;
+		return;
 	}
 
 	for (auto entity_set_iter = entity_container->begin(); entity_set_iter != entity_container->end(); ++entity_set_iter)
 	{
-		auto entity_set = entity_set_iter->second;
+		auto &entity_set = entity_set_iter->second;
 		if (!entity_set)
 		{
 			continue;
 		}
 
-		auto navigation_sources = entity_set->get_navigation_sources();
+		auto &navigation_sources = entity_set->get_navigation_sources();
 		for (auto navigation_source_iter = navigation_sources.begin(); navigation_source_iter != navigation_sources.end(); ++navigation_source_iter)
 		{
 			auto navigation_type = get_navigation_property_from_path(model, entity_set->get_entity_type(), navigation_source_iter->first);
@@ -542,14 +544,13 @@ void edm_model_utility::resolve_navigation_path_for_non_contained_navigation(con
 	}
 }
 
-std::shared_ptr<edm_navigation_type> edm_model_utility::get_navigation_property_from_path(const std::shared_ptr<edm_model>& model, 
-    const std::shared_ptr<edm_entity_type>& entity_type, const ::utility::string_t& navigation_path)
+std::shared_ptr<edm_navigation_type> edm_model_utility::get_navigation_property_from_path(const std::shared_ptr<edm_model>& model, const std::shared_ptr<edm_entity_type>& entity_type, const ::odata::string_t& navigation_path)
 {
 	std::shared_ptr<edm_navigation_type> navigation_type = nullptr;
 
-	std::list<::utility::string_t> paths;
-	::utility::string_t path = navigation_path;
-	::odata::common::split_string(path, U("/"), paths);
+	std::list<::odata::string_t> paths;
+	::odata::string_t path = navigation_path;
+	::odata::common::split_string(path, _XPLATSTR("/"), paths);
 
 	if (paths.size() == 1)
 	{
@@ -561,22 +562,21 @@ std::shared_ptr<edm_navigation_type> edm_model_utility::get_navigation_property_
 			if (navigation_property)
 			{
 				navigation_type = std::dynamic_pointer_cast<edm_navigation_type>(navigation_property->get_property_type());
-			}		
+			}
 		}
 	}
 	else if (paths.size() == 2)
 	{
 		// full entity name/property name
-		auto entity_type_name = paths.front();
-		auto property_name = paths.back();
+		auto &entity_type_name = paths.front();
+		auto &property_name = paths.back();
 
 		if (model)
 		{
-			auto entity_type = model->find_entity_type(entity_type_name);
-
-			if (entity_type)
+			auto Path_entity_type = model->find_entity_type(entity_type_name);
+			if (Path_entity_type)
 			{
-				auto navigation_property = entity_type->find_property(property_name);
+				auto navigation_property = Path_entity_type->find_property(property_name);
 
 				if (navigation_property)
 				{
@@ -593,12 +593,12 @@ void edm_model_utility::resovle_entity_base_type(const std::shared_ptr<edm_model
 {
 	if (!model)
 	{
-		return ;
+		return;
 	}
 
 	if (!entity_type || entity_type->get_base_type_name().empty())
 	{
-		return ;
+		return;
 	}
 
 	auto base_type = model->find_entity_type(entity_type->get_base_type_name());
@@ -612,12 +612,12 @@ void edm_model_utility::resovle_complex_base_type(const std::shared_ptr<edm_mode
 {
 	if (!model)
 	{
-		return ;
+		return;
 	}
 
 	if (!complex_type || complex_type->get_base_type_name().empty())
 	{
-		return ;
+		return;
 	}
 
 	auto base_type = model->find_complex_type(complex_type->get_base_type_name());
@@ -669,7 +669,7 @@ std::shared_ptr<edm_named_type> edm_model_utility::get_navigation_element_type(c
 	return navigation_type->get_navigation_type();
 }
 
-std::shared_ptr<edm_named_type> edm_model_utility::get_property_type_from_name(const std::shared_ptr<edm_entity_type>& entity_type, const ::utility::string_t& property_name)
+std::shared_ptr<edm_named_type> edm_model_utility::get_property_type_from_name(const std::shared_ptr<edm_entity_type>& entity_type, const ::odata::string_t& property_name)
 {
 	if (!entity_type)
 	{

--- a/src/edm/edm_schema.cpp
+++ b/src/edm/edm_schema.cpp
@@ -9,14 +9,20 @@
 namespace odata { namespace edm
 {
 
-std::shared_ptr<edm_entity_type> edm_schema::find_entity_type(::utility::string_t name) const
+std::shared_ptr<edm_entity_type> edm_schema::find_entity_type(::odata::string_t name) const
 {
-    auto nsp_size = m_namespace.size();
-    if (name.size() > nsp_size && name.substr(0, nsp_size) == m_namespace)
-    {
-        // Strip qualification when searching.
-        name = name.substr(nsp_size + 1);
-    }
+	auto nsp_size = m_namespace.size();
+	auto ali_size = m_alias.size();
+	if (name.size() > nsp_size && name.compare(0, nsp_size, m_namespace) == 0)
+	{
+		// Strip qualification when searching.
+		name.erase(0, nsp_size + 1);
+	}
+	else if (name.size() > ali_size && name.compare(0, ali_size, m_alias) == 0)
+	{
+		// Strip qualification when searching.
+		name.erase(0, ali_size + 1);
+	}
 
 	auto find_iter = m_entity_types.find(name);
 	if (find_iter != m_entity_types.end())
@@ -24,55 +30,73 @@ std::shared_ptr<edm_entity_type> edm_schema::find_entity_type(::utility::string_
 		return find_iter->second;
 	}
 
-    return nullptr;
+	return nullptr;
 }
 
-std::shared_ptr<edm_complex_type> edm_schema::find_complex_type(::utility::string_t name) const
+std::shared_ptr<edm_complex_type> edm_schema::find_complex_type(::odata::string_t name) const
 {
-    auto nsp_size = m_namespace.size();
-    if (name.size() > nsp_size && name.substr(0, nsp_size) == m_namespace)
-    {
-        // Strip qualification when searching.
-        name = name.substr(nsp_size + 1);
-    }
+	auto nsp_size = m_namespace.size();
+	auto ali_size = m_alias.size();
+	if (name.size() > nsp_size && name.compare(0, nsp_size, m_namespace) == 0)
+	{
+		// Strip qualification when searching.
+		name.erase(0, nsp_size + 1);
+	}
+	else if (name.size() > ali_size && name.compare(0, ali_size, m_alias) == 0)
+	{
+		// Strip qualification when searching.
+		name.erase(0, ali_size + 1);
+	}
 
-    auto find_iter = m_complex_types.find(name);
+	auto find_iter = m_complex_types.find(name);
 	if (find_iter != m_complex_types.end())
 	{
 		return find_iter->second;
 	}
 
-    return nullptr;
+	return nullptr;
 }
 
-std::shared_ptr<edm_enum_type> edm_schema::find_enum_type(::utility::string_t name) const
+std::shared_ptr<edm_enum_type> edm_schema::find_enum_type(::odata::string_t name) const
 {
-    auto nsp_size = m_namespace.size();
-    if ( name.size() > nsp_size && name.substr(0, nsp_size) == m_namespace)
-    {
-        // Strip qualification when searching.
-        name = name.substr(nsp_size + 1);
-    }
+	auto nsp_size = m_namespace.size();
+	auto ali_size = m_alias.size();
+	if (name.size() > nsp_size && name.compare(0, nsp_size, m_namespace) == 0)
+	{
+		// Strip qualification when searching.
+		name.erase(0, nsp_size + 1);
+	}
+	else if (name.size() > ali_size && name.compare(0, ali_size, m_alias) == 0)
+	{
+		// Strip qualification when searching.
+		name.erase(0, ali_size + 1);
+	}
 
-    auto find_iter = m_enum_types.find(name);
+	auto find_iter = m_enum_types.find(name);
 	if (find_iter != m_enum_types.end())
 	{
 		return find_iter->second;
 	}
 
-    return nullptr;
+	return nullptr;
 }
 
-std::shared_ptr<edm_operation_type> edm_schema::find_operation_type(::utility::string_t name) const
+std::shared_ptr<edm_operation_type> edm_schema::find_operation_type(::odata::string_t name) const
 {
-    auto nsp_size = m_namespace.size();
-    if ( name.size() > nsp_size && name.substr(0, nsp_size) == m_namespace)
-    {
-        // Strip qualification when searching.
-        name = name.substr(nsp_size+1);
-    }
+	auto nsp_size = m_namespace.size();
+	auto ali_size = m_alias.size();
+	if (name.size() > nsp_size && name.compare(0, nsp_size, m_namespace) == 0)
+	{
+		// Strip qualification when searching.
+		name.erase(0, nsp_size + 1);
+	}
+	else if (name.size() > ali_size && name.compare(0, ali_size, m_alias) == 0)
+	{
+		// Strip qualification when searching.
+		name.erase(0, ali_size + 1);
+	}
 
-    auto find_iter = m_operation_types.find(name);
+	auto find_iter = m_operation_types.find(name);
 	if (find_iter != m_operation_types.end())
 	{
 		return find_iter->second;

--- a/src/edm/edm_type.cpp
+++ b/src/edm/edm_type.cpp
@@ -47,193 +47,193 @@ std::shared_ptr<edm_primitive_type> edm_primitive_type::_STRING = nullptr;
 std::shared_ptr<edm_primitive_type> edm_primitive_type::_STREAM = nullptr;
 std::shared_ptr<edm_primitive_type>edm_primitive_type:: _UNKNOWN = nullptr;
 
-std::shared_ptr<edm_primitive_type> edm_primitive_type::BINARY() 
+std::shared_ptr<edm_primitive_type> edm_primitive_type::BINARY()
 {
 	std::lock_guard<std::mutex> lock(mutex());
 
 	if (!_BINARY)
 	{
-		_BINARY.reset(new edm_primitive_type(U("Edm.Binary"), edm_primitive_type_kind_t::Binary));
+		_BINARY.reset(new edm_primitive_type(_XPLATSTR("Edm.Binary"), edm_primitive_type_kind_t::Binary));
 	}
 
 	return _BINARY;
 }
 
-std::shared_ptr<edm_primitive_type> edm_primitive_type::BOOLEAN() 
-{ 
+std::shared_ptr<edm_primitive_type> edm_primitive_type::BOOLEAN()
+{
 	std::lock_guard<std::mutex> lock(mutex());
 
 	if (!_BOOLEAN)
 	{
-		_BOOLEAN.reset(new edm_primitive_type(U("Edm.Boolean"), edm_primitive_type_kind_t::Boolean));
+		_BOOLEAN.reset(new edm_primitive_type(_XPLATSTR("Edm.Boolean"), edm_primitive_type_kind_t::Boolean));
 	}
 
 	return _BOOLEAN;
 }
 
-std::shared_ptr<edm_primitive_type> edm_primitive_type::BYTE() 
-{ 
+std::shared_ptr<edm_primitive_type> edm_primitive_type::BYTE()
+{
 	std::lock_guard<std::mutex> lock(mutex());
 
 	if (!_BYTE)
 	{
-		_BYTE.reset(new edm_primitive_type(U("Edm.Byte"), edm_primitive_type_kind_t::Byte));
+		_BYTE.reset(new edm_primitive_type(_XPLATSTR("Edm.Byte"), edm_primitive_type_kind_t::Byte));
 	}
 
 	return _BYTE;
 }
 
-std::shared_ptr<edm_primitive_type> edm_primitive_type::DATETIMEOFFSET() 
-{ 
+std::shared_ptr<edm_primitive_type> edm_primitive_type::DATETIMEOFFSET()
+{
 	std::lock_guard<std::mutex> lock(mutex());
 
 	if (!_DATETIMEOFFSET)
 	{
-		_DATETIMEOFFSET.reset(new edm_primitive_type(U("Edm.DateTimeOffset"), edm_primitive_type_kind_t::DateTimeOffset));
+		_DATETIMEOFFSET.reset(new edm_primitive_type(_XPLATSTR("Edm.DateTimeOffset"), edm_primitive_type_kind_t::DateTimeOffset));
 	}
 
 	return _DATETIMEOFFSET;
 }
 
-std::shared_ptr<edm_primitive_type> edm_primitive_type::DURATION() 
-{ 
+std::shared_ptr<edm_primitive_type> edm_primitive_type::DURATION()
+{
 	std::lock_guard<std::mutex> lock(mutex());
 
 	if (!_DURATION)
 	{
-		_DURATION.reset(new edm_primitive_type(U("Edm.Duration"), edm_primitive_type_kind_t::Duration));
+		_DURATION.reset(new edm_primitive_type(_XPLATSTR("Edm.Duration"), edm_primitive_type_kind_t::Duration));
 	}
 
 	return _DURATION;
 }
 
-std::shared_ptr<edm_primitive_type> edm_primitive_type::DECIMAL() 
-{ 
+std::shared_ptr<edm_primitive_type> edm_primitive_type::DECIMAL()
+{
 	std::lock_guard<std::mutex> lock(mutex());
 
 	if (!_DECIMAL)
 	{
-		_DECIMAL.reset(new edm_primitive_type(U("Edm.Decimal"), edm_primitive_type_kind_t::Decimal));
+		_DECIMAL.reset(new edm_primitive_type(_XPLATSTR("Edm.Decimal"), edm_primitive_type_kind_t::Decimal));
 	}
 
 	return _DECIMAL;
 }
 
-std::shared_ptr<edm_primitive_type> edm_primitive_type::DOUBLE() 
-{ 
+std::shared_ptr<edm_primitive_type> edm_primitive_type::DOUBLE()
+{
 	std::lock_guard<std::mutex> lock(mutex());
 
 	if (!_DOUBLE)
 	{
-		_DOUBLE.reset(new edm_primitive_type(U("Edm.Double"), edm_primitive_type_kind_t::Double));
+		_DOUBLE.reset(new edm_primitive_type(_XPLATSTR("Edm.Double"), edm_primitive_type_kind_t::Double));
 	}
 
 	return _DOUBLE;
 }
 
 std::shared_ptr<edm_primitive_type> edm_primitive_type::GUID()
-{ 
+{
 	std::lock_guard<std::mutex> lock(mutex());
 
 	if (!_GUID)
 	{
-		_GUID.reset(new edm_primitive_type(U("Edm.Guid"), edm_primitive_type_kind_t::Guid));
+		_GUID.reset(new edm_primitive_type(_XPLATSTR("Edm.Guid"), edm_primitive_type_kind_t::Guid));
 	}
 
 	return _GUID;
 }
 
 std::shared_ptr<edm_primitive_type> edm_primitive_type::INT16()
-{ 
+{
 	std::lock_guard<std::mutex> lock(mutex());
 
 	if (!_INT16)
 	{
-		_INT16.reset(new edm_primitive_type(U("Edm.Int16"), edm_primitive_type_kind_t::Int16));
+		_INT16.reset(new edm_primitive_type(_XPLATSTR("Edm.Int16"), edm_primitive_type_kind_t::Int16));
 	}
 
 	return _INT16;
 }
 
-std::shared_ptr<edm_primitive_type> edm_primitive_type::INT32() 
-{ 
+std::shared_ptr<edm_primitive_type> edm_primitive_type::INT32()
+{
 	std::lock_guard<std::mutex> lock(mutex());
 
 	if (!_INT32)
 	{
-		_INT32.reset(new edm_primitive_type(U("Edm.Int32"), edm_primitive_type_kind_t::Int32));
+		_INT32.reset(new edm_primitive_type(_XPLATSTR("Edm.Int32"), edm_primitive_type_kind_t::Int32));
 	}
 
 	return _INT32;
 }
 
-std::shared_ptr<edm_primitive_type> edm_primitive_type::INT64() 
+std::shared_ptr<edm_primitive_type> edm_primitive_type::INT64()
 {
 	std::lock_guard<std::mutex> lock(mutex());
 
 	if (!_INT64)
 	{
-		_INT64.reset(new edm_primitive_type(U("Edm.Int64"), edm_primitive_type_kind_t::Int64));
+		_INT64.reset(new edm_primitive_type(_XPLATSTR("Edm.Int64"), edm_primitive_type_kind_t::Int64));
 	}
 
 	return _INT64;
 }
 
-std::shared_ptr<edm_primitive_type> edm_primitive_type::SBYTE() 
+std::shared_ptr<edm_primitive_type> edm_primitive_type::SBYTE()
 {
 	std::lock_guard<std::mutex> lock(mutex());
 
 	if (!_SBYTE)
 	{
-		_SBYTE.reset(new edm_primitive_type(U("Edm.SByte"), edm_primitive_type_kind_t::SByte));
+		_SBYTE.reset(new edm_primitive_type(_XPLATSTR("Edm.SByte"), edm_primitive_type_kind_t::SByte));
 	}
 
 	return _SBYTE;
 }
 
-std::shared_ptr<edm_primitive_type> edm_primitive_type::SINGLE() 
-{ 
+std::shared_ptr<edm_primitive_type> edm_primitive_type::SINGLE()
+{
 	std::lock_guard<std::mutex> lock(mutex());
 
 	if (!_SINGLE)
 	{
-		_SINGLE.reset(new edm_primitive_type(U("Edm.Single"), edm_primitive_type_kind_t::Single));
+		_SINGLE.reset(new edm_primitive_type(_XPLATSTR("Edm.Single"), edm_primitive_type_kind_t::Single));
 	}
 
 	return _SINGLE;
 }
 
-std::shared_ptr<edm_primitive_type> edm_primitive_type::STRING() 
+std::shared_ptr<edm_primitive_type> edm_primitive_type::STRING()
 {
 	std::lock_guard<std::mutex> lock(mutex());
 
 	if (!_STRING)
 	{
-		_STRING.reset(new edm_primitive_type(U("Edm.String"), edm_primitive_type_kind_t::String));
+		_STRING.reset(new edm_primitive_type(_XPLATSTR("Edm.String"), edm_primitive_type_kind_t::String));
 	}
 
 	return _STRING;
 }
 
-std::shared_ptr<edm_primitive_type> edm_primitive_type::STREAM() 
+std::shared_ptr<edm_primitive_type> edm_primitive_type::STREAM()
 {
 	std::lock_guard<std::mutex> lock(mutex());
 
 	if (!_STREAM)
 	{
-		_STREAM.reset(new edm_primitive_type(U("Edm.Stream"), edm_primitive_type_kind_t::Stream));
+		_STREAM.reset(new edm_primitive_type(_XPLATSTR("Edm.Stream"), edm_primitive_type_kind_t::Stream));
 	}
 
 	return _STREAM;
 }
 
-std::shared_ptr<edm_primitive_type> edm_primitive_type::UNKNOWN() 
+std::shared_ptr<edm_primitive_type> edm_primitive_type::UNKNOWN()
 {
 	std::lock_guard<std::mutex> lock(mutex());
 
 	if (!_UNKNOWN)
 	{
-		_UNKNOWN.reset(new edm_primitive_type(U("UNKNOWN"), edm_primitive_type_kind_t::NoneVal));
+		_UNKNOWN.reset(new edm_primitive_type(_XPLATSTR("UNKNOWN"), edm_primitive_type_kind_t::NoneVal));
 	}
 
 	return _UNKNOWN;
@@ -245,21 +245,20 @@ std::mutex &edm_primitive_type::mutex()
 	return _mutex;
 }
 
-std::shared_ptr<edm_property_type> edm_structured_type::find_property(::utility::string_t name) const
+std::shared_ptr<edm_property_type> edm_structured_type::find_property(::odata::string_t name) const
 {
-	// todo find property type in base type...
-    auto find_iter = m_properties.find(name);
+	auto find_iter = m_properties.find(name);
 	if (find_iter != m_properties.end())
 	{
 		return find_iter->second;
 	}
 	else if (m_base_type)
 	{
-		// find property type in base type 
+		// find property type in base type
 		return m_base_type->find_property(name);
 	}
 
-    return nullptr;
+	return nullptr;
 }
 
 }}

--- a/tests/e2e/common_tests.cpp
+++ b/tests/e2e/common_tests.cpp
@@ -26,31 +26,31 @@ SUITE(common_tests_raw_client)
 
 TEST_FIXTURE(e2e_raw_client, query_entityset)
 {
-	::utility::string_t entity_set_name = U("Products");
+	::odata::string_t entity_set_name = _XPLATSTR("Products");
 
 	auto entity_set = client.get_entities(entity_set_name).get();
-	
+
 	VERIFY_ARE_EQUAL(entity_set.size(), 5);
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Entity, entity_set[0]->get_value_type()->get_type_kind());
 
 	std::shared_ptr<odata_entity_value> first_entity = entity_set[0];
 	std::shared_ptr<odata_value> property_value;
-	VERIFY_IS_TRUE(first_entity->get_property_value(U("Name"), property_value));
+	VERIFY_IS_TRUE(first_entity->get_property_value(_XPLATSTR("Name"), property_value));
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Primitive, property_value->get_value_type()->get_type_kind());
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value);
-	::utility::string_t name = primitive_value->as<::utility::string_t>();
-	VERIFY_ARE_EQUAL(U("Cheetos"), name);
+	::odata::string_t name = primitive_value->as<::odata::string_t>();
+	VERIFY_ARE_EQUAL(_XPLATSTR("Cheetos"), name);
 }
 
 TEST_FIXTURE(e2e_raw_client, query_entity)
 {
-	auto query_result = client.get_data_from_server(U("Products(6)")).get();
+	auto query_result = client.get_data_from_server(_XPLATSTR("Products(6)")).get();
 	VERIFY_ARE_EQUAL(query_result.size(), 1);
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Entity, query_result[0]->get_value_type()->get_type_kind());
 
 	std::shared_ptr<odata_entity_value> entity = std::dynamic_pointer_cast<odata_entity_value>(query_result[0]);
 	std::shared_ptr<odata_value> property_value;
-	VERIFY_IS_TRUE(entity->get_property_value(U("UnitPrice"), property_value));
+	VERIFY_IS_TRUE(entity->get_property_value(_XPLATSTR("UnitPrice"), property_value));
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Primitive, property_value->get_value_type()->get_type_kind());
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value);
 	double unit_price = primitive_value->as<double>();
@@ -59,7 +59,7 @@ TEST_FIXTURE(e2e_raw_client, query_entity)
 
 TEST_FIXTURE(e2e_raw_client, query_primitive_property)
 {
-	auto query_result = client.get_data_from_server(U("Products(7)/QuantityInStock")).get();
+	auto query_result = client.get_data_from_server(_XPLATSTR("Products(7)/QuantityInStock")).get();
 	VERIFY_ARE_EQUAL(query_result.size(), 1);
 
 	std::shared_ptr<odata_value> property_value = query_result[0];
@@ -71,33 +71,33 @@ TEST_FIXTURE(e2e_raw_client, query_primitive_property)
 
 TEST_FIXTURE(e2e_raw_client, query_complex_property)
 {
-	auto query_result = client.get_data_from_server(U("People(1)/HomeAddress")).get();
+	auto query_result = client.get_data_from_server(_XPLATSTR("People(1)/HomeAddress")).get();
 	VERIFY_ARE_EQUAL(query_result.size(), 1);
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Complex, query_result[0]->get_value_type()->get_type_kind());
 
 	auto property_value = std::dynamic_pointer_cast<odata_complex_value>(query_result[0]);
 	std::shared_ptr<odata_value> street_field;
-	VERIFY_IS_TRUE(property_value->get_property_value(U("Street"), street_field));
+	VERIFY_IS_TRUE(property_value->get_property_value(_XPLATSTR("Street"), street_field));
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Primitive, street_field->get_value_type()->get_type_kind());
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(street_field);
-	::utility::string_t street = primitive_value->as<::utility::string_t>();
-	VERIFY_ARE_EQUAL(U("1 Microsoft Way"), street);
+	::odata::string_t street = primitive_value->as<::odata::string_t>();
+	VERIFY_ARE_EQUAL(_XPLATSTR("1 Microsoft Way"), street);
 }
 
 TEST_FIXTURE(e2e_raw_client, query_collection_property)
 {
-	auto query_result = client.get_data_from_server(U("People(4)/Numbers")).get();
+	auto query_result = client.get_data_from_server(_XPLATSTR("People(4)/Numbers")).get();
 	VERIFY_ARE_EQUAL(query_result.size(), 3);
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Primitive, query_result[0]->get_value_type()->get_type_kind());
 
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(query_result[1]);
-	::utility::string_t number = primitive_value->as<::utility::string_t>();
-	VERIFY_ARE_EQUAL(U("555-555-5555"), number);
+	::odata::string_t number = primitive_value->as<::odata::string_t>();
+	VERIFY_ARE_EQUAL(_XPLATSTR("555-555-5555"), number);
 }
 
 TEST_FIXTURE(e2e_raw_client, query_basic_properties_in_entity)
 {
-	auto query_result = client.get_data_from_server(U("People(4)")).get();
+	auto query_result = client.get_data_from_server(_XPLATSTR("People(4)")).get();
 	VERIFY_ARE_EQUAL(query_result.size(), 1);
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Entity, query_result[0]->get_value_type()->get_type_kind());
 
@@ -105,7 +105,7 @@ TEST_FIXTURE(e2e_raw_client, query_basic_properties_in_entity)
 
 	//collection property
 	std::shared_ptr<odata_value> collection_property;
-	VERIFY_IS_TRUE(entity->get_property_value(U("Numbers"), collection_property));
+	VERIFY_IS_TRUE(entity->get_property_value(_XPLATSTR("Numbers"), collection_property));
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Collection, collection_property->get_value_type()->get_type_kind());
 
 	auto collection_value = std::dynamic_pointer_cast<odata_collection_value>(collection_property);
@@ -113,9 +113,9 @@ TEST_FIXTURE(e2e_raw_client, query_basic_properties_in_entity)
 	VERIFY_ARE_EQUAL(3, collection_vector.size());
 
 	auto collectin_member = std::dynamic_pointer_cast<odata_primitive_value>(collection_vector[1]);
-	VERIFY_ARE_EQUAL(U("555-555-5555"), collectin_member->as<::utility::string_t>());
+	VERIFY_ARE_EQUAL(_XPLATSTR("555-555-5555"), collectin_member->as<::odata::string_t>());
 
-	//TODO-tiano: check the other property types 
+	//TODO-tiano: check the other property types
 }
 
 /*** $value not supported for now
@@ -130,78 +130,78 @@ TEST_FIXTURE(e2e_raw_client, create_entity)
 {
 	auto model = client.get_model().get();
 
-	::utility::string_t entity_set_name = U("Accounts");
-	std::shared_ptr<odata_entity_value> entity = std::make_shared<odata_entity_value>(model->find_container()->find_entity_set(entity_set_name)->get_entity_type());
+	::odata::string_t entity_set_name = _XPLATSTR("Accounts");
+	std::shared_ptr<odata_entity_value> entity = ::odata::make_shared<odata_entity_value>(model->find_container()->find_entity_set(entity_set_name)->get_entity_type());
 
-	entity->set_value(U("AccountID"), 130);
-	entity->set_value(U("CountryRegion"), U("CN"));
+	entity->set_value(_XPLATSTR("AccountID"), 130);
+	entity->set_value(_XPLATSTR("CountryRegion"), _XPLATSTR("CN"));
 
-	auto accountinfo_type = model->find_complex_type(U("AccountInfo"));
-	auto account_info = std::make_shared<odata_complex_value>(accountinfo_type);
-	::utility::string_t account_firstname = U("cpp");
-	::utility::string_t account_lastname = U("client");
-	account_info->set_value(U("FirstName"), account_firstname);
-	account_info->set_value(U("LastName"), account_lastname);
+	auto accountinfo_type = model->find_complex_type(_XPLATSTR("AccountInfo"));
+	auto account_info = ::odata::make_shared<odata_complex_value>(accountinfo_type);
+	::odata::string_t account_firstname = _XPLATSTR("cpp");
+	::odata::string_t account_lastname = _XPLATSTR("client");
+	account_info->set_value(_XPLATSTR("FirstName"), account_firstname);
+	account_info->set_value(_XPLATSTR("LastName"), account_lastname);
 
-	entity->set_value(U("AccountInfo"), account_info);
+	entity->set_value(_XPLATSTR("AccountInfo"), account_info);
 
 	auto response_code = client.create_entity(entity_set_name, entity).get();
 	VERIFY_ARE_EQUAL(201, response_code);
 
 	//query the newly created entity
-	auto query_result = client.get_data_from_server(U("Accounts(130)")).get();
+	auto query_result = client.get_data_from_server(_XPLATSTR("Accounts(130)")).get();
 	VERIFY_ARE_EQUAL(query_result.size(), 1);
 
 	auto new_entity = std::dynamic_pointer_cast<odata_entity_value>(query_result[0]);
 	std::shared_ptr<odata_value> property_value;
-	VERIFY_IS_TRUE(entity->get_property_value(U("AccountID"), property_value));
+	VERIFY_IS_TRUE(entity->get_property_value(_XPLATSTR("AccountID"), property_value));
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value);
 	int32_t new_id = primitive_value->as<int32_t>();
 	VERIFY_ARE_EQUAL(130, new_id);
 }
 
-/* TODO: [tiano] 
+/* TODO: [tiano]
 TEST_FIXTURE(e2e_raw_client, create_entity_with_unescaped_string)
 {
 	auto model = client.get_model().get();
 
-	::utility::string_t entity_set_name = U("Accounts");
-	std::shared_ptr<odata_entity_value> entity = std::make_shared<odata_entity_value>(model->find_entity_set_type(entity_set_name));
+	::odata::string_t entity_set_name = _XPLATSTR("Accounts");
+	std::shared_ptr<odata_entity_value> entity = ::odata::make_shared<odata_entity_value>(model->find_entity_set_type(entity_set_name));
 
-	entity->set_value(U("AccountID"), 130);
-	entity->set_value(U("CountryRegion"), U("CN"));
+	entity->set_value(_XPLATSTR("AccountID"), 130);
+	entity->set_value(_XPLATSTR("CountryRegion"), _XPLATSTR("CN"));
 
-	auto accountinfo_type = model->find_complex_type(U("AccountInfo"));
-	auto account_info = std::make_shared<odata_complex_value>(accountinfo_type);
-	::utility::string_t account_firstname = U("Î¢Èí\nÉÏº£");
-	::utility::string_t account_lastname = U("Å¶µÃËû");
-	account_info->set_value(U("FirstName"), account_firstname);
-	account_info->set_value(U("LastName"), account_lastname);
+	auto accountinfo_type = model->find_complex_type(_XPLATSTR("AccountInfo"));
+	auto account_info = ::odata::make_shared<odata_complex_value>(accountinfo_type);
+	::odata::string_t account_firstname = _XPLATSTR("Î¢Èí\nÉÏº£");
+	::odata::string_t account_lastname = _XPLATSTR("Å¶µÃËû");
+	account_info->set_value(_XPLATSTR("FirstName"), account_firstname);
+	account_info->set_value(_XPLATSTR("LastName"), account_lastname);
 
-	entity->set_value(U("AccountInfo"), account_info);
+	entity->set_value(_XPLATSTR("AccountInfo"), account_info);
 
 	auto response_code = client.create_entity(entity_set_name, entity).get();
 	VERIFY_ARE_EQUAL(201, response_code);
 
 	//query the newly created entity
-	auto query_result = client.get_data_from_server(U("Accounts(130)")).get();
+	auto query_result = client.get_data_from_server(_XPLATSTR("Accounts(130)")).get();
 	VERIFY_ARE_EQUAL(query_result.size(), 1);
 
 	auto new_entity = std::dynamic_pointer_cast<odata_entity_value>(query_result[0]);
 	std::shared_ptr<odata_value> property_value;
-	VERIFY_IS_TRUE(entity->get_property_value(U("AccountID"), property_value));
+	VERIFY_IS_TRUE(entity->get_property_value(_XPLATSTR("AccountID"), property_value));
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value);
 	int32_t new_id = primitive_value->as<int32_t>();
 	VERIFY_ARE_EQUAL(130, new_id);
 
 	std::shared_ptr<odata_value> complex_property_value;
-	new_entity->get_property_value(U("AccountInfo"), complex_property_value);
+	new_entity->get_property_value(_XPLATSTR("AccountInfo"), complex_property_value);
 	auto complex_value = std::dynamic_pointer_cast<odata_complex_value>(complex_property_value);
-	::utility::string_t firstname, lastname;
-	complex_value->try_get(U("FirstName"), firstname);
-	VERIFY_ARE_EQUAL(U("Î¢Èí\nÉÏº£"), firstname);
-	complex_value->try_get(U("LastName"), lastname);
-	VERIFY_ARE_EQUAL(U("Å¶µÃËû"), lastname);
+	::odata::string_t firstname, lastname;
+	complex_value->try_get(_XPLATSTR("FirstName"), firstname);
+	VERIFY_ARE_EQUAL(_XPLATSTR("Î¢Èí\nÉÏº£"), firstname);
+	complex_value->try_get(_XPLATSTR("LastName"), lastname);
+	VERIFY_ARE_EQUAL(_XPLATSTR("Å¶µÃËû"), lastname);
 }
 */
 
@@ -210,28 +210,28 @@ TEST_FIXTURE(e2e_raw_client, update_entity_with_patch)
 	auto model = client.get_model().get();
 
 	//check the old value
-	auto query_result = client.get_data_from_server(U("Accounts(101)")).get();
+	auto query_result = client.get_data_from_server(_XPLATSTR("Accounts(101)")).get();
 	auto old_entity = std::dynamic_pointer_cast<odata_entity_value>(query_result[0]);
 	std::shared_ptr<odata_value> old_value;
-	old_entity->get_property_value(U("CountryRegion"), old_value);
+	old_entity->get_property_value(_XPLATSTR("CountryRegion"), old_value);
 	auto old_country = std::dynamic_pointer_cast<odata_primitive_value>(old_value);
-	VERIFY_ARE_EQUAL(U("US"), old_country->as<::utility::string_t>());
+	VERIFY_ARE_EQUAL(_XPLATSTR("US"), old_country->as<::odata::string_t>());
 
 	//update the entity with patch
-	old_entity->set_value(U("CountryRegion"), U("GB"));
+	old_entity->set_value(_XPLATSTR("CountryRegion"), _XPLATSTR("GB"));
 
-	auto response_code = client.patch_entity(U("Accounts"), old_entity).get();
+	auto response_code = client.patch_entity(_XPLATSTR("Accounts"), old_entity).get();
 	VERIFY_ARE_EQUAL(204, response_code);
 
 	//query the updated entity
-	auto check_query = client.get_data_from_server(U("Accounts(101)")).get();
+	auto check_query = client.get_data_from_server(_XPLATSTR("Accounts(101)")).get();
 
 	auto new_entity = std::dynamic_pointer_cast<odata_entity_value>(check_query[0]);
 	std::shared_ptr<odata_value> property_value;
-	VERIFY_IS_TRUE(new_entity->get_property_value(U("CountryRegion"), property_value));
+	VERIFY_IS_TRUE(new_entity->get_property_value(_XPLATSTR("CountryRegion"), property_value));
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value);
-	::utility::string_t new_country = primitive_value->as<::utility::string_t>();
-	VERIFY_ARE_EQUAL(U("GB"), new_country);
+	::odata::string_t new_country = primitive_value->as<::odata::string_t>();
+	VERIFY_ARE_EQUAL(_XPLATSTR("GB"), new_country);
 }
 }
 
@@ -243,85 +243,85 @@ TEST_FIXTURE(e2e_test_case, query_entityset)
 	auto people = service_context->create_people_query()->execute_query().get();
 
 	VERIFY_ARE_EQUAL(5, people.size());
-	VERIFY_ARE_EQUAL(U("Peter"), people[4]->get_firstname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Peter"), people[4]->get_firstname());
 }
 
 TEST_FIXTURE(e2e_test_case, query_entity)
 {
-	auto people = service_context->create_people_query()->key(U("4"))->execute_query().get();
+	auto people = service_context->create_people_query()->key(_XPLATSTR("4"))->execute_query().get();
 
 	VERIFY_ARE_EQUAL(1, people.size());
-	VERIFY_ARE_EQUAL(U("Elmo"), people[0]->get_firstname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Elmo"), people[0]->get_firstname());
 }
 
 TEST_FIXTURE(e2e_test_case, top_level_query)
 {
-	auto price = service_context->create_query<odata_primitive_query_executor<double>, odata_query_builder>(U("Products(5)/UnitPrice"))->execute_query().get();
+	auto price = service_context->create_query<odata_primitive_query_executor<double>, odata_query_builder>(_XPLATSTR("Products(5)/UnitPrice"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, price.size());
 	VERIFY_ARE_EQUAL(3.24, price[0]);
 
-	auto acct_info = service_context->create_query<odata_complex_query_executor<AccountInfo>, odata_query_builder>(U("Accounts(101)/AccountInfo"))->execute_query().get();
+	auto acct_info = service_context->create_query<odata_complex_query_executor<AccountInfo>, odata_query_builder>(_XPLATSTR("Accounts(101)/AccountInfo"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, acct_info.size());
-	VERIFY_ARE_EQUAL(U("Alex"), acct_info[0]->get_firstname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Alex"), acct_info[0]->get_firstname());
 
-	auto numbers = service_context->create_query<odata_primitive_query_executor<::utility::string_t>, odata_query_builder>(U("People(4)/Numbers"))->execute_query().get();
+	auto numbers = service_context->create_query<odata_primitive_query_executor<::odata::string_t>, odata_query_builder>(_XPLATSTR("People(4)/Numbers"))->execute_query().get();
 	VERIFY_ARE_EQUAL(3, numbers.size());
-	VERIFY_ARE_EQUAL(U("444-444-4444"), numbers[0]);
+	VERIFY_ARE_EQUAL(_XPLATSTR("444-444-4444"), numbers[0]);
 
 	/***
 	//Issue: [tiano] $value doesn't work because the Accept header can't be json. Bug #2265002
-	
-	auto name = service_context->create_query<odata_primitive_query_executor<::utility::string_t>, odata_query_builder>(U("Products(5)/Name/$value"))->execute_query().get();
+
+	auto name = service_context->create_query<odata_primitive_query_executor<::odata::string_t>, odata_query_builder>(_XPLATSTR("Products(5)/Name/$value"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, name.size());
-	VERIFY_ARE_EQUAL(U("Cheetos"), name[0]);
-	
-	auto count = service_context->create_query<odata_primitive_query_executor<int32_t>, odata_query_builder>(U("Products/$count"))->execute_query().get();
+	VERIFY_ARE_EQUAL(_XPLATSTR("Cheetos"), name[0]);
+
+	auto count = service_context->create_query<odata_primitive_query_executor<int32_t>, odata_query_builder>(_XPLATSTR("Products/$count"))->execute_query().get();
 	***/
 }
 
 
-TEST_FIXTURE(e2e_test_case, create_entity)  
-{	
-	auto new_account = std::make_shared<Account>(service_context);
+TEST_FIXTURE(e2e_test_case, create_entity)
+{
+	auto new_account = ::odata::make_shared<Account>(service_context);
 	new_account->set_accountid(140);
-	new_account->set_countryregion(U("DE"));
-	auto acinfo = std::make_shared<AccountInfo>(service_context);
-	acinfo->set_firstname(U("cpp"));
-	acinfo->set_lastname(U("test"));
+	new_account->set_countryregion(_XPLATSTR("DE"));
+	auto acinfo = ::odata::make_shared<AccountInfo>(service_context);
+	acinfo->set_firstname(_XPLATSTR("cpp"));
+	acinfo->set_lastname(_XPLATSTR("test"));
 	new_account->set_accountinfo(acinfo);
 
-	auto status_code = service_context->add_object(U("Accounts"), new_account).get();
+	auto status_code = service_context->add_object(_XPLATSTR("Accounts"), new_account).get();
 	VERIFY_ARE_EQUAL(201, status_code);
 
-	auto account = service_context->create_accounts_query()->key(U("140"))->execute_query().get();
-	VERIFY_ARE_EQUAL(U("DE"), account[0]->get_countryregion());
+	auto account = service_context->create_accounts_query()->key(_XPLATSTR("140"))->execute_query().get();
+	VERIFY_ARE_EQUAL(_XPLATSTR("DE"), account[0]->get_countryregion());
 	auto info = account[0]->get_accountinfo();
-	VERIFY_ARE_EQUAL(U("cpp"), info->get_firstname());
-	VERIFY_ARE_EQUAL(U("test"), info->get_lastname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("cpp"), info->get_firstname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("test"), info->get_lastname());
 }
 
 TEST_FIXTURE(e2e_test_case, update_entity)
 {
-	auto people = service_context->create_people_query()->key(U("5"))->execute_query().get();
+	auto people = service_context->create_people_query()->key(_XPLATSTR("5"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, people.size());
 
-	people[0]->set_firstname(U("cpp test updated"));
+	people[0]->set_firstname(_XPLATSTR("cpp test updated"));
 	auto status_code = service_context->update_object(people[0], HTTP_PUT).get();
 	VERIFY_ARE_EQUAL(204, status_code);
 
-	auto people_new = service_context->create_people_query()->key(U("5"))->execute_query().get();
-	VERIFY_ARE_EQUAL(U("cpp test updated"), people_new[0]->get_firstname());
+	auto people_new = service_context->create_people_query()->key(_XPLATSTR("5"))->execute_query().get();
+	VERIFY_ARE_EQUAL(_XPLATSTR("cpp test updated"), people_new[0]->get_firstname());
 }
 
 TEST_FIXTURE(e2e_test_case, delete_entity)
 {
-	auto accounts = service_context->create_accounts_query()->key(U("107"))->execute_query().get();
+	auto accounts = service_context->create_accounts_query()->key(_XPLATSTR("107"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, accounts.size());
 
 	auto status_code = service_context->delete_object(accounts[0]).get();
 	VERIFY_ARE_EQUAL(204, status_code);
 
-	VERIFY_THROWS(service_context->create_accounts_query()->key(U("107"))->execute_query().get(), ::odata::communication::service_exception); //TODO-tiano: check error codes
+	VERIFY_THROWS(service_context->create_accounts_query()->key(_XPLATSTR("107"))->execute_query().get(), ::odata::communication::service_exception); //TODO-tiano: check error codes
 }
 
 }

--- a/tests/e2e/containment_tests.cpp
+++ b/tests/e2e/containment_tests.cpp
@@ -16,13 +16,13 @@ SUITE(containment_tests_raw_client)
 
 TEST_FIXTURE(e2e_raw_client, query_contained_entityset)
 {
-	auto entity_set = client.get_data_from_server(U("Accounts(101)/MyPaymentInstruments")).get();
+	auto entity_set = client.get_data_from_server(_XPLATSTR("Accounts(101)/MyPaymentInstruments")).get();
 	VERIFY_ARE_EQUAL(entity_set.size(), 3);
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Entity, entity_set[0]->get_value_type()->get_type_kind());
 
 	auto first_entity = std::dynamic_pointer_cast<odata_entity_value>(entity_set[0]);
 	std::shared_ptr<odata_value> property_value;
-	VERIFY_IS_TRUE(first_entity->get_property_value(U("PaymentInstrumentID"), property_value));
+	VERIFY_IS_TRUE(first_entity->get_property_value(_XPLATSTR("PaymentInstrumentID"), property_value));
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value);
 	int32_t id = primitive_value->as<int32_t>();
 	VERIFY_ARE_EQUAL(101901, id);
@@ -30,13 +30,13 @@ TEST_FIXTURE(e2e_raw_client, query_contained_entityset)
 
 TEST_FIXTURE(e2e_raw_client, query_contained_entity)
 {
-	auto entity_set = client.get_data_from_server(U("Accounts(101)/MyPaymentInstruments(101902)")).get();
+	auto entity_set = client.get_data_from_server(_XPLATSTR("Accounts(101)/MyPaymentInstruments(101902)")).get();
 	VERIFY_ARE_EQUAL(entity_set.size(), 1);
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Entity, entity_set[0]->get_value_type()->get_type_kind());
 
 	auto first_entity = std::dynamic_pointer_cast<odata_entity_value>(entity_set[0]);
 	std::shared_ptr<odata_value> property_value;
-	VERIFY_IS_TRUE(first_entity->get_property_value(U("PaymentInstrumentID"), property_value));
+	VERIFY_IS_TRUE(first_entity->get_property_value(_XPLATSTR("PaymentInstrumentID"), property_value));
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Primitive, property_value->get_value_type()->get_type_kind());
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value);
 	int32_t id = primitive_value->as<int32_t>();
@@ -45,13 +45,13 @@ TEST_FIXTURE(e2e_raw_client, query_contained_entity)
 
 TEST_FIXTURE(e2e_raw_client, query_contained_single_valued_entity)
 {
-	auto entity_set = client.get_data_from_server(U("Accounts(101)/MyGiftCard")).get();
+	auto entity_set = client.get_data_from_server(_XPLATSTR("Accounts(101)/MyGiftCard")).get();
 	VERIFY_ARE_EQUAL(entity_set.size(), 1);
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Entity, entity_set[0]->get_value_type()->get_type_kind());
 
 	auto first_entity = std::dynamic_pointer_cast<odata_entity_value>(entity_set[0]);
 	std::shared_ptr<odata_value> property_value;
-	VERIFY_IS_TRUE(first_entity->get_property_value(U("Amount"), property_value));
+	VERIFY_IS_TRUE(first_entity->get_property_value(_XPLATSTR("Amount"), property_value));
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Primitive, property_value->get_value_type()->get_type_kind());
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value);
 	double amount = primitive_value->as<double>();
@@ -62,55 +62,55 @@ TEST_FIXTURE(e2e_raw_client, create_contained_entity)
 {
 	auto model = client.get_model().get();
 
-	::utility::string_t entity_type_name = U("PaymentInstrument");
-	std::shared_ptr<odata_entity_value> entity = std::make_shared<odata_entity_value>(model->find_entity_type(entity_type_name));
+	::odata::string_t entity_type_name = _XPLATSTR("PaymentInstrument");
+	std::shared_ptr<odata_entity_value> entity = ::odata::make_shared<odata_entity_value>(model->find_entity_type(entity_type_name));
 
-	entity->set_value(U("PaymentInstrumentID"), 101920);
-	entity->set_value(U("FriendlyName"), U("created by cpp test"));
+	entity->set_value(_XPLATSTR("PaymentInstrumentID"), 101920);
+	entity->set_value(_XPLATSTR("FriendlyName"), _XPLATSTR("created by cpp test"));
 	datetime now(datetime::utc_now());
-	entity->set_value(U("CreatedDate"), now);
+	entity->set_value(_XPLATSTR("CreatedDate"), now);
 
 	//send the POST request to create the entity
-	auto response_code = client.create_entity(U("Accounts(101)/MyPaymentInstruments"), entity).get();
+	auto response_code = client.create_entity(_XPLATSTR("Accounts(101)/MyPaymentInstruments"), entity).get();
 	VERIFY_ARE_EQUAL(201, response_code);
 
 	//query the newly created entity
-	auto query_result = client.get_data_from_server(U("Accounts(101)/MyPaymentInstruments(101920)")).get();
+	auto query_result = client.get_data_from_server(_XPLATSTR("Accounts(101)/MyPaymentInstruments(101920)")).get();
 	VERIFY_ARE_EQUAL(query_result.size(), 1);
 
 	auto new_entity = std::dynamic_pointer_cast<odata_entity_value>(query_result[0]);
 	std::shared_ptr<odata_value> property_value;
-	VERIFY_IS_TRUE(entity->get_property_value(U("FriendlyName"), property_value));
+	VERIFY_IS_TRUE(entity->get_property_value(_XPLATSTR("FriendlyName"), property_value));
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value);
-	::utility::string_t firendly_name = primitive_value->as<::utility::string_t>();
-	VERIFY_ARE_EQUAL(U("created by cpp test"), firendly_name);
+	::odata::string_t firendly_name = primitive_value->as<::odata::string_t>();
+	VERIFY_ARE_EQUAL(_XPLATSTR("created by cpp test"), firendly_name);
 }
 
 TEST_FIXTURE(e2e_raw_client, create_contained_single_valued_entity)
 {
 	auto model = client.get_model().get();
 
-	::utility::string_t entity_type_name = U("GiftCard");
-	std::shared_ptr<odata_entity_value> entity = std::make_shared<odata_entity_value>(model->find_entity_type(entity_type_name));
+	::odata::string_t entity_type_name = _XPLATSTR("GiftCard");
+	std::shared_ptr<odata_entity_value> entity = ::odata::make_shared<odata_entity_value>(model->find_entity_type(entity_type_name));
 
-	entity->set_value(U("GiftCardID"), 304);
-	::utility::string_t card_number = U("AAASSSDD30");
-	entity->set_value(U("GiftCardNO"), card_number);
-	entity->set_value(U("Amount"), 132.0);
+	entity->set_value(_XPLATSTR("GiftCardID"), 304);
+	::odata::string_t card_number = _XPLATSTR("AAASSSDD30");
+	entity->set_value(_XPLATSTR("GiftCardNO"), card_number);
+	entity->set_value(_XPLATSTR("Amount"), 132.0);
 	datetime now(datetime::utc_now());
-	entity->set_value(U("ExperationDate"), now);
+	entity->set_value(_XPLATSTR("ExperationDate"), now);
 
 	//send the PATCH request to create the entity
-	auto response_code = client.send_data_to_server(U("Accounts(104)/MyGiftCard"), entity,  U("PATCH")).get();
+	auto response_code = client.send_data_to_server(_XPLATSTR("Accounts(104)/MyGiftCard"), entity,  _XPLATSTR("PATCH")).get();
 	VERIFY_ARE_EQUAL(204, response_code);
 
 	//query the newly created entity
-	auto query_result = client.get_data_from_server(U("Accounts(104)/MyGiftCard")).get();
+	auto query_result = client.get_data_from_server(_XPLATSTR("Accounts(104)/MyGiftCard")).get();
 	VERIFY_ARE_EQUAL(query_result.size(), 1);
 
 	auto new_entity = std::dynamic_pointer_cast<odata_entity_value>(query_result[0]);
 	std::shared_ptr<odata_value> property_value;
-	VERIFY_IS_TRUE(entity->get_property_value(U("Amount"), property_value));
+	VERIFY_IS_TRUE(entity->get_property_value(_XPLATSTR("Amount"), property_value));
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value);
 	double amount = primitive_value->as<double>();
 	VERIFY_ARE_EQUAL(132.0, amount);
@@ -121,18 +121,18 @@ TEST_FIXTURE(e2e_raw_client, create_contained_single_valued_entity)
 SUITE(containment_tests)
 {
 
-TEST_FIXTURE(e2e_test_case, query_contained_entity)  
-{	
-	auto accounts = service_context->create_accounts_query()->key(U("101"))->expand(U("MyGiftCard,MyPaymentInstruments"))->execute_query().get();
+TEST_FIXTURE(e2e_test_case, query_contained_entity)
+{
+	auto accounts = service_context->create_accounts_query()->key(_XPLATSTR("101"))->expand(_XPLATSTR("MyGiftCard,MyPaymentInstruments"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, accounts.size());
 	std::shared_ptr<Account> account101 = accounts[0];
 
 	VERIFY_ARE_EQUAL(19.9, account101->get_mygiftcard()->get_amount());
-	VERIFY_ARE_EQUAL(U("101 first PI"), account101->get_mypaymentinstruments()[0]->get_friendlyname());
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyGiftCard"), account101->get_mygiftcard()->get_edit_link());
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101901)"), account101->get_mypaymentinstruments()[0]->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("101 first PI"), account101->get_mypaymentinstruments()[0]->get_friendlyname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyGiftCard"), account101->get_mygiftcard()->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101901)"), account101->get_mypaymentinstruments()[0]->get_edit_link());
 
-	accounts = service_context->create_accounts_query()->key(U("103"))->execute_query().get();
+	accounts = service_context->create_accounts_query()->key(_XPLATSTR("103"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, accounts.size());
 	std::shared_ptr<Account> account103 = accounts[0];
 
@@ -140,51 +140,51 @@ TEST_FIXTURE(e2e_test_case, query_contained_entity)
 	account103->load_mypaymentinstruments().get();
 
 	VERIFY_ARE_EQUAL(1.9, account103->get_mygiftcard()->get_amount());
-	VERIFY_ARE_EQUAL(U("103 frist PI"), account103->get_mypaymentinstruments()[0]->get_friendlyname());
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)/MyGiftCard"), account103->get_mygiftcard()->get_edit_link());
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)/MyPaymentInstruments(103901)"), account103->get_mypaymentinstruments()[0]->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("103 frist PI"), account103->get_mypaymentinstruments()[0]->get_friendlyname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)/MyGiftCard"), account103->get_mygiftcard()->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)/MyPaymentInstruments(103901)"), account103->get_mypaymentinstruments()[0]->get_edit_link());
 }
 
-TEST_FIXTURE(e2e_test_case, create_contained_entity)  
-{	
-	auto accounts = service_context->create_accounts_query()->key(U("101"))->execute_query().get();
+TEST_FIXTURE(e2e_test_case, create_contained_entity)
+{
+	auto accounts = service_context->create_accounts_query()->key(_XPLATSTR("101"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, accounts.size());
 	std::shared_ptr<Account> account = accounts[0];
 
-	auto new_pi = std::make_shared<CreditCardPI>(service_context);
+	auto new_pi = ::odata::make_shared<CreditCardPI>(service_context);
 	new_pi->set_paymentinstrumentid(101920);
-	new_pi->set_friendlyname(U("cpp test containment creation"));
+	new_pi->set_friendlyname(_XPLATSTR("cpp test containment creation"));
 	new_pi->set_createddate(::utility::datetime::utc_now());
-	new_pi->set_cardnumber(U("9200000000000000"));
-	new_pi->set_cvv(U("801"));
-	new_pi->set_holdername(U("cpp"));
+	new_pi->set_cardnumber(_XPLATSTR("9200000000000000"));
+	new_pi->set_cvv(_XPLATSTR("801"));
+	new_pi->set_holdername(_XPLATSTR("cpp"));
 	new_pi->set_balance(32.0);
 	new_pi->set_experationdate(::utility::datetime::utc_now());
-	auto status_code = service_context->add_related_object(account, U("MyPaymentInstruments"), new_pi).get();
+	auto status_code = service_context->add_related_object(account, _XPLATSTR("MyPaymentInstruments"), new_pi).get();
 
 	VERIFY_ARE_EQUAL(201, status_code);
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101920)"), new_pi->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101920)"), new_pi->get_edit_link());
 
-	auto pi = service_context->create_query<odata_singleton_query_executor<PaymentInstrument>, odata_query_builder>(U("Accounts(101)/MyPaymentInstruments(101920)"))
+	auto pi = service_context->create_query<odata_singleton_query_executor<PaymentInstrument>, odata_query_builder>(_XPLATSTR("Accounts(101)/MyPaymentInstruments(101920)"))
 		->execute_query().get();
-	VERIFY_ARE_EQUAL(U("cpp test containment creation"), pi->get_friendlyname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("cpp test containment creation"), pi->get_friendlyname());
 }
 
-TEST_FIXTURE(e2e_test_case, create_contained_single_valued_entity)  
+TEST_FIXTURE(e2e_test_case, create_contained_single_valued_entity)
 {
-	auto accounts = service_context->create_accounts_query()->key(U("101"))->execute_query().get();
+	auto accounts = service_context->create_accounts_query()->key(_XPLATSTR("101"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, accounts.size());
 	std::shared_ptr<Account> account = accounts[0];
 
-	auto new_giftcard = std::make_shared<GiftCard>(service_context);
+	auto new_giftcard = ::odata::make_shared<GiftCard>(service_context);
 	new_giftcard->set_giftcardid(304);
-	new_giftcard->set_giftcardno(U("AAB999A"));
+	new_giftcard->set_giftcardno(_XPLATSTR("AAB999A"));
 	new_giftcard->set_amount(30.0);
 	new_giftcard->set_experationdate(::utility::datetime::utc_now());
-	auto status_code = service_context->update_related_object(account, U("MyGiftCard"), new_giftcard).get();
+	auto status_code = service_context->update_related_object(account, _XPLATSTR("MyGiftCard"), new_giftcard).get();
 
 	VERIFY_ARE_EQUAL(204, status_code);
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyGiftCard"), new_giftcard->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyGiftCard"), new_giftcard->get_edit_link());
 
 	account->load_mygiftcard().get();
 	auto giftcard = account->get_mygiftcard();
@@ -194,7 +194,7 @@ TEST_FIXTURE(e2e_test_case, create_contained_single_valued_entity)
 
 TEST_FIXTURE(e2e_test_case, update_contained_entity)
 {
-	auto accounts = service_context->create_accounts_query()->key(U("101"))->execute_query().get();
+	auto accounts = service_context->create_accounts_query()->key(_XPLATSTR("101"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, accounts.size());
 	std::shared_ptr<Account> account = accounts[0];
 
@@ -210,15 +210,15 @@ TEST_FIXTURE(e2e_test_case, update_contained_entity)
 }
 
 
-TEST_FIXTURE(e2e_test_case, delete_contained_entity) 
+TEST_FIXTURE(e2e_test_case, delete_contained_entity)
 {
-	auto accounts = service_context->create_accounts_query()->key(U("101"))->expand(U("MyPaymentInstruments"))->execute_query().get();
+	auto accounts = service_context->create_accounts_query()->key(_XPLATSTR("101"))->expand(_XPLATSTR("MyPaymentInstruments"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, accounts.size());
 	std::shared_ptr<Account> account = accounts[0];
 
 	VERIFY_ARE_EQUAL(3, account->get_mypaymentinstruments().size());
 	auto cc = std::dynamic_pointer_cast<CreditCardPI>(account->get_mypaymentinstruments()[1]);
-	VERIFY_ARE_EQUAL(U("101 frist credit PI"), cc->get_friendlyname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("101 frist credit PI"), cc->get_friendlyname());
 
 	auto status_code = service_context->delete_object(cc).get();
 	VERIFY_ARE_EQUAL(204, status_code);
@@ -227,21 +227,21 @@ TEST_FIXTURE(e2e_test_case, delete_contained_entity)
 	VERIFY_ARE_EQUAL(2, account->get_mypaymentinstruments().size());
 }
 
-TEST_FIXTURE(e2e_test_case, query_contained_entities_with_query_options) 
+TEST_FIXTURE(e2e_test_case, query_contained_entities_with_query_options)
 {
-	auto pis = service_context->create_query<odata_entityset_query_executor<PaymentInstrument>, odata_query_builder>(U("Accounts(101)/MyPaymentInstruments"))
-		->filter(U("PaymentInstrumentID gt 101901"))->execute_query().get(); 
+	auto pis = service_context->create_query<odata_entityset_query_executor<PaymentInstrument>, odata_query_builder>(_XPLATSTR("Accounts(101)/MyPaymentInstruments"))
+		->filter(_XPLATSTR("PaymentInstrumentID gt 101901"))->execute_query().get();
 	VERIFY_ARE_EQUAL(2, pis.size());
 	VERIFY_ARE_EQUAL(101902, pis[0]->get_paymentinstrumentid());
 	VERIFY_ARE_EQUAL(101903, pis[1]->get_paymentinstrumentid());
 
 	//complicated query options
-		
+
 }
 
-TEST_FIXTURE(e2e_test_case, level2_contained_entity) 
+TEST_FIXTURE(e2e_test_case, level2_contained_entity)
 {
-	auto accounts = service_context->create_accounts_query()->key(U("103"))->execute_query().get();
+	auto accounts = service_context->create_accounts_query()->key(_XPLATSTR("103"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, accounts.size());
 	VERIFY_ARE_EQUAL(103, accounts[0]->get_accountid());
 
@@ -256,17 +256,17 @@ TEST_FIXTURE(e2e_test_case, level2_contained_entity)
 	auto statements = pi->get_billingstatements();
 	VERIFY_ARE_EQUAL(2, statements.size());
 	VERIFY_ARE_EQUAL(103901002, statements[1]->get_statementid());
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901002)"), statements[1]->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901002)"), statements[1]->get_edit_link());
 
-	auto single_statement = service_context->create_query<odata_singleton_query_executor<Statement>, odata_query_builder>(U("Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901001)"))
+	auto single_statement = service_context->create_query<odata_singleton_query_executor<Statement>, odata_query_builder>(_XPLATSTR("Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901001)"))
 		->execute_query().get();
 	VERIFY_ARE_EQUAL(103901001, single_statement->get_statementid());
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901001)"), single_statement->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901001)"), single_statement->get_edit_link());
 }
 
-TEST_FIXTURE(e2e_test_case, level2_noncontained_entity) 
+TEST_FIXTURE(e2e_test_case, level2_noncontained_entity)
 {
-	auto accounts = service_context->create_accounts_query()->key(U("103"))->execute_query().get();
+	auto accounts = service_context->create_accounts_query()->key(_XPLATSTR("103"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, accounts.size());
 	VERIFY_ARE_EQUAL(103, accounts[0]->get_accountid());
 
@@ -281,12 +281,12 @@ TEST_FIXTURE(e2e_test_case, level2_noncontained_entity)
 	auto the_stored_pi = pi->get_thestoredpi();
 	VERIFY_IS_NOT_NULL(the_stored_pi);
 	VERIFY_ARE_EQUAL(802, the_stored_pi->get_storedpiid());
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/StoredPIs(802)"), the_stored_pi->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/StoredPIs(802)"), the_stored_pi->get_edit_link());
 }
 
-TEST_FIXTURE(e2e_test_case, derived_type_contained_entity) 
+TEST_FIXTURE(e2e_test_case, derived_type_contained_entity)
 {
-	auto accounts = service_context->create_accounts_query()->key(U("101"))->execute_query().get();
+	auto accounts = service_context->create_accounts_query()->key(_XPLATSTR("101"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, accounts.size());
 	VERIFY_ARE_EQUAL(101, accounts[0]->get_accountid());
 
@@ -294,25 +294,25 @@ TEST_FIXTURE(e2e_test_case, derived_type_contained_entity)
 	account->load_mypaymentinstruments().get();
 	auto pis = account->get_mypaymentinstruments();
 	VERIFY_ARE_EQUAL(3, pis.size());
-	
+
 	VERIFY_ARE_EQUAL(101901, pis[0]->get_paymentinstrumentid());
 	auto cc1 = std::dynamic_pointer_cast<CreditCardPI>(pis[1]);
 	VERIFY_IS_NOT_NULL(cc1);
-	VERIFY_ARE_EQUAL(U("234"), cc1->get_cvv());
+	VERIFY_ARE_EQUAL(_XPLATSTR("234"), cc1->get_cvv());
 
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101902)/Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI"), cc1->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101902)/Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI"), cc1->get_edit_link());
 	auto cc2 = std::dynamic_pointer_cast<CreditCardPI>(pis[2]);
 	VERIFY_IS_NOT_NULL(cc2);
-	VERIFY_ARE_EQUAL(U("012"), cc2->get_cvv());
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101903)/Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI"), cc2->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("012"), cc2->get_cvv());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101903)/Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI"), cc2->get_edit_link());
 
 	cc1->load_creditrecords().get();
 	auto credit_records = cc1->get_creditrecords();
 	VERIFY_ARE_EQUAL(2, credit_records.size());
 
 	auto credit_record = credit_records[0];
-	VERIFY_ARE_EQUAL(U("Shopping"), credit_record->get_reason());
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101902)/Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI/CreditRecords(1)"), credit_record->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Shopping"), credit_record->get_reason());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101902)/Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI/CreditRecords(1)"), credit_record->get_edit_link());
 
 }
 

--- a/tests/e2e/derived_type_tests.cpp
+++ b/tests/e2e/derived_type_tests.cpp
@@ -17,30 +17,30 @@ SUITE(derived_type_tests_raw_client)
 
 TEST_FIXTURE(e2e_raw_client, query_entity_collection)
 {
-	auto entities = client.get_data_from_server(U("People/Microsoft.Test.OData.Services.ODataWCFService.Customer")).get();
+	auto entities = client.get_data_from_server(_XPLATSTR("People/Microsoft.Test.OData.Services.ODataWCFService.Customer")).get();
 	VERIFY_ARE_EQUAL(entities.size(), 2);
 
 	std::shared_ptr<odata_entity_value> first_entity = std::dynamic_pointer_cast<odata_entity_value>(entities[0]);
 	std::shared_ptr<odata_value> property_value;
-	VERIFY_IS_TRUE(first_entity->get_property_value(U("City"), property_value));
+	VERIFY_IS_TRUE(first_entity->get_property_value(_XPLATSTR("City"), property_value));
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Primitive, property_value->get_value_type()->get_type_kind());
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value);
-	::utility::string_t city = primitive_value->as<::utility::string_t>();
-	VERIFY_ARE_EQUAL(U("London"), city);
+	::odata::string_t city = primitive_value->as<::odata::string_t>();
+	VERIFY_ARE_EQUAL(_XPLATSTR("London"), city);
 }
 
 TEST_FIXTURE(e2e_raw_client, query_single_entity)
 {
-	auto entities = client.get_data_from_server(U("People(3)/Microsoft.Test.OData.Services.ODataWCFService.Employee")).get();
+	auto entities = client.get_data_from_server(_XPLATSTR("People(3)/Microsoft.Test.OData.Services.ODataWCFService.Employee")).get();
 	VERIFY_ARE_EQUAL(entities.size(), 1);
 
 	std::shared_ptr<odata_entity_value> first_entity = std::dynamic_pointer_cast<odata_entity_value>(entities[0]);
 	std::shared_ptr<odata_value> property_value;
-	VERIFY_IS_TRUE(first_entity->get_property_value(U("DateHired"), property_value));
+	VERIFY_IS_TRUE(first_entity->get_property_value(_XPLATSTR("DateHired"), property_value));
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Primitive, property_value->get_value_type()->get_type_kind());
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value);
-	::utility::string_t date_hired = primitive_value->as<::utility::string_t>();
-	VERIFY_ARE_EQUAL(U("2010-12-13T00:00:00Z"), date_hired);
+	::odata::string_t date_hired = primitive_value->as<::odata::string_t>();
+	VERIFY_ARE_EQUAL(_XPLATSTR("2010-12-13T00:00:00Z"), date_hired);
 }
 
 }
@@ -50,95 +50,95 @@ SUITE(derived_type_tests)
 {
 
 TEST_FIXTURE(e2e_test_case, query_entity_collection)
-{	
+{
 	auto people = service_context->create_people_query()->execute_query().get();
 	VERIFY_ARE_EQUAL(people.size(), 5);
 
 	auto customer = std::dynamic_pointer_cast<Customer>(people[0]);
-	VERIFY_ARE_EQUAL(U("London") ,customer->get_city());	
+	VERIFY_ARE_EQUAL(_XPLATSTR("London") ,customer->get_city());
 }
 
 TEST_FIXTURE(e2e_test_case, create_derived_type_entity)
-{	
-	auto new_customer = std::make_shared<Customer>(service_context);
+{
+	auto new_customer = ::odata::make_shared<Customer>(service_context);
 	new_customer->set_personid(10);
-	new_customer->set_firstname(U("cpp"));
-	new_customer->set_lastname(U("test"));
-	std::vector<::utility::string_t> numbers;
-	numbers.push_back(U("111-111-1112"));
-	numbers.push_back(U("111-222-2222"));
+	new_customer->set_firstname(_XPLATSTR("cpp"));
+	new_customer->set_lastname(_XPLATSTR("test"));
+	std::vector<::odata::string_t> numbers;
+	numbers.push_back(_XPLATSTR("111-111-1112"));
+	numbers.push_back(_XPLATSTR("111-222-2222"));
 	new_customer->set_numbers(numbers);
-	std::vector<::utility::string_t> emails;
-	emails.push_back(U("abc@mail.com"));
+	std::vector<::odata::string_t> emails;
+	emails.push_back(_XPLATSTR("abc@mail.com"));
 	new_customer->set_emails(emails);
 	new_customer->set_birthday(::utility::datetime::utc_now());
-	new_customer->set_city(U("Shanghai"));
+	new_customer->set_city(_XPLATSTR("Shanghai"));
 	::utility::seconds time(123);
 	new_customer->set_timebetweenlasttwoorders(time);
 
-	auto status_code = service_context->add_object(U("People"), new_customer).get();
+	auto status_code = service_context->add_object(_XPLATSTR("People"), new_customer).get();
 	VERIFY_ARE_EQUAL(201, status_code);
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(10)"), new_customer->get_edit_link()); //Service issue: [tiano] should be People(10)/Microsoft.Test.OData.Services.ODataWCFService.Customer
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(10)"), new_customer->get_edit_link()); //Service issue: [tiano] should be People(10)/Microsoft.Test.OData.Services.ODataWCFService.Customer
 
-	auto check_result = service_context->create_query<odata_singleton_query_executor<Customer>, odata_query_builder>(U("People(10)/Microsoft.Test.OData.Services.ODataWCFService.Customer"))->execute_query().get();
-	VERIFY_ARE_EQUAL(U("Shanghai"), check_result->get_city());
+	auto check_result = service_context->create_query<odata_singleton_query_executor<Customer>, odata_query_builder>(_XPLATSTR("People(10)/Microsoft.Test.OData.Services.ODataWCFService.Customer"))->execute_query().get();
+	VERIFY_ARE_EQUAL(_XPLATSTR("Shanghai"), check_result->get_city());
 
-	new_customer->set_city(U("Beijing"));
+	new_customer->set_city(_XPLATSTR("Beijing"));
 	status_code = service_context->update_object(new_customer).get();
 	VERIFY_ARE_EQUAL(204, status_code);
-	check_result = service_context->create_query<odata_singleton_query_executor<Customer>, odata_query_builder>(U("People(10)/Microsoft.Test.OData.Services.ODataWCFService.Customer"))->execute_query().get();
-	VERIFY_ARE_EQUAL(U("Beijing"), check_result->get_city());
+	check_result = service_context->create_query<odata_singleton_query_executor<Customer>, odata_query_builder>(_XPLATSTR("People(10)/Microsoft.Test.OData.Services.ODataWCFService.Customer"))->execute_query().get();
+	VERIFY_ARE_EQUAL(_XPLATSTR("Beijing"), check_result->get_city());
 }
 
 TEST_FIXTURE(e2e_test_case, update_derived_type_entity)
-{	
-	auto people = service_context->create_people_query()->key(U("2"))->execute_query().get();
+{
+	auto people = service_context->create_people_query()->key(_XPLATSTR("2"))->execute_query().get();
 	VERIFY_ARE_EQUAL(people.size(), 1);
 	auto customer = std::dynamic_pointer_cast<Customer>(people[0]);
-	VERIFY_ARE_EQUAL(U("Sydney") ,customer->get_city());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Sydney") ,customer->get_city());
 
-	customer->set_city(U("Beijing"));
+	customer->set_city(_XPLATSTR("Beijing"));
 	::utility::seconds time(600);
 	customer->set_timebetweenlasttwoorders(time);
 	auto status_code = service_context->update_object(customer).get();
 	VERIFY_ARE_EQUAL(204, status_code);
 
-	auto new_people = service_context->create_people_query()->key(U("2"))->execute_query().get();
+	auto new_people = service_context->create_people_query()->key(_XPLATSTR("2"))->execute_query().get();
 	VERIFY_ARE_EQUAL(new_people.size(), 1);
 	auto new_customer = std::dynamic_pointer_cast<Customer>(new_people[0]);
-	VERIFY_ARE_EQUAL(U("Beijing") ,new_customer->get_city());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Beijing") ,new_customer->get_city());
 }
 
 TEST_FIXTURE(e2e_test_case, delete_derived_type_entity)
-{	
-	auto people = service_context->create_people_query()->key(U("2"))->execute_query().get();
+{
+	auto people = service_context->create_people_query()->key(_XPLATSTR("2"))->execute_query().get();
 	VERIFY_ARE_EQUAL(people.size(), 1);
 	auto customer = std::dynamic_pointer_cast<Customer>(people[0]);
-	VERIFY_ARE_EQUAL(U("Sydney") ,customer->get_city());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Sydney") ,customer->get_city());
 
 	auto status_code = service_context->delete_object(customer).get();
 	VERIFY_ARE_EQUAL(204, status_code);
 
-	VERIFY_THROWS(service_context->create_people_query()->key(U("2"))->execute_query().get(), ::odata::communication::service_exception); //TODO-tiano: check error codes
+	VERIFY_THROWS(service_context->create_people_query()->key(_XPLATSTR("2"))->execute_query().get(), ::odata::communication::service_exception); //TODO-tiano: check error codes
 }
 
 TEST_FIXTURE(e2e_test_case, query_derived_type_complex)
 {
-	auto people = service_context->create_people_query()->key(U("1"))->execute_query().get();
+	auto people = service_context->create_people_query()->key(_XPLATSTR("1"))->execute_query().get();
 	VERIFY_ARE_EQUAL(people.size(), 1);
 
 	auto address = people[0]->get_homeaddress();
-	VERIFY_ARE_EQUAL(address->get_city(), U("Tokyo"));
-	VERIFY_ARE_EQUAL(address->get_street(), U("1 Microsoft Way"));
-	VERIFY_ARE_EQUAL(address->get_postalcode(), U("98052"));
+	VERIFY_ARE_EQUAL(address->get_city(), _XPLATSTR("Tokyo"));
+	VERIFY_ARE_EQUAL(address->get_street(), _XPLATSTR("1 Microsoft Way"));
+	VERIFY_ARE_EQUAL(address->get_postalcode(), _XPLATSTR("98052"));
 
 	auto home = (HomeAddress*)(address);
-	VERIFY_ARE_EQUAL(*(home->get_familyname()), U("Cats"));
+	VERIFY_ARE_EQUAL(*(home->get_familyname()), _XPLATSTR("Cats"));
 }
 
 TEST_FIXTURE(e2e_test_case, update_derived_type_complex)
 {
-	auto people = service_context->create_people_query()->key(U("1"))->execute_query().get();
+	auto people = service_context->create_people_query()->key(_XPLATSTR("1"))->execute_query().get();
 	VERIFY_ARE_EQUAL(people.size(), 1);
 	auto customer = std::dynamic_pointer_cast<Customer>(people[0]);
 
@@ -147,61 +147,61 @@ TEST_FIXTURE(e2e_test_case, update_derived_type_complex)
 
 	auto address = customer->get_homeaddress();
 	auto home = (HomeAddress*)(address);
-	home->set_city(U("Shang Hai"));
-	home->set_street(U("Zi Zhu"));
-	home->set_postalcode(U("120012"));
-	home->set_familyname(U("Panda"));
+	home->set_city(_XPLATSTR("Shang Hai"));
+	home->set_street(_XPLATSTR("Zi Zhu"));
+	home->set_postalcode(_XPLATSTR("120012"));
+	home->set_familyname(_XPLATSTR("Panda"));
 	auto status_code = service_context->update_object(customer).get();
 	VERIFY_ARE_EQUAL(204, status_code);
 
-	people = service_context->create_people_query()->key(U("1"))->execute_query().get();
+	people = service_context->create_people_query()->key(_XPLATSTR("1"))->execute_query().get();
 
 	address = people[0]->get_homeaddress();
-	VERIFY_ARE_EQUAL(address->get_city(), U("Shang Hai"));
-	VERIFY_ARE_EQUAL(address->get_street(), U("Zi Zhu"));
-	VERIFY_ARE_EQUAL(address->get_postalcode(), U("120012"));
+	VERIFY_ARE_EQUAL(address->get_city(), _XPLATSTR("Shang Hai"));
+	VERIFY_ARE_EQUAL(address->get_street(), _XPLATSTR("Zi Zhu"));
+	VERIFY_ARE_EQUAL(address->get_postalcode(), _XPLATSTR("120012"));
 
 	home = (HomeAddress*)(address);
-	VERIFY_ARE_EQUAL(*(home->get_familyname()), U("Panda"));
+	VERIFY_ARE_EQUAL(*(home->get_familyname()), _XPLATSTR("Panda"));
 }
 
 TEST_FIXTURE(e2e_test_case, create_derived_type_complex_in_entity)
-{	
-    auto new_customer = std::make_shared<Customer>(service_context);
+{
+    auto new_customer = ::odata::make_shared<Customer>(service_context);
 	new_customer->set_personid(10);
-	new_customer->set_firstname(U("cpp"));
-	new_customer->set_lastname(U("test"));
-	std::vector<::utility::string_t> numbers;
-	numbers.push_back(U("111-111-1112"));
-	numbers.push_back(U("111-222-2222"));
+	new_customer->set_firstname(_XPLATSTR("cpp"));
+	new_customer->set_lastname(_XPLATSTR("test"));
+	std::vector<::odata::string_t> numbers;
+	numbers.push_back(_XPLATSTR("111-111-1112"));
+	numbers.push_back(_XPLATSTR("111-222-2222"));
 	new_customer->set_numbers(numbers);
-	std::vector<::utility::string_t> emails;
-	emails.push_back(U("abc@mail.com"));
+	std::vector<::odata::string_t> emails;
+	emails.push_back(_XPLATSTR("abc@mail.com"));
 	new_customer->set_emails(emails);
 	new_customer->set_birthday(::utility::datetime::utc_now());
-	new_customer->set_city(U("Shanghai"));
+	new_customer->set_city(_XPLATSTR("Shanghai"));
 	::utility::seconds time(123);
 	new_customer->set_timebetweenlasttwoorders(time);
 
-	auto homeaddress = std::make_shared<HomeAddress>(service_context);
-	homeaddress->set_city(U("Shang Hai"));
-	homeaddress->set_street(U("Zi Zhu"));
-	homeaddress->set_postalcode(U("120012"));
-	homeaddress->set_familyname(U("Panda"));
+	auto homeaddress = ::odata::make_shared<HomeAddress>(service_context);
+	homeaddress->set_city(_XPLATSTR("Shang Hai"));
+	homeaddress->set_street(_XPLATSTR("Zi Zhu"));
+	homeaddress->set_postalcode(_XPLATSTR("120012"));
+	homeaddress->set_familyname(_XPLATSTR("Panda"));
 	new_customer->set_homeaddress(homeaddress);
 
-	auto status_code = service_context->add_object(U("People"), new_customer).get();
+	auto status_code = service_context->add_object(_XPLATSTR("People"), new_customer).get();
 	VERIFY_ARE_EQUAL(201, status_code);
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(10)"), new_customer->get_edit_link()); //Service issue: [tiano] should be People(10)/Microsoft.Test.OData.Services.ODataWCFService.Customer
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(10)"), new_customer->get_edit_link()); //Service issue: [tiano] should be People(10)/Microsoft.Test.OData.Services.ODataWCFService.Customer
 
-	auto check_result = service_context->create_query<odata_singleton_query_executor<Customer>, odata_query_builder>(U("People(10)/Microsoft.Test.OData.Services.ODataWCFService.Customer"))->execute_query().get();
-	VERIFY_ARE_EQUAL(U("Shanghai"), check_result->get_city());
+	auto check_result = service_context->create_query<odata_singleton_query_executor<Customer>, odata_query_builder>(_XPLATSTR("People(10)/Microsoft.Test.OData.Services.ODataWCFService.Customer"))->execute_query().get();
+	VERIFY_ARE_EQUAL(_XPLATSTR("Shanghai"), check_result->get_city());
 
-	new_customer->set_city(U("Beijing"));
+	new_customer->set_city(_XPLATSTR("Beijing"));
 	status_code = service_context->update_object(new_customer).get();
 	VERIFY_ARE_EQUAL(204, status_code);
-	check_result = service_context->create_query<odata_singleton_query_executor<Customer>, odata_query_builder>(U("People(10)/Microsoft.Test.OData.Services.ODataWCFService.Customer"))->execute_query().get();
-	VERIFY_ARE_EQUAL(U("Beijing"), check_result->get_city());
+	check_result = service_context->create_query<odata_singleton_query_executor<Customer>, odata_query_builder>(_XPLATSTR("People(10)/Microsoft.Test.OData.Services.ODataWCFService.Customer"))->execute_query().get();
+	VERIFY_ARE_EQUAL(_XPLATSTR("Beijing"), check_result->get_city());
 }
 
 //Derived type in navigation properties?

--- a/tests/e2e/e2e_test_case.h
+++ b/tests/e2e/e2e_test_case.h
@@ -19,9 +19,9 @@ class e2e_raw_client
 public:
 	odata_client client;
 
-    e2e_raw_client() : client(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService")) {
+    e2e_raw_client() : client(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService")) {
 		//Reset data source first.
-		client.send_data_to_server(U("ResetDataSource")).get();
+		client.send_data_to_server(_XPLATSTR("ResetDataSource")).get();
 	}
 };
 
@@ -32,7 +32,7 @@ public:
 	std::shared_ptr<InMemoryEntities> service_context;
 
     e2e_test_case() {
-		service_context = std::make_shared<InMemoryEntities>(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService"));
+		service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService"));
 
 		//Reset data source first.
 		service_context->ResetDataSource().get();

--- a/tests/e2e/edit_link_tests.cpp
+++ b/tests/e2e/edit_link_tests.cpp
@@ -18,21 +18,21 @@ SUITE(edit_link_tests)
 //http://services.odata.org/V4/Northwind/Northwind.svc/Products
 TEST(query_entity_set)
 {
-	//auto norwind_service = std::make_shared<InMemoryEntities>(U("http://services.odata.org/V4/Northwind/Northwind.svc"));
+	//auto norwind_service = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://services.odata.org/V4/Northwind/Northwind.svc"));
 	//auto ret = norwind_service->create_products_query()->top(3)->execute_query().get();
-	
-	//VERIFY_ARE_EQUAL(U("http://services.odata.org/V4/Northwind/Northwind.svc/Products(1)"), ret[0]->get_edit_link());
-	//VERIFY_ARE_EQUAL(U("http://services.odata.org/V4/Northwind/Northwind.svc/Products(2)"), ret[1]->get_edit_link());
-	//VERIFY_ARE_EQUAL(U("http://services.odata.org/V4/Northwind/Northwind.svc/Products(3)"), ret[2]->get_edit_link());
+
+	//VERIFY_ARE_EQUAL(_XPLATSTR("http://services.odata.org/V4/Northwind/Northwind.svc/Products(1)"), ret[0]->get_edit_link());
+	//VERIFY_ARE_EQUAL(_XPLATSTR("http://services.odata.org/V4/Northwind/Northwind.svc/Products(2)"), ret[1]->get_edit_link());
+	//VERIFY_ARE_EQUAL(_XPLATSTR("http://services.odata.org/V4/Northwind/Northwind.svc/Products(3)"), ret[2]->get_edit_link());
 }
 
 //http://services.odata.org/V4/Northwind/Northwind.svc/Products(1)
 TEST(query_entity_set_with_key)
 {
-	//auto norwind_service = std::make_shared<InMemoryEntities>(U("http://services.odata.org/V4/Northwind/Northwind.svc"));
-	//auto ret = norwind_service->create_products_query()->key(U("1"))->execute_query().get();
+	//auto norwind_service = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://services.odata.org/V4/Northwind/Northwind.svc"));
+	//auto ret = norwind_service->create_products_query()->key(_XPLATSTR("1"))->execute_query().get();
 
-	//VERIFY_ARE_EQUAL(U("http://services.odata.org/V4/Northwind/Northwind.svc/Products(1)"), ret[0]->get_edit_link());
+	//VERIFY_ARE_EQUAL(_XPLATSTR("http://services.odata.org/V4/Northwind/Northwind.svc/Products(1)"), ret[0]->get_edit_link());
 }
 
 // todo we should find service that has not @editLink value

--- a/tests/e2e/enum_tests.cpp
+++ b/tests/e2e/enum_tests.cpp
@@ -21,23 +21,23 @@ SUITE(enum_tests_raw_client)
 {
 TEST_FIXTURE(e2e_raw_client, query_enum_in_entity)
 {
-	auto entities = client.get_entities(U("Products")).get();
+	auto entities = client.get_entities(_XPLATSTR("Products")).get();
 	auto firstEntity = entities[0];
 	std::shared_ptr<odata_value> skinColor;
-	firstEntity->get_property_value(U("SkinColor"), skinColor);
+	firstEntity->get_property_value(_XPLATSTR("SkinColor"), skinColor);
 	VERIFY_ARE_EQUAL(skinColor->get_value_type()->get_type_kind(), Enum);
 
 	auto skinColorEnum = std::dynamic_pointer_cast<odata_enum_value>(skinColor);
-	VERIFY_ARE_EQUAL(U("Red"), skinColorEnum->to_string());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Red"), skinColorEnum->to_string());
 }
 
 TEST_FIXTURE(e2e_raw_client, query_enum_property)
 {
-	auto data = client.get_data_from_server(U("Products(5)/SkinColor")).get();
+	auto data = client.get_data_from_server(_XPLATSTR("Products(5)/SkinColor")).get();
 	VERIFY_ARE_EQUAL(data.size(), 1);
 
 	auto skinColor = std::dynamic_pointer_cast<odata_enum_value>(data[0]);
-	VERIFY_ARE_EQUAL(U("Red"), skinColor->to_string());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Red"), skinColor->to_string());
 }
 
 TEST_FIXTURE(e2e_raw_client, update_enum_property)
@@ -45,28 +45,28 @@ TEST_FIXTURE(e2e_raw_client, update_enum_property)
 	auto model = client.get_model().get();
 
 	//check the old value
-	auto old_data = client.get_data_from_server(U("Products(5)")).get();
+	auto old_data = client.get_data_from_server(_XPLATSTR("Products(5)")).get();
 	auto old_entity = std::dynamic_pointer_cast<odata_entity_value>(old_data[0]);
 	std::shared_ptr<odata_value> old_value;
-	old_entity->get_property_value(U("UserAccess"), old_value);
+	old_entity->get_property_value(_XPLATSTR("UserAccess"), old_value);
 	auto old_enum = std::dynamic_pointer_cast<odata_enum_value>(old_value);
-	VERIFY_ARE_EQUAL(U("None"), old_enum->to_string());
+	VERIFY_ARE_EQUAL(_XPLATSTR("None"), old_enum->to_string());
 
 	//update the entity with patch
-	auto access_level_type = model->find_enum_type(U("AccessLevel"));
-	auto new_access = std::make_shared<odata_enum_value>(access_level_type, U("ReadWrite"));
-	old_entity->set_value(U("UserAccess"), std::dynamic_pointer_cast<odata_value>(new_access));
+	auto access_level_type = model->find_enum_type(_XPLATSTR("AccessLevel"));
+	auto new_access = ::odata::make_shared<odata_enum_value>(access_level_type, _XPLATSTR("ReadWrite"));
+	old_entity->set_value(_XPLATSTR("UserAccess"), std::dynamic_pointer_cast<odata_value>(new_access));
 
-	auto response_code = client.patch_entity(U("Products"), old_entity).get();
+	auto response_code = client.patch_entity(_XPLATSTR("Products"), old_entity).get();
 	VERIFY_ARE_EQUAL(204, response_code);
 
 	//check the new value
-	auto new_data = client.get_data_from_server(U("Products(5)")).get();
+	auto new_data = client.get_data_from_server(_XPLATSTR("Products(5)")).get();
 	auto new_entity = std::dynamic_pointer_cast<odata_entity_value>(new_data[0]);
 	std::shared_ptr<odata_value> new_value;
-	new_entity->get_property_value(U("UserAccess"), new_value);
+	new_entity->get_property_value(_XPLATSTR("UserAccess"), new_value);
 	auto new_enum = std::dynamic_pointer_cast<odata_enum_value>(new_value);
-	VERIFY_ARE_EQUAL(U("ReadWrite"), new_enum->to_string());
+	VERIFY_ARE_EQUAL(_XPLATSTR("ReadWrite"), new_enum->to_string());
 }
 
 }
@@ -75,8 +75,8 @@ SUITE(enum_tests)
 {
 
 TEST_FIXTURE(e2e_test_case, query_with_enum)
-{	
-	auto products = service_context->create_products_query()->key(U("5"))->execute_query().get();
+{
+	auto products = service_context->create_products_query()->key(_XPLATSTR("5"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, products.size());
 
 	auto product = products[0];
@@ -85,20 +85,20 @@ TEST_FIXTURE(e2e_test_case, query_with_enum)
 	VERIFY_ARE_EQUAL(3, product->get_covercolors().size());
 	VERIFY_ARE_EQUAL(Blue, product->get_covercolors()[2]);
 
-	auto skin_color = service_context->create_query<odata_enum_query_executor<Color, enum_type_resolver>, odata_query_builder>(U("Products(5)/SkinColor"))->execute_query().get();
+	auto skin_color = service_context->create_query<odata_enum_query_executor<Color, enum_type_resolver>, odata_query_builder>(_XPLATSTR("Products(5)/SkinColor"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, skin_color.size());
 	VERIFY_ARE_EQUAL(Red, skin_color[0]);
-	auto user_access = service_context->create_query<odata_enum_query_executor<AccessLevel, enum_type_resolver>, odata_query_builder>(U("Products(5)/UserAccess"))->execute_query().get();
+	auto user_access = service_context->create_query<odata_enum_query_executor<AccessLevel, enum_type_resolver>, odata_query_builder>(_XPLATSTR("Products(5)/UserAccess"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, user_access.size());
 	VERIFY_ARE_EQUAL(None, user_access[0]);
-	auto cover_colors = service_context->create_query<odata_enum_query_executor<Color, enum_type_resolver>, odata_query_builder>(U("Products(5)/CoverColors"))->execute_query().get();
+	auto cover_colors = service_context->create_query<odata_enum_query_executor<Color, enum_type_resolver>, odata_query_builder>(_XPLATSTR("Products(5)/CoverColors"))->execute_query().get();
 	VERIFY_ARE_EQUAL(3, cover_colors.size());
 	VERIFY_ARE_EQUAL(Blue, cover_colors[2]);
 }
 
 TEST_FIXTURE(e2e_test_case, update_with_enum)
-{	
-	auto products = service_context->create_products_query()->key(U("5"))->execute_query().get();
+{
+	auto products = service_context->create_products_query()->key(_XPLATSTR("5"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, products.size());
 
 	auto product = products[0];
@@ -108,17 +108,17 @@ TEST_FIXTURE(e2e_test_case, update_with_enum)
 	new_cover_colors.push_back(Green);
 	new_cover_colors.push_back(Blue);
 	product->set_covercolors(new_cover_colors);
-	
+
 	auto status_code = service_context->update_object(product).get();
 	VERIFY_ARE_EQUAL(204, status_code);
 
-	auto skin_color = service_context->create_query<odata_enum_query_executor<Color, enum_type_resolver>, odata_query_builder>(U("Products(5)/SkinColor"))->execute_query().get();
+	auto skin_color = service_context->create_query<odata_enum_query_executor<Color, enum_type_resolver>, odata_query_builder>(_XPLATSTR("Products(5)/SkinColor"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, skin_color.size());
 	VERIFY_ARE_EQUAL(Green, skin_color[0]);
-	auto user_access = service_context->create_query<odata_enum_query_executor<AccessLevel, enum_type_resolver>, odata_query_builder>(U("Products(5)/UserAccess"))->execute_query().get();
+	auto user_access = service_context->create_query<odata_enum_query_executor<AccessLevel, enum_type_resolver>, odata_query_builder>(_XPLATSTR("Products(5)/UserAccess"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, user_access.size());
 	VERIFY_ARE_EQUAL(ReadWrite, user_access[0]);
-	auto cover_colors = service_context->create_query<odata_enum_query_executor<Color, enum_type_resolver>, odata_query_builder>(U("Products(5)/CoverColors"))->execute_query().get();
+	auto cover_colors = service_context->create_query<odata_enum_query_executor<Color, enum_type_resolver>, odata_query_builder>(_XPLATSTR("Products(5)/CoverColors"))->execute_query().get();
 	VERIFY_ARE_EQUAL(2, cover_colors.size());
 	VERIFY_ARE_EQUAL(Blue, cover_colors[1]);
 }

--- a/tests/e2e/exchange_service.cpp
+++ b/tests/e2e/exchange_service.cpp
@@ -268,8 +268,8 @@ BEGIN_COMPLEX_DESTRUCTOR(Recipient)
     ON_PROPERTY_IN_COMPLEX_DESTRUCTOR(address)
 END_COMPLEX_DESTRUCTOR(Recipient)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Recipient, name, Name, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Recipient, address, Address, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Recipient, name, Name, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Recipient, address, Address, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Recipient, Microsoft.Exchange.Services.OData.Model, Recipient)
 
@@ -352,7 +352,7 @@ BEGIN_COMPLEX_DESTRUCTOR(ItemBody)
 END_COMPLEX_DESTRUCTOR(ItemBody)
 
 IMPLEMENT_NULLABLE_ENUM_PROPERTY_IN_COMPLEX_MAPPING(ItemBody, contenttype, ContentType, BodyType);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(ItemBody, content, Content, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(ItemBody, content, Content, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(ItemBody, Microsoft.Exchange.Services.OData.Model, ItemBody)
 
@@ -374,7 +374,7 @@ BEGIN_COMPLEX_DESTRUCTOR(Location)
     ON_PROPERTY_IN_COMPLEX_DESTRUCTOR(displayname)
 END_COMPLEX_DESTRUCTOR(Location)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Location, displayname, DisplayName, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Location, displayname, DisplayName, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Location, Microsoft.Exchange.Services.OData.Model, Location)
 
@@ -416,7 +416,7 @@ END_ENTITY_CONSTRUCTOR(Entity, type_base)
 BEGIN_ENTITY_DESTRUCTOR(Entity)
 END_ENTITY_DESTRUCTOR(Entity)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Entity, id, Id, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Entity, id, Id, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Entity, Microsoft.Exchange.Services.OData.Model, Entity)
 
@@ -448,15 +448,15 @@ BEGIN_ENTITY_DESTRUCTOR(Item)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(bodypreview)
 END_ENTITY_DESTRUCTOR(Item)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Item, changekey, ChangeKey, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Item, classname, ClassName, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Item, subject, Subject, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Item, changekey, ChangeKey, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Item, classname, ClassName, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Item, subject, Subject, ::odata::string_t);
 IMPLEMENT_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(Item, importance, Importance, Importance);
 IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Item, body, Body, ItemBody);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Item, hasattachments, HasAttachments, bool);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Item, bodypreview, BodyPreview, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Item, bodypreview, BodyPreview, ::odata::string_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Item, attachments, Attachments, Attachment);
-IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Item, categories, Categories, ::utility::string_t);
+IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Item, categories, Categories, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Item, Microsoft.Exchange.Services.OData.Model, Item)
 
@@ -492,9 +492,9 @@ BEGIN_ENTITY_DESTRUCTOR(Calendar)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(changekey)
 END_ENTITY_DESTRUCTOR(Calendar)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Calendar, name, Name, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Calendar, name, Name, ::odata::string_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Calendar, events, Events, Event);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Calendar, changekey, ChangeKey, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Calendar, changekey, ChangeKey, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Calendar, Microsoft.Exchange.Services.OData.Model, Calendar)
 
@@ -544,33 +544,33 @@ BEGIN_ENTITY_DESTRUCTOR(Message)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(datetimecreated)
 END_ENTITY_DESTRUCTOR(Message)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Message, parentfolderid, ParentFolderId, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Message, parentfolderid, ParentFolderId, ::odata::string_t);
 IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Message, from, From, Recipient);
 IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Message, sender, Sender, Recipient);
 IMPLEMENT_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Message, torecipients, ToRecipients, Recipient);
-IMPLEMENT_ACTION_P1(Message, ReplyAll, odata_void_query_executor, Comment, ::utility::string_t, Comment);
+IMPLEMENT_ACTION_P1(Message, ReplyAll, odata_void_query_executor, Comment, ::odata::string_t, Comment);
 IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Message, uniquebody, UniqueBody, ItemBody);
 IMPLEMENT_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Message, ccrecipients, CcRecipients, Recipient);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Message, conversationid, ConversationId, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Message, conversationid, ConversationId, ::odata::string_t);
 IMPLEMENT_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Message, bccrecipients, BccRecipients, Recipient);
-IMPLEMENT_ACTION_P1(Message, Move, odata_entityset_query_executor<Message>, DestinationId, ::utility::string_t, DestinationId);
+IMPLEMENT_ACTION_P1(Message, Move, odata_entityset_query_executor<Message>, DestinationId, ::odata::string_t, DestinationId);
 IMPLEMENT_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Message, replyto, ReplyTo, Recipient);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Message, datetimereceived, DateTimeReceived, ::utility::datetime);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Message, lastmodifiedtime, LastModifiedTime, ::utility::datetime);
-IMPLEMENT_ACTION_P1(Message, Copy, odata_entityset_query_executor<Message>, DestinationId, ::utility::string_t, DestinationId);
+IMPLEMENT_ACTION_P1(Message, Copy, odata_entityset_query_executor<Message>, DestinationId, ::odata::string_t, DestinationId);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Message, datetimesent, DateTimeSent, ::utility::datetime);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Message, isdeliveryreceiptrequested, IsDeliveryReceiptRequested, bool);
 IMPLEMENT_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(Message, meetingmessagetype, MeetingMessageType, MeetingMessageType);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Message, isreadreceiptrequested, IsReadReceiptRequested, bool);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Message, isdraft, IsDraft, bool);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Message, isread, IsRead, bool);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Message, eventid, EventId, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Message, eventid, EventId, ::odata::string_t);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Message, datetimecreated, DateTimeCreated, ::utility::datetime);
 IMPLEMENT_ACTION_P0(Message, CreateReply, odata_entityset_query_executor<Message>);
 IMPLEMENT_ACTION_P0(Message, CreateForward, odata_entityset_query_executor<Message>);
 IMPLEMENT_ACTION_P0(Message, CreateReplyAll, odata_entityset_query_executor<Message>);
-IMPLEMENT_ACTION_P1(Message, Reply, odata_void_query_executor, Comment, ::utility::string_t, Comment);
-IMPLEMENT_ACTION_P2(Message, Forward, odata_void_query_executor, Comment, ::utility::string_t, Comment, ToRecipients, std::vector<Recipient>, ToRecipients);
+IMPLEMENT_ACTION_P1(Message, Reply, odata_void_query_executor, Comment, ::odata::string_t, Comment);
+IMPLEMENT_ACTION_P2(Message, Forward, odata_void_query_executor, Comment, ::odata::string_t, Comment, ToRecipients, std::vector<Recipient>, ToRecipients);
 IMPLEMENT_ACTION_P0(Message, Send, odata_void_query_executor);
 
 IMPLEMENT_EDM_INFO(Message, Microsoft.Exchange.Services.OData.Model, Message)
@@ -632,8 +632,8 @@ BEGIN_ENTITY_DESTRUCTOR(Attachment)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(lastmodifiedtime)
 END_ENTITY_DESTRUCTOR(Attachment)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Attachment, name, Name, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Attachment, contenttype, ContentType, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Attachment, name, Name, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Attachment, contenttype, ContentType, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Attachment, size, Size, int32_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Attachment, isinline, IsInline, bool);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Attachment, lastmodifiedtime, LastModifiedTime, ::utility::datetime);
@@ -673,11 +673,11 @@ BEGIN_ENTITY_DESTRUCTOR(User)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(mailboxguid)
 END_ENTITY_DESTRUCTOR(User)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(User, displayname, DisplayName, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(User, displayname, DisplayName, ::odata::string_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(User, folders, Folders, Folder);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(User, alias, Alias, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(User, alias, Alias, ::odata::string_t);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(User, drafts, Drafts, Folder);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(User, mailboxguid, MailboxGuid, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(User, mailboxguid, MailboxGuid, ::odata::string_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(User, messages, Messages, Message);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(User, rootfolder, RootFolder, Folder);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(User, inbox, Inbox, Folder);
@@ -734,12 +734,12 @@ BEGIN_ENTITY_DESTRUCTOR(Folder)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(totalcount)
 END_ENTITY_DESTRUCTOR(Folder)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Folder, parentfolderid, ParentFolderId, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Folder, parentfolderid, ParentFolderId, ::odata::string_t);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Folder, childfoldercount, ChildFolderCount, int32_t);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Folder, unreaditemcount, UnreadItemCount, int32_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Folder, childfolders, ChildFolders, Folder);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Folder, displayname, DisplayName, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Folder, classname, ClassName, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Folder, displayname, DisplayName, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Folder, classname, ClassName, ::odata::string_t);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Folder, totalcount, TotalCount, int32_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Folder, messages, Messages, Message);
 
@@ -777,8 +777,8 @@ BEGIN_ENTITY_DESTRUCTOR(FileAttachment)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(contentbytes)
 END_ENTITY_DESTRUCTOR(FileAttachment)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(FileAttachment, contentid, ContentId, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(FileAttachment, contentlocation, ContentLocation, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(FileAttachment, contentid, ContentId, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(FileAttachment, contentlocation, ContentLocation, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(FileAttachment, iscontactphoto, IsContactPhoto, bool);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(FileAttachment, contentbytes, ContentBytes, std::vector<unsigned char>);
 
@@ -826,10 +826,10 @@ BEGIN_ENTITY_DESTRUCTOR(CalendarGroup)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(classid)
 END_ENTITY_DESTRUCTOR(CalendarGroup)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CalendarGroup, name, Name, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CalendarGroup, changekey, ChangeKey, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CalendarGroup, name, Name, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CalendarGroup, changekey, ChangeKey, ::odata::string_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(CalendarGroup, calendars, Calendars, Calendar);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CalendarGroup, classid, ClassId, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CalendarGroup, classid, ClassId, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(CalendarGroup, Microsoft.Exchange.Services.OData.Model, CalendarGroup)
 
@@ -883,13 +883,13 @@ IMPLEMENT_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(Event, showas, ShowAs, FreeBu
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Event, iscancelled, IsCancelled, bool);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Event, isorganizer, IsOrganizer, bool);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Event, responserequested, ResponseRequested, bool);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Event, seriesid, SeriesId, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Event, seriesid, SeriesId, ::odata::string_t);
 IMPLEMENT_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Event, attendees, Attendees, Attendee);
 IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Event, recurrence, Recurrence, PatternedRecurrence);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Event, calendar, Calendar, Calendar);
-IMPLEMENT_ACTION_P1(Event, Accept, odata_void_query_executor, Comment, ::utility::string_t, Comment);
-IMPLEMENT_ACTION_P1(Event, Decline, odata_void_query_executor, Comment, ::utility::string_t, Comment);
-IMPLEMENT_ACTION_P1(Event, TentativelyAccept, odata_void_query_executor, Comment, ::utility::string_t, Comment);
+IMPLEMENT_ACTION_P1(Event, Accept, odata_void_query_executor, Comment, ::odata::string_t, Comment);
+IMPLEMENT_ACTION_P1(Event, Decline, odata_void_query_executor, Comment, ::odata::string_t, Comment);
+IMPLEMENT_ACTION_P1(Event, TentativelyAccept, odata_void_query_executor, Comment, ::odata::string_t, Comment);
 
 IMPLEMENT_EDM_INFO(Event, Microsoft.Exchange.Services.OData.Model, Event)
 
@@ -995,37 +995,37 @@ BEGIN_ENTITY_DESTRUCTOR(Contact)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(lastmodifiedtime)
 END_ENTITY_DESTRUCTOR(Contact)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, parentfolderid, ParentFolderId, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, parentfolderid, ParentFolderId, ::odata::string_t);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, birthday, Birthday, ::utility::datetime);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, fileas, FileAs, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, givenname, GivenName, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, displayname, DisplayName, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, mobilephone1, MobilePhone1, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, initials, Initials, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, homephone1, HomePhone1, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, middlename, MiddleName, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, nickname, NickName, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, surname, Surname, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, emailaddress1, EmailAddress1, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, title, Title, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, imaddress2, ImAddress2, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, generation, Generation, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, profession, Profession, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, emailaddress2, EmailAddress2, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, emailaddress3, EmailAddress3, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, imaddress1, ImAddress1, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, imaddress3, ImAddress3, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, jobtitle, JobTitle, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, companyname, CompanyName, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, businessphone2, BusinessPhone2, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, department, Department, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, officelocation, OfficeLocation, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, businesshomepage, BusinessHomePage, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, assistantname, AssistantName, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, manager, Manager, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, homephone2, HomePhone2, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, businessphone1, BusinessPhone1, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, otherphone, OtherPhone, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, fileas, FileAs, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, givenname, GivenName, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, displayname, DisplayName, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, mobilephone1, MobilePhone1, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, initials, Initials, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, homephone1, HomePhone1, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, middlename, MiddleName, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, nickname, NickName, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, surname, Surname, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, emailaddress1, EmailAddress1, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, title, Title, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, imaddress2, ImAddress2, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, generation, Generation, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, profession, Profession, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, emailaddress2, EmailAddress2, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, emailaddress3, EmailAddress3, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, imaddress1, ImAddress1, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, imaddress3, ImAddress3, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, jobtitle, JobTitle, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, companyname, CompanyName, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, businessphone2, BusinessPhone2, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, department, Department, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, officelocation, OfficeLocation, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, businesshomepage, BusinessHomePage, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, assistantname, AssistantName, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, manager, Manager, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, homephone2, HomePhone2, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, businessphone1, BusinessPhone1, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, otherphone, OtherPhone, ::odata::string_t);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, datetimecreated, DateTimeCreated, ::utility::datetime);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Contact, lastmodifiedtime, LastModifiedTime, ::utility::datetime);
 
@@ -1112,9 +1112,9 @@ BEGIN_ENTITY_DESTRUCTOR(ContactFolder)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(displayname)
 END_ENTITY_DESTRUCTOR(ContactFolder)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ContactFolder, parentfolderid, ParentFolderId, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ContactFolder, parentfolderid, ParentFolderId, ::odata::string_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(ContactFolder, childfolders, ChildFolders, ContactFolder);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ContactFolder, displayname, DisplayName, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ContactFolder, displayname, DisplayName, ::odata::string_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(ContactFolder, contacts, Contacts, Contact);
 
 IMPLEMENT_EDM_INFO(ContactFolder, Microsoft.Exchange.Services.OData.Model, ContactFolder)

--- a/tests/e2e/exchange_service.h
+++ b/tests/e2e/exchange_service.h
@@ -221,8 +221,8 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(name, Name, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(address, Address, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(name, Name, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(address, Address, ::odata::string_t);
 };
 
 class RecurrenceRange : public type_base
@@ -260,7 +260,7 @@ public:
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
     DECLARE_NULLABLE_ENUM_PROPERTY_IN_COMPLEX_MAPPING(contenttype, ContentType, BodyType);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(content, Content, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(content, Content, ::odata::string_t);
 };
 
 class Location : public type_base
@@ -271,7 +271,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(displayname, DisplayName, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(displayname, DisplayName, ::odata::string_t);
 };
 
 class ResponseStatus : public Recipient
@@ -294,7 +294,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(id, Id, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(id, Id, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, Id, id);
 };
@@ -307,15 +307,15 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(changekey, ChangeKey, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(classname, ClassName, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(subject, Subject, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(changekey, ChangeKey, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(classname, ClassName, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(subject, Subject, ::odata::string_t);
     DECLARE_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(importance, Importance, Importance);
     DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(body, Body, ItemBody);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(hasattachments, HasAttachments, bool);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(bodypreview, BodyPreview, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(bodypreview, BodyPreview, ::odata::string_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(attachments, Attachments, Attachment);
-    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(categories, Categories, ::utility::string_t);
+    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(categories, Categories, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_NO_PARAM(Entity);
 };
@@ -328,9 +328,9 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(events, Events, Event);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(changekey, ChangeKey, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(changekey, ChangeKey, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_NO_PARAM(Entity);
 };
@@ -343,33 +343,33 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(parentfolderid, ParentFolderId, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(parentfolderid, ParentFolderId, ::odata::string_t);
     DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(from, From, Recipient);
     DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(sender, Sender, Recipient);
     DECLARE_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(torecipients, ToRecipients, Recipient);
-    DECLARE_ACTION_P1(Message, ReplyAll, odata_void_query_executor, Comment, ::utility::string_t, Comment);
+    DECLARE_ACTION_P1(Message, ReplyAll, odata_void_query_executor, Comment, ::odata::string_t, Comment);
     DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(uniquebody, UniqueBody, ItemBody);
     DECLARE_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(ccrecipients, CcRecipients, Recipient);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(conversationid, ConversationId, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(conversationid, ConversationId, ::odata::string_t);
     DECLARE_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(bccrecipients, BccRecipients, Recipient);
-    DECLARE_ACTION_P1(Message, Move, odata_entityset_query_executor<Message>, DestinationId, ::utility::string_t, DestinationId);
+    DECLARE_ACTION_P1(Message, Move, odata_entityset_query_executor<Message>, DestinationId, ::odata::string_t, DestinationId);
     DECLARE_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(replyto, ReplyTo, Recipient);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(datetimereceived, DateTimeReceived, ::utility::datetime);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(lastmodifiedtime, LastModifiedTime, ::utility::datetime);
-    DECLARE_ACTION_P1(Message, Copy, odata_entityset_query_executor<Message>, DestinationId, ::utility::string_t, DestinationId);
+    DECLARE_ACTION_P1(Message, Copy, odata_entityset_query_executor<Message>, DestinationId, ::odata::string_t, DestinationId);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(datetimesent, DateTimeSent, ::utility::datetime);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(isdeliveryreceiptrequested, IsDeliveryReceiptRequested, bool);
     DECLARE_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(meetingmessagetype, MeetingMessageType, MeetingMessageType);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(isreadreceiptrequested, IsReadReceiptRequested, bool);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(isdraft, IsDraft, bool);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(isread, IsRead, bool);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(eventid, EventId, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(eventid, EventId, ::odata::string_t);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(datetimecreated, DateTimeCreated, ::utility::datetime);
     DECLARE_ACTION_P0(Message, CreateReply, odata_entityset_query_executor<Message>);
     DECLARE_ACTION_P0(Message, CreateForward, odata_entityset_query_executor<Message>);
     DECLARE_ACTION_P0(Message, CreateReplyAll, odata_entityset_query_executor<Message>);
-    DECLARE_ACTION_P1(Message, Reply, odata_void_query_executor, Comment, ::utility::string_t, Comment);
-    DECLARE_ACTION_P2(Message, Forward, odata_void_query_executor, Comment, ::utility::string_t, Comment, ToRecipients, std::vector<Recipient>, ToRecipients);
+    DECLARE_ACTION_P1(Message, Reply, odata_void_query_executor, Comment, ::odata::string_t, Comment);
+    DECLARE_ACTION_P2(Message, Forward, odata_void_query_executor, Comment, ::odata::string_t, Comment, ToRecipients, std::vector<Recipient>, ToRecipients);
     DECLARE_ACTION_P0(Message, Send, odata_void_query_executor);
 
     DECLARE_GET_KEY_PROPERTY_STRING_NO_PARAM(Item);
@@ -383,8 +383,8 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(contenttype, ContentType, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(contenttype, ContentType, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(size, Size, int32_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(isinline, IsInline, bool);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(lastmodifiedtime, LastModifiedTime, ::utility::datetime);
@@ -400,11 +400,11 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(displayname, DisplayName, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(displayname, DisplayName, ::odata::string_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(folders, Folders, Folder);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(alias, Alias, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(alias, Alias, ::odata::string_t);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(drafts, Drafts, Folder);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(mailboxguid, MailboxGuid, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(mailboxguid, MailboxGuid, ::odata::string_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(messages, Messages, Message);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(rootfolder, RootFolder, Folder);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(inbox, Inbox, Folder);
@@ -428,12 +428,12 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(parentfolderid, ParentFolderId, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(parentfolderid, ParentFolderId, ::odata::string_t);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(childfoldercount, ChildFolderCount, int32_t);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(unreaditemcount, UnreadItemCount, int32_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(childfolders, ChildFolders, Folder);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(displayname, DisplayName, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(classname, ClassName, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(displayname, DisplayName, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(classname, ClassName, ::odata::string_t);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(totalcount, TotalCount, int32_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(messages, Messages, Message);
 
@@ -448,8 +448,8 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(contentid, ContentId, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(contentlocation, ContentLocation, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(contentid, ContentId, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(contentlocation, ContentLocation, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(iscontactphoto, IsContactPhoto, bool);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(contentbytes, ContentBytes, std::vector<unsigned char>);
 
@@ -477,10 +477,10 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(changekey, ChangeKey, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(changekey, ChangeKey, ::odata::string_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(calendars, Calendars, Calendar);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(classid, ClassId, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(classid, ClassId, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_NO_PARAM(Entity);
 };
@@ -502,13 +502,13 @@ public:
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(iscancelled, IsCancelled, bool);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(isorganizer, IsOrganizer, bool);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(responserequested, ResponseRequested, bool);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(seriesid, SeriesId, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(seriesid, SeriesId, ::odata::string_t);
     DECLARE_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(attendees, Attendees, Attendee);
     DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(recurrence, Recurrence, PatternedRecurrence);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(calendar, Calendar, Calendar);
-    DECLARE_ACTION_P1(Event, Accept, odata_void_query_executor, Comment, ::utility::string_t, Comment);
-    DECLARE_ACTION_P1(Event, Decline, odata_void_query_executor, Comment, ::utility::string_t, Comment);
-    DECLARE_ACTION_P1(Event, TentativelyAccept, odata_void_query_executor, Comment, ::utility::string_t, Comment);
+    DECLARE_ACTION_P1(Event, Accept, odata_void_query_executor, Comment, ::odata::string_t, Comment);
+    DECLARE_ACTION_P1(Event, Decline, odata_void_query_executor, Comment, ::odata::string_t, Comment);
+    DECLARE_ACTION_P1(Event, TentativelyAccept, odata_void_query_executor, Comment, ::odata::string_t, Comment);
 
     DECLARE_GET_KEY_PROPERTY_STRING_NO_PARAM(Item);
 };
@@ -521,37 +521,37 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(parentfolderid, ParentFolderId, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(parentfolderid, ParentFolderId, ::odata::string_t);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(birthday, Birthday, ::utility::datetime);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(fileas, FileAs, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(givenname, GivenName, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(displayname, DisplayName, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(mobilephone1, MobilePhone1, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(initials, Initials, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(homephone1, HomePhone1, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(middlename, MiddleName, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(nickname, NickName, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(surname, Surname, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(emailaddress1, EmailAddress1, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(title, Title, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(imaddress2, ImAddress2, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(generation, Generation, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(profession, Profession, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(emailaddress2, EmailAddress2, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(emailaddress3, EmailAddress3, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(imaddress1, ImAddress1, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(imaddress3, ImAddress3, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(jobtitle, JobTitle, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(companyname, CompanyName, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(businessphone2, BusinessPhone2, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(department, Department, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(officelocation, OfficeLocation, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(businesshomepage, BusinessHomePage, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(assistantname, AssistantName, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(manager, Manager, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(homephone2, HomePhone2, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(businessphone1, BusinessPhone1, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(otherphone, OtherPhone, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(fileas, FileAs, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(givenname, GivenName, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(displayname, DisplayName, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(mobilephone1, MobilePhone1, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(initials, Initials, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(homephone1, HomePhone1, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(middlename, MiddleName, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(nickname, NickName, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(surname, Surname, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(emailaddress1, EmailAddress1, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(title, Title, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(imaddress2, ImAddress2, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(generation, Generation, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(profession, Profession, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(emailaddress2, EmailAddress2, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(emailaddress3, EmailAddress3, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(imaddress1, ImAddress1, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(imaddress3, ImAddress3, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(jobtitle, JobTitle, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(companyname, CompanyName, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(businessphone2, BusinessPhone2, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(department, Department, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(officelocation, OfficeLocation, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(businesshomepage, BusinessHomePage, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(assistantname, AssistantName, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(manager, Manager, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(homephone2, HomePhone2, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(businessphone1, BusinessPhone1, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(otherphone, OtherPhone, ::odata::string_t);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(datetimecreated, DateTimeCreated, ::utility::datetime);
     DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(lastmodifiedtime, LastModifiedTime, ::utility::datetime);
 
@@ -566,9 +566,9 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(parentfolderid, ParentFolderId, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(parentfolderid, ParentFolderId, ::odata::string_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(childfolders, ChildFolders, ContactFolder);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(displayname, DisplayName, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(displayname, DisplayName, ::odata::string_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(contacts, Contacts, Contact);
 
     DECLARE_GET_KEY_PROPERTY_STRING_NO_PARAM(Entity);
@@ -577,18 +577,18 @@ public:
 class EntityContainer : public odata_service_context
 {
 public:
-    EntityContainer(const ::utility::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)
+    EntityContainer(const ::odata::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)
     {
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<User>, odata_query_builder>> create_users_query()
     {
-        return create_query<odata_entityset_query_executor<User>, odata_query_builder>(U("Users"));
+        return create_query<odata_entityset_query_executor<User>, odata_query_builder>(_XPLATSTR("Users"));
     }
 
     std::shared_ptr<odata_service_query<odata_singleton_query_executor<User>, odata_query_builder>> create_me_query()
     {
-        return create_query<odata_singleton_query_executor<User>, odata_query_builder>(U("Me"));
+        return create_query<odata_singleton_query_executor<User>, odata_query_builder>(_XPLATSTR("Me"));
     }
 
 };

--- a/tests/e2e/exchange_test_case.h
+++ b/tests/e2e/exchange_test_case.h
@@ -19,9 +19,9 @@ class e2e_raw_client
 public:
 	odata_client client;
 
-    e2e_raw_client() : client(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService")) {
+    e2e_raw_client() : client(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService")) {
 		//Reset data source first.
-		client.send_data_to_server(U("ResetDataSource")).get();
+		client.send_data_to_server(_XPLATSTR("ResetDataSource")).get();
 	}
 };
 
@@ -32,10 +32,10 @@ public:
 	std::shared_ptr<InMemoryEntities> service_context;
 
     e2e_test_case() {
-		service_context = std::make_shared<InMemoryEntities>(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService"));
+		service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService"));
 
 		//Reset data source first.
-		service_context->get_client()->send_data_to_server(U("ResetDataSource")).get(); //TODO: [tiano] use API instead of odata_client
+		service_context->get_client()->send_data_to_server(_XPLATSTR("ResetDataSource")).get(); //TODO: [tiano] use API instead of odata_client
 	}
 };
 }}}

--- a/tests/e2e/exchange_tests.cpp
+++ b/tests/e2e/exchange_tests.cpp
@@ -16,8 +16,8 @@ class exchange_test_case
 public:
 	std::shared_ptr<EntityContainer> service_context;
 
-    exchange_test_case() {
-		service_context = std::make_shared<EntityContainer>(U("http://odatae2etest.azurewebsites.net/cpptemp/DefaultService/"));
+	exchange_test_case() {
+		service_context = ::odata::make_shared<EntityContainer>(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptemp/DefaultService/"));
 	}
 };
 

--- a/tests/e2e/function_action_tests.cpp
+++ b/tests/e2e/function_action_tests.cpp
@@ -17,7 +17,7 @@ SUITE(function_action_tests_raw_client)
 
 TEST_FIXTURE(e2e_raw_client, invoke_unbound_function)
 {
-	auto function_ret = client.get_data_from_server(U("Company/Microsoft.Test.OData.Services.ODataWCFService.GetEmployeesCount()")).get();
+	auto function_ret = client.get_data_from_server(_XPLATSTR("Company/Microsoft.Test.OData.Services.ODataWCFService.GetEmployeesCount()")).get();
 	VERIFY_ARE_EQUAL(function_ret.size(), 1);
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Primitive, function_ret[0]->get_value_type()->get_type_kind());
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(function_ret[0]);
@@ -27,7 +27,7 @@ TEST_FIXTURE(e2e_raw_client, invoke_unbound_function)
 
 TEST_FIXTURE(e2e_raw_client, simple_function)
 {
-	::utility::string_t employees_count_path = U("Company/Microsoft.Test.OData.Services.ODataWCFService.GetEmployeesCount");
+	::odata::string_t employees_count_path = _XPLATSTR("Company/Microsoft.Test.OData.Services.ODataWCFService.GetEmployeesCount");
 	std::vector<std::shared_ptr<odata_parameter>> parameters;
 	std::vector<std::shared_ptr<odata_value>> returned_values;
 	client.send_data_to_server(employees_count_path, parameters, returned_values, HTTP_GET).get();
@@ -38,32 +38,32 @@ TEST_FIXTURE(e2e_raw_client, simple_function)
 
 TEST_FIXTURE(e2e_raw_client, function_return_collection_of_complex_value)
 {
-	::utility::string_t product_details_path = U("Products(5)/Microsoft.Test.OData.Services.ODataWCFService.GetProductDetails");
+	::odata::string_t product_details_path = _XPLATSTR("Products(5)/Microsoft.Test.OData.Services.ODataWCFService.GetProductDetails");
 	std::vector<std::shared_ptr<odata_parameter>> parameters;
-	parameters.push_back(std::make_shared<odata_parameter>(U("count"), odata_primitive_value::make_primitive_value(3)));
+	parameters.push_back(::odata::make_shared<odata_parameter>(_XPLATSTR("count"), odata_primitive_value::make_primitive_value(3)));
 	std::vector<std::shared_ptr<odata_value>> returned_values;
 	client.send_data_to_server(product_details_path, parameters, returned_values, HTTP_GET).get();
 
 	VERIFY_ARE_EQUAL(3, returned_values.size());
 	auto detail1 = std::dynamic_pointer_cast<odata_entity_value>(returned_values[0]);
 	int32_t product_id;
-	detail1->try_get(U("ProductID"), product_id);
+	detail1->try_get(_XPLATSTR("ProductID"), product_id);
 	VERIFY_ARE_EQUAL(5, product_id);
 }
 
 TEST_FIXTURE(e2e_raw_client, action_of_primitive_value)
 {
-	::utility::string_t company_revenue_path = U("Company/Revenue");
+	::odata::string_t company_revenue_path = _XPLATSTR("Company/Revenue");
 	auto revenue_odata_value = client.get_data_from_server(company_revenue_path).get()[0];
 	auto revenue_primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(revenue_odata_value);
 	int32_t revenue = revenue_primitive_value->as<int32_t>();
 	VERIFY_ARE_EQUAL(100000, revenue);
 
 	std::vector<std::shared_ptr<odata_parameter>> parameters;
-	parameters.push_back(std::make_shared<odata_parameter>(U("IncreaseValue"), odata_primitive_value::make_primitive_value(100000)));
+	parameters.push_back(::odata::make_shared<odata_parameter>(_XPLATSTR("IncreaseValue"), odata_primitive_value::make_primitive_value(100000)));
 	std::vector<std::shared_ptr<odata_value>> returned_values;
-	client.send_data_to_server(U("Company/Microsoft.Test.OData.Services.ODataWCFService.IncreaseRevenue"), parameters, returned_values).get();
-	
+	client.send_data_to_server(_XPLATSTR("Company/Microsoft.Test.OData.Services.ODataWCFService.IncreaseRevenue"), parameters, returned_values).get();
+
 	VERIFY_ARE_EQUAL(1, returned_values.size());
 	std::shared_ptr<odata_value> returned_value = returned_values[0];
 	revenue_odata_value = client.get_data_from_server(company_revenue_path).get()[0];
@@ -77,63 +77,63 @@ TEST_FIXTURE(e2e_raw_client, action_of_primitive_value)
 
 TEST_FIXTURE(e2e_raw_client, action_of_enum_value)
 {
-	::utility::string_t product_user_access = U("Products(5)/UserAccess");
+	::odata::string_t product_user_access = _XPLATSTR("Products(5)/UserAccess");
 	auto user_access_value = std::dynamic_pointer_cast<odata_enum_value>(client.get_data_from_server(product_user_access).get()[0]);
-	VERIFY_ARE_EQUAL(U("None"), user_access_value->to_string());
+	VERIFY_ARE_EQUAL(_XPLATSTR("None"), user_access_value->to_string());
 
 	auto model = client.get_model().get();
-	auto new_access = std::make_shared<odata_enum_value>(model->find_enum_type(U("AccessLevel")), U("ReadWrite"));
+	auto new_access = ::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("AccessLevel")), _XPLATSTR("ReadWrite"));
 
 	std::vector<std::shared_ptr<odata_parameter>> parameters;
-	parameters.push_back(std::make_shared<odata_parameter>(U("accessRight"), new_access));
+	parameters.push_back(::odata::make_shared<odata_parameter>(_XPLATSTR("accessRight"), new_access));
 	std::vector<std::shared_ptr<odata_value>> returned_values;
-	client.send_data_to_server(U("Products(5)/Microsoft.Test.OData.Services.ODataWCFService.AddAccessRight"), parameters, returned_values).get();
+	client.send_data_to_server(_XPLATSTR("Products(5)/Microsoft.Test.OData.Services.ODataWCFService.AddAccessRight"), parameters, returned_values).get();
 
 	VERIFY_ARE_EQUAL(1, returned_values.size());
 	std::shared_ptr<odata_value> returned_value = returned_values[0];
 
 	user_access_value = std::dynamic_pointer_cast<odata_enum_value>(client.get_data_from_server(product_user_access).get()[0]);
-	VERIFY_ARE_EQUAL(U("ReadWrite"), user_access_value->to_string());
+	VERIFY_ARE_EQUAL(_XPLATSTR("ReadWrite"), user_access_value->to_string());
 
 	auto returned_enum_value = std::dynamic_pointer_cast<odata_enum_value>(returned_value);
-	VERIFY_ARE_EQUAL(U("ReadWrite"), returned_enum_value->to_string());
+	VERIFY_ARE_EQUAL(_XPLATSTR("ReadWrite"), returned_enum_value->to_string());
 }
 
 TEST_FIXTURE(e2e_raw_client, action_of_complex_value)
 {
-	::utility::string_t home_address = U("People(1)/HomeAddress");
+	::odata::string_t home_address = _XPLATSTR("People(1)/HomeAddress");
 	auto home_address_value = std::dynamic_pointer_cast<odata_complex_value>(client.get_data_from_server(home_address).get()[0]);
 	std::shared_ptr<odata_value> property_value;
-	home_address_value->get_property_value(U("City"), property_value);
-	VERIFY_ARE_EQUAL(U("Tokyo"), std::dynamic_pointer_cast<odata_primitive_value>(property_value)->as<::utility::string_t>());
+	home_address_value->get_property_value(_XPLATSTR("City"), property_value);
+	VERIFY_ARE_EQUAL(_XPLATSTR("Tokyo"), std::dynamic_pointer_cast<odata_primitive_value>(property_value)->as<::odata::string_t>());
 
 	auto model = client.get_model().get();
-	auto address_type = model->find_complex_type(U("Address"));
-	auto new_address1 = std::make_shared<odata_complex_value>(address_type);
-	new_address1->set_value(U("City"), U("Shanghai"));
-	new_address1->set_value(U("PostalCode"), U("200000"));
-	new_address1->set_value(U("Street"), U("Zixing Road"));
+	auto address_type = model->find_complex_type(_XPLATSTR("Address"));
+	auto new_address1 = ::odata::make_shared<odata_complex_value>(address_type);
+	new_address1->set_value(_XPLATSTR("City"), _XPLATSTR("Shanghai"));
+	new_address1->set_value(_XPLATSTR("PostalCode"), _XPLATSTR("200000"));
+	new_address1->set_value(_XPLATSTR("Street"), _XPLATSTR("Zixing Road"));
 
-	auto addresses = std::make_shared<odata_collection_value>(std::make_shared<edm_collection_type>(U("AddressCollection"), address_type));
+	auto addresses = ::odata::make_shared<odata_collection_value>(::odata::make_shared<edm_collection_type>(_XPLATSTR("AddressCollection"), address_type));
 	addresses->add_collection_value(new_address1);
 
 	std::vector<std::shared_ptr<odata_parameter>> parameters;
-	parameters.push_back(std::make_shared<odata_parameter>(U("addresses"), addresses));
-	parameters.push_back(std::make_shared<odata_parameter>(U("index"), odata_primitive_value::make_primitive_value(0)));
+	parameters.push_back(::odata::make_shared<odata_parameter>(_XPLATSTR("addresses"), addresses));
+	parameters.push_back(::odata::make_shared<odata_parameter>(_XPLATSTR("index"), odata_primitive_value::make_primitive_value(0)));
 	std::vector<std::shared_ptr<odata_value>> returned_values;
-	client.send_data_to_server(U("People(1)/Microsoft.Test.OData.Services.ODataWCFService.ResetAddress"), parameters, returned_values).get();
+	client.send_data_to_server(_XPLATSTR("People(1)/Microsoft.Test.OData.Services.ODataWCFService.ResetAddress"), parameters, returned_values).get();
 
 	VERIFY_ARE_EQUAL(1, returned_values.size());
 	std::shared_ptr<odata_value> returned_value = returned_values[0];
 
 	home_address_value = std::dynamic_pointer_cast<odata_complex_value>(client.get_data_from_server(home_address).get()[0]);
-	home_address_value->get_property_value(U("City"), property_value);
-	VERIFY_ARE_EQUAL(U("Shanghai"), std::dynamic_pointer_cast<odata_primitive_value>(property_value)->as<::utility::string_t>());
+	home_address_value->get_property_value(_XPLATSTR("City"), property_value);
+	VERIFY_ARE_EQUAL(_XPLATSTR("Shanghai"), std::dynamic_pointer_cast<odata_primitive_value>(property_value)->as<::odata::string_t>());
 
 	auto returned_entity_value = std::dynamic_pointer_cast<odata_entity_value>(returned_value);
-	returned_entity_value->get_property_value(U("HomeAddress"), property_value);
-	std::dynamic_pointer_cast<odata_complex_value>(property_value)->get_property_value(U("City"), property_value);
-	VERIFY_ARE_EQUAL(U("Shanghai"), std::dynamic_pointer_cast<odata_primitive_value>(property_value)->as<::utility::string_t>());
+	returned_entity_value->get_property_value(_XPLATSTR("HomeAddress"), property_value);
+	std::dynamic_pointer_cast<odata_complex_value>(property_value)->get_property_value(_XPLATSTR("City"), property_value);
+	VERIFY_ARE_EQUAL(_XPLATSTR("Shanghai"), std::dynamic_pointer_cast<odata_primitive_value>(property_value)->as<::odata::string_t>());
 }
 
 }
@@ -157,33 +157,33 @@ TEST_FIXTURE(e2e_test_case, function_one_param_return_collection_entity)
 
 	VERIFY_ARE_EQUAL(ret.size(), 5);
 
-	VERIFY_ARE_EQUAL(ret[0]->get_edit_link(), U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/ProductDetails(ProductID=5,ProductDetailID=2)"));
+	VERIFY_ARE_EQUAL(ret[0]->get_edit_link(), _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/ProductDetails(ProductID=5,ProductDetailID=2)"));
 	VERIFY_ARE_EQUAL(ret[0]->get_productid(), 5);
 	VERIFY_ARE_EQUAL(ret[0]->get_productdetailid(), 2);
-	VERIFY_ARE_EQUAL(ret[0]->get_productname(), U("CheeseCake"));
-	VERIFY_ARE_EQUAL(ret[0]->get_description(), U("Cheese-flavored snack"));
+	VERIFY_ARE_EQUAL(ret[0]->get_productname(), _XPLATSTR("CheeseCake"));
+	VERIFY_ARE_EQUAL(ret[0]->get_description(), _XPLATSTR("Cheese-flavored snack"));
 
-	VERIFY_ARE_EQUAL(ret[4]->get_edit_link(), U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/ProductDetails(ProductID=5,ProductDetailID=6)"));
+	VERIFY_ARE_EQUAL(ret[4]->get_edit_link(), _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/ProductDetails(ProductID=5,ProductDetailID=6)"));
 	VERIFY_ARE_EQUAL(ret[4]->get_productid(), 5);
 	VERIFY_ARE_EQUAL(ret[4]->get_productdetailid(), 6);
-	VERIFY_ARE_EQUAL(ret[4]->get_productname(), U("Gatorade"));
-	VERIFY_ARE_EQUAL(ret[4]->get_description(), U("fitness drink!"));
+	VERIFY_ARE_EQUAL(ret[4]->get_productname(), _XPLATSTR("Gatorade"));
+	VERIFY_ARE_EQUAL(ret[4]->get_description(), _XPLATSTR("fitness drink!"));
 
 	auto products_ret = ret[0]->GetRelatedProduct().get();
 
 	VERIFY_ARE_EQUAL(products_ret.size(), 1);
 
-	VERIFY_ARE_EQUAL(products_ret[0]->get_edit_link(), U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Products(5)"));
+	VERIFY_ARE_EQUAL(products_ret[0]->get_edit_link(), _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Products(5)"));
 	VERIFY_ARE_EQUAL(products_ret[0]->get_productid(), 5);
-	VERIFY_ARE_EQUAL(products_ret[0]->get_name(), U("Cheetos"));
-	VERIFY_ARE_EQUAL(products_ret[0]->get_quantityperunit(), U("100g Bag"));
+	VERIFY_ARE_EQUAL(products_ret[0]->get_name(), _XPLATSTR("Cheetos"));
+	VERIFY_ARE_EQUAL(products_ret[0]->get_quantityperunit(), _XPLATSTR("100g Bag"));
 	VERIFY_ARE_EQUAL(products_ret[0]->get_covercolors().size(), 3);
 	VERIFY_ARE_EQUAL(products_ret[0]->get_covercolors()[0], Color::Green);
 }
 
 TEST_FIXTURE(e2e_test_case, function_no_param_return_complex)
 {
-	auto people = service_context->create_people_query()->key(U("1"))->execute_query().get();
+	auto people = service_context->create_people_query()->key(_XPLATSTR("1"))->execute_query().get();
 
 	VERIFY_ARE_EQUAL(people.size(), 1);
 
@@ -191,10 +191,10 @@ TEST_FIXTURE(e2e_test_case, function_no_param_return_complex)
 
 	VERIFY_ARE_EQUAL(home_address_obj.size(), 1);
 
-	VERIFY_ARE_EQUAL(*(home_address_obj[0]->get_familyname()), U("Cats"));
-	VERIFY_ARE_EQUAL(home_address_obj[0]->get_city(), U("Tokyo"));
-	VERIFY_ARE_EQUAL(home_address_obj[0]->get_postalcode(), U("98052"));
-	VERIFY_ARE_EQUAL(home_address_obj[0]->get_street(), U("1 Microsoft Way"));
+	VERIFY_ARE_EQUAL(*(home_address_obj[0]->get_familyname()), _XPLATSTR("Cats"));
+	VERIFY_ARE_EQUAL(home_address_obj[0]->get_city(), _XPLATSTR("Tokyo"));
+	VERIFY_ARE_EQUAL(home_address_obj[0]->get_postalcode(), _XPLATSTR("98052"));
+	VERIFY_ARE_EQUAL(home_address_obj[0]->get_street(), _XPLATSTR("1 Microsoft Way"));
 }
 
 TEST_FIXTURE(e2e_test_case, function_import_no_param_return_collection_entity)
@@ -203,44 +203,44 @@ TEST_FIXTURE(e2e_test_case, function_import_no_param_return_collection_entity)
 
 	VERIFY_ARE_EQUAL(products.size(), 5);
 
-	VERIFY_ARE_EQUAL(products[0]->get_edit_link(), U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Products(5)"));
+	VERIFY_ARE_EQUAL(products[0]->get_edit_link(), _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Products(5)"));
 	VERIFY_ARE_EQUAL(products[0]->get_productid(), 5);
-	VERIFY_ARE_EQUAL(products[0]->get_name(), U("Cheetos"));
-	VERIFY_ARE_EQUAL(products[0]->get_quantityperunit(), U("100g Bag"));
+	VERIFY_ARE_EQUAL(products[0]->get_name(), _XPLATSTR("Cheetos"));
+	VERIFY_ARE_EQUAL(products[0]->get_quantityperunit(), _XPLATSTR("100g Bag"));
 	VERIFY_ARE_EQUAL(products[0]->get_covercolors().size(), 3);
 	VERIFY_ARE_EQUAL(products[0]->get_covercolors()[0], Color::Green);
 }
 
 TEST_FIXTURE(e2e_test_case, action_function_import_two_param_return_collection_primitive)
 {
-	std::vector<::utility::string_t> emails;
-	emails.push_back(U("email_1"));
-	emails.push_back(U("email_2"));
-	emails.push_back(U("email_3"));
+	std::vector<::odata::string_t> emails;
+	emails.push_back(_XPLATSTR("email_1"));
+	emails.push_back(_XPLATSTR("email_2"));
+	emails.push_back(_XPLATSTR("email_3"));
 	auto action_ret = service_context->ResetBossEmail(emails).get();
 
 	VERIFY_ARE_EQUAL(action_ret.size(), 3);
-	VERIFY_ARE_EQUAL(action_ret[0], U("email_1"));
-	VERIFY_ARE_EQUAL(action_ret[1], U("email_2"));
-	VERIFY_ARE_EQUAL(action_ret[2], U("email_3"));
+	VERIFY_ARE_EQUAL(action_ret[0], _XPLATSTR("email_1"));
+	VERIFY_ARE_EQUAL(action_ret[1], _XPLATSTR("email_2"));
+	VERIFY_ARE_EQUAL(action_ret[2], _XPLATSTR("email_3"));
 
 	auto function_ret = service_context->GetBossEmails(0, 5).get();
 
 	VERIFY_ARE_EQUAL(function_ret.size(), 3);
-	VERIFY_ARE_EQUAL(function_ret[0], U("email_1"));
-	VERIFY_ARE_EQUAL(function_ret[1], U("email_2"));
-	VERIFY_ARE_EQUAL(function_ret[2], U("email_3"));
+	VERIFY_ARE_EQUAL(function_ret[0], _XPLATSTR("email_1"));
+	VERIFY_ARE_EQUAL(function_ret[1], _XPLATSTR("email_2"));
+	VERIFY_ARE_EQUAL(function_ret[2], _XPLATSTR("email_3"));
 }
 
 TEST_FIXTURE(e2e_test_case, function_import_one_param_return_entity)
 {
-	auto ret = service_context->GetPerson2(U("Tokyo")).get();
+	auto ret = service_context->GetPerson2(_XPLATSTR("Tokyo")).get();
 
 	VERIFY_ARE_EQUAL(ret.size(), 1);
 
-	VERIFY_ARE_EQUAL(ret[0]->get_edit_link(), U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(1)/Microsoft.Test.OData.Services.ODataWCFService.Customer"));
-	VERIFY_ARE_EQUAL(ret[0]->get_firstname(), U("Bob"));
-	VERIFY_ARE_EQUAL(ret[0]->get_lastname(), U("Cat"));
+	VERIFY_ARE_EQUAL(ret[0]->get_edit_link(), _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(1)/Microsoft.Test.OData.Services.ODataWCFService.Customer"));
+	VERIFY_ARE_EQUAL(ret[0]->get_firstname(), _XPLATSTR("Bob"));
+	VERIFY_ARE_EQUAL(ret[0]->get_lastname(), _XPLATSTR("Cat"));
 }
 
 TEST_FIXTURE(e2e_test_case, action_one_param_return_enum)
@@ -287,17 +287,17 @@ TEST_FIXTURE(e2e_test_case, action_import_return_void)
 TEST_FIXTURE(e2e_test_case, action_import_one_param_return_complex)
 {
 	Address address(service_context);
-	address.set_city(U("Shang Hai"));
-	address.set_postalcode(U("123123"));
-	address.set_street(U("ZiXing Road"));
+	address.set_city(_XPLATSTR("Shang Hai"));
+	address.set_postalcode(_XPLATSTR("123123"));
+	address.set_street(_XPLATSTR("ZiXing Road"));
 
 	auto ret = service_context->ResetBossAddress(address).get();
 
 	VERIFY_ARE_EQUAL(ret.size(), 1);
 
-	VERIFY_ARE_EQUAL(ret[0]->get_city(), U("Shang Hai"));
-	VERIFY_ARE_EQUAL(ret[0]->get_postalcode(), U("123123"));
-	VERIFY_ARE_EQUAL(ret[0]->get_street(), U("ZiXing Road"));
+	VERIFY_ARE_EQUAL(ret[0]->get_city(), _XPLATSTR("Shang Hai"));
+	VERIFY_ARE_EQUAL(ret[0]->get_postalcode(), _XPLATSTR("123123"));
+	VERIFY_ARE_EQUAL(ret[0]->get_street(), _XPLATSTR("ZiXing Road"));
 }
 
 TEST_FIXTURE(e2e_test_case, action_one_param_return_entity)
@@ -305,44 +305,44 @@ TEST_FIXTURE(e2e_test_case, action_one_param_return_entity)
 	std::vector<Address> addresses;
 
 	Address address1(service_context);
-	address1.set_city(U("Shang Hai"));
-	address1.set_postalcode(U("123123"));
-	address1.set_street(U("ZiXing Road"));
+	address1.set_city(_XPLATSTR("Shang Hai"));
+	address1.set_postalcode(_XPLATSTR("123123"));
+	address1.set_street(_XPLATSTR("ZiXing Road"));
 	addresses.push_back(address1);
 
 	Address address2(service_context);
-	address2.set_city(U("Bei Jing"));
-	address2.set_postalcode(U("006767"));
-	address2.set_street(U("TiananMen Road"));
+	address2.set_city(_XPLATSTR("Bei Jing"));
+	address2.set_postalcode(_XPLATSTR("006767"));
+	address2.set_street(_XPLATSTR("TiananMen Road"));
 	addresses.push_back(address2);
 
 	Address address3(service_context);
-	address3.set_city(U("La Sa"));
-	address3.set_postalcode(U("221122"));
-	address3.set_street(U("LaSa Road"));
+	address3.set_city(_XPLATSTR("La Sa"));
+	address3.set_postalcode(_XPLATSTR("221122"));
+	address3.set_street(_XPLATSTR("LaSa Road"));
 	addresses.push_back(address3);
 
-	auto people = service_context->create_people_query()->key(U("1"))->execute_query().get();
+	auto people = service_context->create_people_query()->key(_XPLATSTR("1"))->execute_query().get();
 
 	auto ret = people[0]->ResetAddress(addresses, 2).get();
 
-	people = service_context->create_people_query()->key(U("1"))->execute_query().get();
+	people = service_context->create_people_query()->key(_XPLATSTR("1"))->execute_query().get();
 
 	VERIFY_ARE_EQUAL(people.size(), 1);
 
-	VERIFY_ARE_EQUAL(people[0]->get_homeaddress()->get_city(), U("La Sa"));
-	VERIFY_ARE_EQUAL(people[0]->get_homeaddress()->get_postalcode(), U("221122"));
-	VERIFY_ARE_EQUAL(people[0]->get_homeaddress()->get_street(), U("LaSa Road"));
+	VERIFY_ARE_EQUAL(people[0]->get_homeaddress()->get_city(), _XPLATSTR("La Sa"));
+	VERIFY_ARE_EQUAL(people[0]->get_homeaddress()->get_postalcode(), _XPLATSTR("221122"));
+	VERIFY_ARE_EQUAL(people[0]->get_homeaddress()->get_street(), _XPLATSTR("LaSa Road"));
 }
 
 TEST_FIXTURE(e2e_test_case, action_one_param__datetime_return_entity)
 {
-	auto accounts = service_context->create_accounts_query()->key(U("101"))->execute_query().get();
+	auto accounts = service_context->create_accounts_query()->key(_XPLATSTR("101"))->execute_query().get();
 
-	::utility::datetime dt = ::utility::datetime::from_string(U("2014-05-19T14:05:00Z"), ::utility::datetime::date_format::ISO_8601); 
+	::utility::datetime dt = ::utility::datetime::from_string(_XPLATSTR("2014-05-19T14:05:00Z"), ::utility::datetime::date_format::ISO_8601);
 	auto ret = accounts[0]->RefreshDefaultPI(dt).get();
 
-	VERIFY_ARE_EQUAL(ret[0]->get_createddate().to_string(::utility::datetime::date_format::ISO_8601), U("2014-05-19T14:05:00Z"));
+	VERIFY_ARE_EQUAL(ret[0]->get_createddate().to_string(::utility::datetime::date_format::ISO_8601), _XPLATSTR("2014-05-19T14:05:00Z"));
 }
 
 }

--- a/tests/e2e/navigation_property_tests.cpp
+++ b/tests/e2e/navigation_property_tests.cpp
@@ -14,19 +14,19 @@ using namespace odata_wcf_service;
 
 SUITE(navigation_property_tests_raw_client)
 {
-	
+
 TEST_FIXTURE(e2e_raw_client, query_navigaton_collection)
 {
-	auto entities = client.get_data_from_server(U("Products(5)/Details")).get();
+	auto entities = client.get_data_from_server(_XPLATSTR("Products(5)/Details")).get();
 	VERIFY_ARE_EQUAL(entities.size(), 5);
 
 	std::shared_ptr<odata_entity_value> first_entity = std::dynamic_pointer_cast<odata_entity_value>(entities[1]);
 	std::shared_ptr<odata_value> property_value;
-	VERIFY_IS_TRUE(first_entity->get_property_value(U("@odata.editLink"), property_value));
+	VERIFY_IS_TRUE(first_entity->get_property_value(_XPLATSTR("@odata.editLink"), property_value));
 	VERIFY_ARE_EQUAL(edm_type_kind_t::PayloadAnnotation, property_value->get_value_type()->get_type_kind());
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value);
-	::utility::string_t edit_link = primitive_value->as<::utility::string_t>();
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/ProductDetails(ProductID=5,ProductDetailID=3)"), edit_link);
+	::odata::string_t edit_link = primitive_value->as<::odata::string_t>();
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/ProductDetails(ProductID=5,ProductDetailID=3)"), edit_link);
 }
 
 //other cases: add_link, delete_link, set_link, add_related_object, update_related_object
@@ -39,27 +39,27 @@ SUITE(navigation_property_tests)
 
 TEST_FIXTURE(e2e_test_case, query_navigaton_collection)
 {
-	auto products = service_context->create_products_query()->key(U("5"))->execute_query().get();
+	auto products = service_context->create_products_query()->key(_XPLATSTR("5"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, products.size());
 	auto product = products[0];
 
 	product->load_details().get();
 	VERIFY_ARE_EQUAL(5, product->get_details().size());
 	auto detail = product->get_details()[0];
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/ProductDetails(ProductID=5,ProductDetailID=2)"), detail->get_edit_link());
-	VERIFY_ARE_EQUAL(U("CheeseCake"), detail->get_productname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/ProductDetails(ProductID=5,ProductDetailID=2)"), detail->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("CheeseCake"), detail->get_productname());
 }
 
 TEST_FIXTURE(e2e_test_case, query_navigaton_single)
 {
-	auto people = service_context->create_people_query()->key(U("1"))->execute_query().get();
+	auto people = service_context->create_people_query()->key(_XPLATSTR("1"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, people.size());
 	auto person = people[0];
-	
+
 	person->load_parent().get();
 	auto parent = person->get_parent();
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(2)/Microsoft.Test.OData.Services.ODataWCFService.Customer"), parent->get_edit_link());
-	VERIFY_ARE_EQUAL(U("Jill"), parent->get_firstname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(2)/Microsoft.Test.OData.Services.ODataWCFService.Customer"), parent->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Jill"), parent->get_firstname());
 }
 
 //Add, Update, Delete on navigation properties

--- a/tests/e2e/odata_wcf_service.cpp
+++ b/tests/e2e/odata_wcf_service.cpp
@@ -60,8 +60,8 @@ END_COMPLEX_CONSTRUCTOR(AccountInfo, type_base)
 BEGIN_COMPLEX_DESTRUCTOR(AccountInfo)
 END_COMPLEX_DESTRUCTOR(AccountInfo)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo, firstname, FirstName, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo, lastname, LastName, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo, firstname, FirstName, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo, lastname, LastName, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(AccountInfo, Microsoft.Test.OData.Services.ODataWCFService, AccountInfo)
 
@@ -81,9 +81,9 @@ END_COMPLEX_CONSTRUCTOR(Address, type_base)
 BEGIN_COMPLEX_DESTRUCTOR(Address)
 END_COMPLEX_DESTRUCTOR(Address)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, street, Street, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, city, City, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, postalcode, PostalCode, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, street, Street, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, city, City, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, postalcode, PostalCode, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Address, Microsoft.Test.OData.Services.ODataWCFService, Address)
 
@@ -106,7 +106,7 @@ BEGIN_COMPLEX_DESTRUCTOR(HomeAddress)
     ON_PROPERTY_IN_COMPLEX_DESTRUCTOR(familyname)
 END_COMPLEX_DESTRUCTOR(HomeAddress)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(HomeAddress, familyname, FamilyName, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(HomeAddress, familyname, FamilyName, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(HomeAddress, Microsoft.Test.OData.Services.ODataWCFService, HomeAddress)
 
@@ -123,7 +123,7 @@ END_COMPLEX_CONSTRUCTOR(CompanyAddress, Address)
 BEGIN_COMPLEX_DESTRUCTOR(CompanyAddress)
 END_COMPLEX_DESTRUCTOR(CompanyAddress)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(CompanyAddress, companyname, CompanyName, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(CompanyAddress, companyname, CompanyName, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(CompanyAddress, Microsoft.Test.OData.Services.ODataWCFService, CompanyAddress)
 
@@ -141,7 +141,7 @@ END_COMPLEX_CONSTRUCTOR(CityInformation, type_base)
 BEGIN_COMPLEX_DESTRUCTOR(CityInformation)
 END_COMPLEX_DESTRUCTOR(CityInformation)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(CityInformation, countryregion, CountryRegion, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(CityInformation, countryregion, CountryRegion, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(CityInformation, iscapital, IsCapital, bool);
 
 IMPLEMENT_EDM_INFO(CityInformation, Microsoft.Test.OData.Services.ODataWCFService, CityInformation)
@@ -166,12 +166,12 @@ BEGIN_ENTITY_DESTRUCTOR(Person)
 END_ENTITY_DESTRUCTOR(Person)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, personid, PersonID, int32_t);
-IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, numbers, Numbers, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, firstname, FirstName, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, lastname, LastName, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, middlename, MiddleName, ::utility::string_t);
+IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, numbers, Numbers, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, firstname, FirstName, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, lastname, LastName, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, middlename, MiddleName, ::odata::string_t);
 IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Person, homeaddress, HomeAddress, Address);
-IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, emails, Emails, ::utility::string_t);
+IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, emails, Emails, ::odata::string_t);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Person, parent, Parent, Person);
 IMPLEMENT_ACTION_P2(Person, ResetAddress, odata_entityset_query_executor<Person>, addresses, std::vector<Address>, addresses, index, int32_t, index);
 IMPLEMENT_FUNCTION_P0(Person, GetHomeAddress, odata_complex_query_executor<HomeAddress>);
@@ -208,9 +208,9 @@ BEGIN_ENTITY_DESTRUCTOR(Statement)
 END_ENTITY_DESTRUCTOR(Statement)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Statement, statementid, StatementID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Statement, transactiontype, TransactionType, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Statement, transactiontype, TransactionType, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Statement, amount, Amount, double);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Statement, transactiondescription, TransactionDescription, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Statement, transactiondescription, TransactionDescription, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Statement, Microsoft.Test.OData.Services.ODataWCFService, Statement)
 
@@ -241,8 +241,8 @@ BEGIN_ENTITY_DESTRUCTOR(Product)
 END_ENTITY_DESTRUCTOR(Product)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, productid, ProductID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, name, Name, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, quantityperunit, QuantityPerUnit, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, name, Name, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, quantityperunit, QuantityPerUnit, ::odata::string_t);
 IMPLEMENT_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(Product, skincolor, SkinColor, Color);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, unitprice, UnitPrice, float);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, discontinued, Discontinued, bool);
@@ -289,9 +289,9 @@ BEGIN_ENTITY_DESTRUCTOR(Department)
 END_ENTITY_DESTRUCTOR(Department)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Department, departmentid, DepartmentID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Department, name, Name, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Department, name, Name, ::odata::string_t);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Department, company, Company, Company);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Department, departmentno, DepartmentNO, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Department, departmentno, DepartmentNO, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Department, Microsoft.Test.OData.Services.ODataWCFService, Department)
 
@@ -314,7 +314,7 @@ END_ENTITY_CONSTRUCTOR(Customer, Person)
 BEGIN_ENTITY_DESTRUCTOR(Customer)
 END_ENTITY_DESTRUCTOR(Customer)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Customer, city, City, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Customer, city, City, ::odata::string_t);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Customer, company, Company, Company);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Customer, birthday, Birthday, ::utility::datetime);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Customer, timebetweenlasttwoorders, TimeBetweenLastTwoOrders, ::utility::seconds);
@@ -344,9 +344,9 @@ BEGIN_ENTITY_DESTRUCTOR(ProductDetail)
 END_ENTITY_DESTRUCTOR(ProductDetail)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, productid, ProductID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, description, Description, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, description, Description, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, productdetailid, ProductDetailID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, productname, ProductName, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, productname, ProductName, ::odata::string_t);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, relatedproduct, RelatedProduct, Product);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, reviews, Reviews, ProductReview);
 IMPLEMENT_FUNCTION_P0(ProductDetail, GetRelatedProduct, odata_entityset_query_executor<Product>);
@@ -400,9 +400,9 @@ END_ENTITY_DESTRUCTOR(ProductReview)
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, productid, ProductID, int32_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, revisionid, RevisionID, int32_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, productdetailid, ProductDetailID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, reviewtitle, ReviewTitle, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, comment, Comment, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, author, Author, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, reviewtitle, ReviewTitle, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, comment, Comment, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, author, Author, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(ProductReview, Microsoft.Test.OData.Services.ODataWCFService, ProductReview)
 
@@ -511,7 +511,7 @@ END_ENTITY_DESTRUCTOR(Company)
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Company, companyid, CompanyID, int32_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Company, revenue, Revenue, int64_t);
 IMPLEMENT_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(Company, companycategory, CompanyCategory, CompanyCategory);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Company, name, Name, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Company, name, Name, ::odata::string_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Company, departments, Departments, Department);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Company, coredepartment, CoreDepartment, Department);
 IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Company, address, Address, Address);
@@ -549,7 +549,7 @@ BEGIN_ENTITY_DESTRUCTOR(PublicCompany)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(stockexchange)
 END_ENTITY_DESTRUCTOR(PublicCompany)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PublicCompany, stockexchange, StockExchange, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PublicCompany, stockexchange, StockExchange, ::odata::string_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(PublicCompany, assets, Assets, Asset);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(PublicCompany, club, Club, Club);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(PublicCompany, labourunion, LabourUnion, LabourUnion);
@@ -576,7 +576,7 @@ BEGIN_ENTITY_DESTRUCTOR(Asset)
 END_ENTITY_DESTRUCTOR(Asset)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Asset, assetid, AssetID, int32_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Asset, name, Name, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Asset, name, Name, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Asset, number, Number, int32_t);
 
 IMPLEMENT_EDM_INFO(Asset, Microsoft.Test.OData.Services.ODataWCFService, Asset)
@@ -603,11 +603,11 @@ BEGIN_ENTITY_DESTRUCTOR(GiftCard)
 END_ENTITY_DESTRUCTOR(GiftCard)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, giftcardid, GiftCardID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, giftcardno, GiftCardNO, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, giftcardno, GiftCardNO, ::odata::string_t);
 IMPLEMENT_FUNCTION_P1(GiftCard, GetActualAmount, odata_primitive_query_executor<double>, bonusRate, double, bonusRate);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, amount, Amount, double);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, experationdate, ExperationDate, ::utility::datetime);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, ownername, OwnerName, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, ownername, OwnerName, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(GiftCard, Microsoft.Test.OData.Services.ODataWCFService, GiftCard)
 
@@ -636,7 +636,7 @@ BEGIN_ENTITY_DESTRUCTOR(Club)
 END_ENTITY_DESTRUCTOR(Club)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Club, clubid, ClubID, int32_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Club, name, Name, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Club, name, Name, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Club, Microsoft.Test.OData.Services.ODataWCFService, Club)
 
@@ -659,8 +659,8 @@ BEGIN_ENTITY_DESTRUCTOR(LabourUnion)
 END_ENTITY_DESTRUCTOR(LabourUnion)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(LabourUnion, labourunionid, LabourUnionID, int32_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(LabourUnion, name, Name, ::utility::string_t);
-IMPLEMENT_ACTION_P1(LabourUnion, ChangeLabourUnionName, odata_void_query_executor, name, ::utility::string_t, name);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(LabourUnion, name, Name, ::odata::string_t);
+IMPLEMENT_ACTION_P1(LabourUnion, ChangeLabourUnionName, odata_void_query_executor, name, ::odata::string_t, name);
 
 IMPLEMENT_EDM_INFO(LabourUnion, Microsoft.Test.OData.Services.ODataWCFService, LabourUnion)
 
@@ -686,7 +686,7 @@ IMPLEMENT_FUNCTION_P0(Account, GetDefaultPI, odata_entityset_query_executor<Paym
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Account, accountid, AccountID, int32_t);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Account, mygiftcard, MyGiftCard, GiftCard);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Account, activesubscriptions, ActiveSubscriptions, Subscription);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Account, countryregion, CountryRegion, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Account, countryregion, CountryRegion, ::odata::string_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Account, mypaymentinstruments, MyPaymentInstruments, PaymentInstrument);
 IMPLEMENT_ACTION_P1(Account, RefreshDefaultPI, odata_entityset_query_executor<PaymentInstrument>, newDate, ::utility::datetime, newDate);
 IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Account, accountinfo, AccountInfo, AccountInfo);
@@ -719,7 +719,7 @@ BEGIN_ENTITY_DESTRUCTOR(PaymentInstrument)
 END_ENTITY_DESTRUCTOR(PaymentInstrument)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PaymentInstrument, paymentinstrumentid, PaymentInstrumentID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PaymentInstrument, friendlyname, FriendlyName, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PaymentInstrument, friendlyname, FriendlyName, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PaymentInstrument, createddate, CreatedDate, ::utility::datetime);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(PaymentInstrument, backupstoredpi, BackupStoredPI, StoredPI);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(PaymentInstrument, thestoredpi, TheStoredPI, StoredPI);
@@ -752,7 +752,7 @@ END_ENTITY_DESTRUCTOR(CreditRecord)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditRecord, creditrecordid, CreditRecordID, int32_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditRecord, isgood, IsGood, bool);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditRecord, reason, Reason, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditRecord, reason, Reason, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditRecord, createddate, CreatedDate, ::utility::datetime);
 
 IMPLEMENT_EDM_INFO(CreditRecord, Microsoft.Test.OData.Services.ODataWCFService, CreditRecord)
@@ -778,9 +778,9 @@ END_ENTITY_CONSTRUCTOR(CreditCardPI, PaymentInstrument)
 BEGIN_ENTITY_DESTRUCTOR(CreditCardPI)
 END_ENTITY_DESTRUCTOR(CreditCardPI)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, cardnumber, CardNumber, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, holdername, HolderName, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, cvv, CVV, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, cardnumber, CardNumber, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, holdername, HolderName, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, cvv, CVV, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, experationdate, ExperationDate, ::utility::datetime);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, creditrecords, CreditRecords, CreditRecord);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, balance, Balance, double);
@@ -811,8 +811,8 @@ BEGIN_ENTITY_DESTRUCTOR(StoredPI)
 END_ENTITY_DESTRUCTOR(StoredPI)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(StoredPI, storedpiid, StoredPIID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(StoredPI, piname, PIName, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(StoredPI, pitype, PIType, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(StoredPI, piname, PIName, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(StoredPI, pitype, PIType, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(StoredPI, createddate, CreatedDate, ::utility::datetime);
 
 IMPLEMENT_EDM_INFO(StoredPI, Microsoft.Test.OData.Services.ODataWCFService, StoredPI)
@@ -839,9 +839,9 @@ BEGIN_ENTITY_DESTRUCTOR(Subscription)
 END_ENTITY_DESTRUCTOR(Subscription)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Subscription, subscriptionid, SubscriptionID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Subscription, templateguid, TemplateGuid, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Subscription, title, Title, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Subscription, category, Category, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Subscription, templateguid, TemplateGuid, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Subscription, title, Title, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Subscription, category, Category, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Subscription, createddate, CreatedDate, ::utility::datetime);
 
 IMPLEMENT_EDM_INFO(Subscription, Microsoft.Test.OData.Services.ODataWCFService, Subscription)
@@ -862,9 +862,9 @@ BEGIN_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Subscription)
     ON_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Subscription, createddate)
 END_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Subscription)
 
-IMPLEMENT_FUNCTION_IMPORT_P2(InMemoryEntities, GetBossEmails, odata_primitive_query_executor<::utility::string_t>, start, int32_t, start, count, int32_t, count);
+IMPLEMENT_FUNCTION_IMPORT_P2(InMemoryEntities, GetBossEmails, odata_primitive_query_executor<::odata::string_t>, start, int32_t, start, count, int32_t, count);
 
-IMPLEMENT_ACTION_IMPORT_P1(InMemoryEntities, ResetBossEmail, odata_primitive_query_executor<::utility::string_t>, emails, std::vector<::utility::string_t>, emails);
+IMPLEMENT_ACTION_IMPORT_P1(InMemoryEntities, ResetBossEmail, odata_primitive_query_executor<::odata::string_t>, emails, std::vector<::odata::string_t>, emails);
 
 IMPLEMENT_ACTION_IMPORT_P1(InMemoryEntities, Discount, odata_void_query_executor, percentage, int32_t, percentage);
 
@@ -878,9 +878,9 @@ IMPLEMENT_ACTION_IMPORT_P0(InMemoryEntities, ResetDataSource, odata_void_query_e
 
 IMPLEMENT_FUNCTION_IMPORT_P1(InMemoryEntities, GetPerson, odata_entityset_query_executor<Person>, address, Address, address);
 
-IMPLEMENT_FUNCTION_IMPORT_P1(InMemoryEntities, GetPerson2, odata_entityset_query_executor<Person>, city, ::utility::string_t, city);
+IMPLEMENT_FUNCTION_IMPORT_P1(InMemoryEntities, GetPerson2, odata_entityset_query_executor<Person>, city, ::odata::string_t, city);
 
-IMPLEMENT_FUNCTION_IMPORT_P1(InMemoryEntities, GetProductsByAccessLevel, odata_primitive_query_executor<::utility::string_t>, accessLevel, AccessLevel, accessLevel);
+IMPLEMENT_FUNCTION_IMPORT_P1(InMemoryEntities, GetProductsByAccessLevel, odata_primitive_query_executor<::odata::string_t>, accessLevel, AccessLevel, accessLevel);
 
 DECLARE_DERIVED_COMPLEX_CREATOR_FUNC(HomeAddress, homeaddress)
 DECLARE_DERIVED_COMPLEX_CREATOR_FUNC(CompanyAddress, companyaddress)

--- a/tests/e2e/odata_wcf_service.h
+++ b/tests/e2e/odata_wcf_service.h
@@ -101,8 +101,8 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(firstname, FirstName, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(lastname, LastName, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(firstname, FirstName, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(lastname, LastName, ::odata::string_t);
 };
 
 class Address : public type_base
@@ -113,9 +113,9 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(street, Street, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(city, City, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(postalcode, PostalCode, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(street, Street, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(city, City, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(postalcode, PostalCode, ::odata::string_t);
 };
 
 class HomeAddress : public Address
@@ -126,7 +126,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(familyname, FamilyName, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(familyname, FamilyName, ::odata::string_t);
 };
 
 class CompanyAddress : public Address
@@ -137,7 +137,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(companyname, CompanyName, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(companyname, CompanyName, ::odata::string_t);
 };
 
 class CityInformation : public type_base
@@ -148,7 +148,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(countryregion, CountryRegion, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(countryregion, CountryRegion, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(iscapital, IsCapital, bool);
 };
 
@@ -161,12 +161,12 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(personid, PersonID, int32_t);
-    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(numbers, Numbers, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(firstname, FirstName, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(lastname, LastName, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(middlename, MiddleName, ::utility::string_t);
+    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(numbers, Numbers, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(firstname, FirstName, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(lastname, LastName, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(middlename, MiddleName, ::odata::string_t);
     DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(homeaddress, HomeAddress, Address);
-    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(emails, Emails, ::utility::string_t);
+    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(emails, Emails, ::odata::string_t);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(parent, Parent, Person);
     DECLARE_ACTION_P2(Person, ResetAddress, odata_entityset_query_executor<Person>, addresses, std::vector<Address>, addresses, index, int32_t, index);
     DECLARE_FUNCTION_P0(Person, GetHomeAddress, odata_complex_query_executor<HomeAddress>);
@@ -183,9 +183,9 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(statementid, StatementID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(transactiontype, TransactionType, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(transactiontype, TransactionType, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(amount, Amount, double);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(transactiondescription, TransactionDescription, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(transactiondescription, TransactionDescription, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, StatementID, statementid);
 };
@@ -199,8 +199,8 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productid, ProductID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(quantityperunit, QuantityPerUnit, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(quantityperunit, QuantityPerUnit, ::odata::string_t);
     DECLARE_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(skincolor, SkinColor, Color);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(unitprice, UnitPrice, float);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(discontinued, Discontinued, bool);
@@ -224,9 +224,9 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(departmentid, DepartmentID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(company, Company, Company);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(departmentno, DepartmentNO, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(departmentno, DepartmentNO, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, DepartmentID, departmentid);
 };
@@ -239,7 +239,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(city, City, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(city, City, ::odata::string_t);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(company, Company, Company);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(birthday, Birthday, ::utility::datetime);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(timebetweenlasttwoorders, TimeBetweenLastTwoOrders, ::utility::seconds);
@@ -257,9 +257,9 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productid, ProductID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(description, Description, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(description, Description, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productdetailid, ProductDetailID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productname, ProductName, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productname, ProductName, ::odata::string_t);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(relatedproduct, RelatedProduct, Product);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(reviews, Reviews, ProductReview);
     DECLARE_FUNCTION_P0(ProductDetail, GetRelatedProduct, odata_entityset_query_executor<Product>);
@@ -292,9 +292,9 @@ public:
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productid, ProductID, int32_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(revisionid, RevisionID, int32_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productdetailid, ProductDetailID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(reviewtitle, ReviewTitle, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(comment, Comment, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(author, Author, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(reviewtitle, ReviewTitle, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(comment, Comment, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(author, Author, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_FOUR_PARAM(type_base, ProductID, productid, RevisionID, revisionid, ProductDetailID, productdetailid, ReviewTitle, reviewtitle);
 };
@@ -348,7 +348,7 @@ public:
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(companyid, CompanyID, int32_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(revenue, Revenue, int64_t);
     DECLARE_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(companycategory, CompanyCategory, CompanyCategory);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(departments, Departments, Department);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(coredepartment, CoreDepartment, Department);
     DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(address, Address, Address);
@@ -368,7 +368,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(stockexchange, StockExchange, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(stockexchange, StockExchange, ::odata::string_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(assets, Assets, Asset);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(club, Club, Club);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(labourunion, LabourUnion, LabourUnion);
@@ -385,7 +385,7 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(assetid, AssetID, int32_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(number, Number, int32_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, AssetID, assetid);
@@ -400,11 +400,11 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(giftcardid, GiftCardID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(giftcardno, GiftCardNO, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(giftcardno, GiftCardNO, ::odata::string_t);
     DECLARE_FUNCTION_P1(GiftCard, GetActualAmount, odata_primitive_query_executor<double>, bonusRate, double, bonusRate);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(amount, Amount, double);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(experationdate, ExperationDate, ::utility::datetime);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ownername, OwnerName, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ownername, OwnerName, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, GiftCardID, giftcardid);
 };
@@ -418,7 +418,7 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(clubid, ClubID, int32_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, ClubID, clubid);
 };
@@ -432,8 +432,8 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(labourunionid, LabourUnionID, int32_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
-    DECLARE_ACTION_P1(LabourUnion, ChangeLabourUnionName, odata_void_query_executor, name, ::utility::string_t, name);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
+    DECLARE_ACTION_P1(LabourUnion, ChangeLabourUnionName, odata_void_query_executor, name, ::odata::string_t, name);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, LabourUnionID, labourunionid);
 };
@@ -450,7 +450,7 @@ public:
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(accountid, AccountID, int32_t);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(mygiftcard, MyGiftCard, GiftCard);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(activesubscriptions, ActiveSubscriptions, Subscription);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(countryregion, CountryRegion, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(countryregion, CountryRegion, ::odata::string_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(mypaymentinstruments, MyPaymentInstruments, PaymentInstrument);
     DECLARE_ACTION_P1(Account, RefreshDefaultPI, odata_entityset_query_executor<PaymentInstrument>, newDate, ::utility::datetime, newDate);
     DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(accountinfo, AccountInfo, AccountInfo);
@@ -469,7 +469,7 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(paymentinstrumentid, PaymentInstrumentID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(friendlyname, FriendlyName, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(friendlyname, FriendlyName, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(createddate, CreatedDate, ::utility::datetime);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(backupstoredpi, BackupStoredPI, StoredPI);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(thestoredpi, TheStoredPI, StoredPI);
@@ -488,7 +488,7 @@ public:
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(creditrecordid, CreditRecordID, int32_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(isgood, IsGood, bool);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(reason, Reason, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(reason, Reason, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(createddate, CreatedDate, ::utility::datetime);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, CreditRecordID, creditrecordid);
@@ -502,9 +502,9 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(cardnumber, CardNumber, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(holdername, HolderName, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(cvv, CVV, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(cardnumber, CardNumber, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(holdername, HolderName, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(cvv, CVV, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(experationdate, ExperationDate, ::utility::datetime);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(creditrecords, CreditRecords, CreditRecord);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(balance, Balance, double);
@@ -521,8 +521,8 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(storedpiid, StoredPIID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(piname, PIName, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(pitype, PIType, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(piname, PIName, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(pitype, PIType, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(createddate, CreatedDate, ::utility::datetime);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, StoredPIID, storedpiid);
@@ -537,9 +537,9 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(subscriptionid, SubscriptionID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(templateguid, TemplateGuid, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(title, Title, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(category, Category, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(templateguid, TemplateGuid, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(title, Title, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(category, Category, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(createddate, CreatedDate, ::utility::datetime);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, SubscriptionID, subscriptionid);
@@ -548,106 +548,106 @@ public:
 class InMemoryEntities : public odata_service_context
 {
 public:
-    InMemoryEntities(const ::utility::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)
+    InMemoryEntities(const ::odata::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)
     {
     }
 
-    DECLARE_FUNCTION_IMPORT_P2(InMemoryEntities, GetBossEmails, odata_primitive_query_executor<::utility::string_t>, start, int32_t, start, count, int32_t, count);
+    DECLARE_FUNCTION_IMPORT_P2(InMemoryEntities, GetBossEmails, odata_primitive_query_executor<::odata::string_t>, start, int32_t, start, count, int32_t, count);
 
-    DECLARE_ACTION_IMPORT_P1(InMemoryEntities, ResetBossEmail, odata_primitive_query_executor<::utility::string_t>, emails, std::vector<::utility::string_t>, emails);
+    DECLARE_ACTION_IMPORT_P1(InMemoryEntities, ResetBossEmail, odata_primitive_query_executor<::odata::string_t>, emails, std::vector<::odata::string_t>, emails);
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Person>, odata_query_builder>> create_people_query()
     {
-        return create_query<odata_entityset_query_executor<Person>, odata_query_builder>(U("People"));
+        return create_query<odata_entityset_query_executor<Person>, odata_query_builder>(_XPLATSTR("People"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Customer>, odata_query_builder>> create_customers_query()
     {
-        return create_query<odata_entityset_query_executor<Customer>, odata_query_builder>(U("Customers"));
+        return create_query<odata_entityset_query_executor<Customer>, odata_query_builder>(_XPLATSTR("Customers"));
     }
 
     std::shared_ptr<odata_service_query<odata_singleton_query_executor<Company>, odata_query_builder>> create_company_query()
     {
-        return create_query<odata_singleton_query_executor<Company>, odata_query_builder>(U("Company"));
+        return create_query<odata_singleton_query_executor<Company>, odata_query_builder>(_XPLATSTR("Company"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Department>, odata_query_builder>> create_departments_query()
     {
-        return create_query<odata_entityset_query_executor<Department>, odata_query_builder>(U("Departments"));
+        return create_query<odata_entityset_query_executor<Department>, odata_query_builder>(_XPLATSTR("Departments"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<StoredPI>, odata_query_builder>> create_storedpis_query()
     {
-        return create_query<odata_entityset_query_executor<StoredPI>, odata_query_builder>(U("StoredPIs"));
+        return create_query<odata_entityset_query_executor<StoredPI>, odata_query_builder>(_XPLATSTR("StoredPIs"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Employee>, odata_query_builder>> create_employees_query()
     {
-        return create_query<odata_entityset_query_executor<Employee>, odata_query_builder>(U("Employees"));
+        return create_query<odata_entityset_query_executor<Employee>, odata_query_builder>(_XPLATSTR("Employees"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<ProductDetail>, odata_query_builder>> create_productdetails_query()
     {
-        return create_query<odata_entityset_query_executor<ProductDetail>, odata_query_builder>(U("ProductDetails"));
+        return create_query<odata_entityset_query_executor<ProductDetail>, odata_query_builder>(_XPLATSTR("ProductDetails"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Product>, odata_query_builder>> create_products_query()
     {
-        return create_query<odata_entityset_query_executor<Product>, odata_query_builder>(U("Products"));
+        return create_query<odata_entityset_query_executor<Product>, odata_query_builder>(_XPLATSTR("Products"));
     }
 
     DECLARE_ACTION_IMPORT_P1(InMemoryEntities, Discount, odata_void_query_executor, percentage, int32_t, percentage);
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<ProductReview>, odata_query_builder>> create_productreviews_query()
     {
-        return create_query<odata_entityset_query_executor<ProductReview>, odata_query_builder>(U("ProductReviews"));
+        return create_query<odata_entityset_query_executor<ProductReview>, odata_query_builder>(_XPLATSTR("ProductReviews"));
     }
 
     std::shared_ptr<odata_service_query<odata_singleton_query_executor<Person>, odata_query_builder>> create_boss_query()
     {
-        return create_query<odata_singleton_query_executor<Person>, odata_query_builder>(U("Boss"));
+        return create_query<odata_singleton_query_executor<Person>, odata_query_builder>(_XPLATSTR("Boss"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Order>, odata_query_builder>> create_orders_query()
     {
-        return create_query<odata_entityset_query_executor<Order>, odata_query_builder>(U("Orders"));
+        return create_query<odata_entityset_query_executor<Order>, odata_query_builder>(_XPLATSTR("Orders"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<OrderDetail>, odata_query_builder>> create_orderdetails_query()
     {
-        return create_query<odata_entityset_query_executor<OrderDetail>, odata_query_builder>(U("OrderDetails"));
+        return create_query<odata_entityset_query_executor<OrderDetail>, odata_query_builder>(_XPLATSTR("OrderDetails"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Account>, odata_query_builder>> create_accounts_query()
     {
-        return create_query<odata_entityset_query_executor<Account>, odata_query_builder>(U("Accounts"));
+        return create_query<odata_entityset_query_executor<Account>, odata_query_builder>(_XPLATSTR("Accounts"));
     }
 
     DECLARE_FUNCTION_IMPORT_P0(InMemoryEntities, GetAllProducts, odata_entityset_query_executor<Product>);
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Subscription>, odata_query_builder>> create_subscriptiontemplates_query()
     {
-        return create_query<odata_entityset_query_executor<Subscription>, odata_query_builder>(U("SubscriptionTemplates"));
+        return create_query<odata_entityset_query_executor<Subscription>, odata_query_builder>(_XPLATSTR("SubscriptionTemplates"));
     }
 
     std::shared_ptr<odata_service_query<odata_singleton_query_executor<Customer>, odata_query_builder>> create_vipcustomer_query()
     {
-        return create_query<odata_singleton_query_executor<Customer>, odata_query_builder>(U("VipCustomer"));
+        return create_query<odata_singleton_query_executor<Customer>, odata_query_builder>(_XPLATSTR("VipCustomer"));
     }
 
     std::shared_ptr<odata_service_query<odata_singleton_query_executor<Company>, odata_query_builder>> create_publiccompany_query()
     {
-        return create_query<odata_singleton_query_executor<Company>, odata_query_builder>(U("PublicCompany"));
+        return create_query<odata_singleton_query_executor<Company>, odata_query_builder>(_XPLATSTR("PublicCompany"));
     }
 
     std::shared_ptr<odata_service_query<odata_singleton_query_executor<LabourUnion>, odata_query_builder>> create_labourunion_query()
     {
-        return create_query<odata_singleton_query_executor<LabourUnion>, odata_query_builder>(U("LabourUnion"));
+        return create_query<odata_singleton_query_executor<LabourUnion>, odata_query_builder>(_XPLATSTR("LabourUnion"));
     }
 
     std::shared_ptr<odata_service_query<odata_singleton_query_executor<StoredPI>, odata_query_builder>> create_defaultstoredpi_query()
     {
-        return create_query<odata_singleton_query_executor<StoredPI>, odata_query_builder>(U("DefaultStoredPI"));
+        return create_query<odata_singleton_query_executor<StoredPI>, odata_query_builder>(_XPLATSTR("DefaultStoredPI"));
     }
 
     DECLARE_ACTION_IMPORT_P1(InMemoryEntities, ResetBossAddress, odata_complex_query_executor<Address>, address, Address, address);
@@ -659,9 +659,9 @@ public:
 
     DECLARE_FUNCTION_IMPORT_P1(InMemoryEntities, GetPerson, odata_entityset_query_executor<Person>, address, Address, address);
 
-    DECLARE_FUNCTION_IMPORT_P1(InMemoryEntities, GetPerson2, odata_entityset_query_executor<Person>, city, ::utility::string_t, city);
+    DECLARE_FUNCTION_IMPORT_P1(InMemoryEntities, GetPerson2, odata_entityset_query_executor<Person>, city, ::odata::string_t, city);
 
-    DECLARE_FUNCTION_IMPORT_P1(InMemoryEntities, GetProductsByAccessLevel, odata_primitive_query_executor<::utility::string_t>, accessLevel, AccessLevel, accessLevel);
+    DECLARE_FUNCTION_IMPORT_P1(InMemoryEntities, GetProductsByAccessLevel, odata_primitive_query_executor<::odata::string_t>, accessLevel, AccessLevel, accessLevel);
 
 };
 

--- a/tests/e2e/query_option_tests.cpp
+++ b/tests/e2e/query_option_tests.cpp
@@ -19,14 +19,14 @@ SUITE(query_option_tests_raw_client)
 /***
 TEST_FIXTURE(e2e_raw_client, filter_option)  //TODO-tiano: bug #2163372
 {
-	auto entities = client.get_data_from_server(U("Accounts?$filter=CountryRegion eq 'US'")).get();
+	auto entities = client.get_data_from_server(_XPLATSTR("Accounts?$filter=CountryRegion eq 'US'")).get();
 	VERIFY_ARE_EQUAL(entities.size(), 2);
 }
 ***/
 
 TEST_FIXTURE(e2e_raw_client, expand_option)
 {
-	auto entities = client.get_data_from_server(U("Accounts(101)?$expand=MyGiftCard")).get();
+	auto entities = client.get_data_from_server(_XPLATSTR("Accounts(101)?$expand=MyGiftCard")).get();
 	VERIFY_ARE_EQUAL(entities.size(), 1);
 
 	//verify the expand
@@ -40,63 +40,63 @@ SUITE(query_option_tests)
 
 TEST_FIXTURE(e2e_test_case, filter_option)
 {
-	auto accounts = service_context->create_accounts_query()->filter(U("CountryRegion eq 'US'"))->execute_query().get();
+	auto accounts = service_context->create_accounts_query()->filter(_XPLATSTR("CountryRegion eq 'US'"))->execute_query().get();
 	VERIFY_ARE_EQUAL(2, accounts.size());
-	for (auto iter = accounts.cbegin(); iter != accounts.cend(); iter++)
+	for (auto iter = accounts.cbegin(); iter != accounts.cend(); ++iter)
 	{
-		VERIFY_ARE_EQUAL(U("US"), (*iter)->get_countryregion());
+		VERIFY_ARE_EQUAL(_XPLATSTR("US"), (*iter)->get_countryregion());
 	}
 
 	//filter on derived type property
 	//filter on property of navigation proerty entity
 }
 
-TEST_FIXTURE(e2e_test_case, orderby_option) 
+TEST_FIXTURE(e2e_test_case, orderby_option)
 {
-	auto accounts = service_context->create_accounts_query()->orderby(U("CountryRegion"))->execute_query().get();
+	auto accounts = service_context->create_accounts_query()->orderby(_XPLATSTR("CountryRegion"))->execute_query().get();
 	VERIFY_ARE_EQUAL(7, accounts.size());
-	VERIFY_ARE_EQUAL(U("CN"), accounts[0]->get_countryregion());
-	VERIFY_ARE_EQUAL(U("FR"), accounts[3]->get_countryregion());
-	VERIFY_ARE_EQUAL(U("US"), accounts[5]->get_countryregion());
+	VERIFY_ARE_EQUAL(_XPLATSTR("CN"), accounts[0]->get_countryregion());
+	VERIFY_ARE_EQUAL(_XPLATSTR("FR"), accounts[3]->get_countryregion());
+	VERIFY_ARE_EQUAL(_XPLATSTR("US"), accounts[5]->get_countryregion());
 }
 
-TEST_FIXTURE(e2e_test_case, select_option) 
+TEST_FIXTURE(e2e_test_case, select_option)
 {
-	auto products = service_context->create_products_query()->key(U("5"))->select(U("Name, UserAccess"))->execute_query().get();
+	auto products = service_context->create_products_query()->key(_XPLATSTR("5"))->select(_XPLATSTR("Name, UserAccess"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, products.size());
 	std::shared_ptr<Product> product = products[0];
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Products(5)"), product->get_edit_link());
-	
-	auto products2 = service_context->create_products_query()->key(U("5"))->select(U("*"))->execute_query().get();
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Products(5)"), product->get_edit_link());
+
+	auto products2 = service_context->create_products_query()->key(_XPLATSTR("5"))->select(_XPLATSTR("*"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, products2.size());
 	std::shared_ptr<Product> product2 = products2[0];
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Products(5)"), product2->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Products(5)"), product2->get_edit_link());
 }
 
-TEST_FIXTURE(e2e_test_case, expand_option) 
+TEST_FIXTURE(e2e_test_case, expand_option)
 {
-	auto products = service_context->create_products_query()->key(U("5"))->expand(U("Details"))->execute_query().get();
+	auto products = service_context->create_products_query()->key(_XPLATSTR("5"))->expand(_XPLATSTR("Details"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, products.size());
 	std::shared_ptr<Product> product = products[0];
 
 	auto details = product->get_details();
 	VERIFY_ARE_EQUAL(5, details.size());
 	VERIFY_ARE_EQUAL(2, details[0]->get_productdetailid());
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/ProductDetails(ProductID=5,ProductDetailID=2)"), details[0]->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/ProductDetails(ProductID=5,ProductDetailID=2)"), details[0]->get_edit_link());
 
-	auto people = service_context->create_people_query()->key(U("1"))->expand(U("Parent"))->execute_query().get();
+	auto people = service_context->create_people_query()->key(_XPLATSTR("1"))->expand(_XPLATSTR("Parent"))->execute_query().get();
 	VERIFY_ARE_EQUAL(1, people.size());
 	auto person = people[0];
 
 	auto parent = person->get_parent();
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(2)/Microsoft.Test.OData.Services.ODataWCFService.Customer"), parent->get_edit_link());
-	VERIFY_ARE_EQUAL(U("Jill"), parent->get_firstname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(2)/Microsoft.Test.OData.Services.ODataWCFService.Customer"), parent->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Jill"), parent->get_firstname());
 }
 
-TEST_FIXTURE(e2e_test_case, mixed_query_options) 
+TEST_FIXTURE(e2e_test_case, mixed_query_options)
 {
-	auto accounts = service_context->create_accounts_query()->key(U("103"))
-		->expand(odata_query_path::creat_query_path(U("MyPaymentInstruments"))->select(U("PaymentInstrumentID,FriendlyName"))->orderby(U("FriendlyName")))
+	auto accounts = service_context->create_accounts_query()->key(_XPLATSTR("103"))
+		->expand(odata_query_path::creat_query_path(_XPLATSTR("MyPaymentInstruments"))->select(_XPLATSTR("PaymentInstrumentID,FriendlyName"))->orderby(_XPLATSTR("FriendlyName")))
 		->execute_query().get();
 	VERIFY_ARE_EQUAL(1, accounts.size());
 
@@ -104,9 +104,9 @@ TEST_FIXTURE(e2e_test_case, mixed_query_options)
 	auto pis = account->get_mypaymentinstruments();
 	VERIFY_ARE_EQUAL(4, pis.size());
 	VERIFY_ARE_EQUAL(101910, pis[0]->get_paymentinstrumentid());
-	VERIFY_ARE_EQUAL(U("103 backup PI"), pis[0]->get_friendlyname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("103 backup PI"), pis[0]->get_friendlyname());
 	VERIFY_ARE_EQUAL(103901, pis[1]->get_paymentinstrumentid());
-	VERIFY_ARE_EQUAL(U("103 frist PI"), pis[1]->get_friendlyname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("103 frist PI"), pis[1]->get_friendlyname());
 }
 
 }

--- a/tests/e2e/reference_tests.cpp
+++ b/tests/e2e/reference_tests.cpp
@@ -16,12 +16,12 @@ SUITE(reference_tests_raw_client)
 
 TEST_FIXTURE(e2e_raw_client, add_reference)
 {
-	::utility::string_t orders_of_customer1 = U("Customers(1)/Orders");
+	::odata::string_t orders_of_customer1 = _XPLATSTR("Customers(1)/Orders");
 	auto orders = client.get_data_from_server(orders_of_customer1).get();
 	VERIFY_ARE_EQUAL(1, orders.size());
 
-	auto orderEntity = std::dynamic_pointer_cast<odata_entity_value>(client.get_data_from_server(U("Orders(7)")).get()[0]);
-	
+	auto orderEntity = std::dynamic_pointer_cast<odata_entity_value>(client.get_data_from_server(_XPLATSTR("Orders(7)")).get()[0]);
+
 	string_t orderId;
 	orderEntity->try_get(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_ID, orderId);
 	client.add_reference(orders_of_customer1, orderId).get();
@@ -32,7 +32,7 @@ TEST_FIXTURE(e2e_raw_client, add_reference)
 
 TEST_FIXTURE(e2e_raw_client, delete_reference_in_collection_valued_navigation_property)
 {
-	::utility::string_t orders_of_customer1 = U("Customers(1)/Orders");
+	::odata::string_t orders_of_customer1 = _XPLATSTR("Customers(1)/Orders");
 	auto orders = client.get_data_from_server(orders_of_customer1).get();
 	VERIFY_ARE_EQUAL(1, orders.size());
 
@@ -48,11 +48,11 @@ TEST_FIXTURE(e2e_raw_client, delete_reference_in_collection_valued_navigation_pr
 // The test service seems do not support this, defect 2260922
 //TEST_FIXTURE(e2e_raw_client, delete_reference_in_single_valued_navigation_property)
 //{
-//	::utility::string_t product_of_product_detail = U("ProductDetails(ProductID=6,ProductDetailID=1)/RelatedProduct");
+//	::odata::string_t product_of_product_detail = _XPLATSTR("ProductDetails(ProductID=6,ProductDetailID=1)/RelatedProduct");
 //	auto product = client.get_data_from_server(product_of_product_detail).get();
 //	VERIFY_ARE_EQUAL(1, product.size());
 //
-//	client.remove_reference(product_of_product_detail, U("")).get();
+//	client.remove_reference(product_of_product_detail, _XPLATSTR("")).get();
 //
 //	product = client.get_data_from_server(product_of_product_detail).get();
 //	VERIFY_ARE_EQUAL(0, product.size());
@@ -61,16 +61,16 @@ TEST_FIXTURE(e2e_raw_client, delete_reference_in_collection_valued_navigation_pr
 
 TEST_FIXTURE(e2e_raw_client, update_reference)
 {
-	::utility::string_t parent = U("People(1)/Parent");
-	::utility::string_t person_id_property = U("PersonID");
+	::odata::string_t parent = _XPLATSTR("People(1)/Parent");
+	::odata::string_t person_id_property = _XPLATSTR("PersonID");
 
 	auto parentEntity = std::dynamic_pointer_cast<odata_entity_value>(client.get_data_from_server(parent).get()[0]);
 	int32_t person_id;
 	parentEntity->try_get(person_id_property, person_id);
 	VERIFY_ARE_EQUAL(2, person_id);
 
-	auto newParentEntity = std::dynamic_pointer_cast<odata_entity_value>(client.get_data_from_server(U("People(3)")).get()[0]);
-	::utility::string_t newParentId;
+	auto newParentEntity = std::dynamic_pointer_cast<odata_entity_value>(client.get_data_from_server(_XPLATSTR("People(3)")).get()[0]);
+	::odata::string_t newParentId;
 	newParentEntity->try_get(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_ID, newParentId);
 
 	client.update_reference(parent, newParentId).get();
@@ -85,25 +85,25 @@ TEST_FIXTURE(e2e_raw_client, update_reference)
 SUITE(reference_tests)
 {
 
-TEST_FIXTURE(e2e_test_case, add_reference)  
-{	
-	auto customer = service_context->create_customers_query()->key(U("1"))->expand(U("Orders"))->execute_query().get()[0];
+TEST_FIXTURE(e2e_test_case, add_reference)
+{
+	auto customer = service_context->create_customers_query()->key(_XPLATSTR("1"))->expand(_XPLATSTR("Orders"))->execute_query().get()[0];
 	VERIFY_ARE_EQUAL(1, customer->get_orders().size());
-	
-	auto order = service_context->create_orders_query()->key(U("7"))->execute_query().get()[0];
-	service_context->add_reference(customer, U("Orders"), order).get();
-	
+
+	auto order = service_context->create_orders_query()->key(_XPLATSTR("7"))->execute_query().get()[0];
+	service_context->add_reference(customer, _XPLATSTR("Orders"), order).get();
+
 	customer->load_orders().get();
 	VERIFY_ARE_EQUAL(2, customer->get_orders().size());
 }
 
 TEST_FIXTURE(e2e_test_case, update_reference)
 {
-	auto people = service_context->create_people_query()->key(U("1"))->expand(U("Parent"))->execute_query().get()[0];
+	auto people = service_context->create_people_query()->key(_XPLATSTR("1"))->expand(_XPLATSTR("Parent"))->execute_query().get()[0];
 	VERIFY_ARE_EQUAL(2, people->get_parent()->get_personid());
-	
-	auto parent = service_context->create_people_query()->key(U("3"))->execute_query().get()[0];
-	service_context->update_reference(people, U("Parent"), parent);
+
+	auto parent = service_context->create_people_query()->key(_XPLATSTR("3"))->execute_query().get()[0];
+	service_context->update_reference(people, _XPLATSTR("Parent"), parent);
 
 	people->load_parent().get();
 	VERIFY_ARE_EQUAL(3, people->get_parent()->get_personid());

--- a/tests/e2e/singleton_tests.cpp
+++ b/tests/e2e/singleton_tests.cpp
@@ -16,7 +16,7 @@ SUITE(singleton_tests_raw_client)
 
 TEST_FIXTURE(e2e_raw_client, query_singleton)
 {
-	auto query_result = client.get_data_from_server(U("Company")).get();
+	auto query_result = client.get_data_from_server(_XPLATSTR("Company")).get();
 	VERIFY_ARE_EQUAL(query_result.size(), 1);
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Entity, query_result[0]->get_value_type()->get_type_kind());
 }
@@ -30,16 +30,16 @@ TEST_FIXTURE(e2e_test_case, query_update_singleton)
 {
 	auto vip = service_context->create_vipcustomer_query()->execute_query().get();
 	VERIFY_ARE_EQUAL(1, vip->get_personid());
-	VERIFY_ARE_EQUAL(U("London"), vip->get_city());
+	VERIFY_ARE_EQUAL(_XPLATSTR("London"), vip->get_city());
 
-	vip->set_city(U("Shanghai"));
+	vip->set_city(_XPLATSTR("Shanghai"));
 	::utility::seconds time(123);
 	vip->set_timebetweenlasttwoorders(time);
 	auto status_code = service_context->update_object(vip).get();
 	VERIFY_ARE_EQUAL(204, status_code);
 
 	auto new_vip = service_context->create_vipcustomer_query()->execute_query().get();
-	VERIFY_ARE_EQUAL(U("Shanghai"), new_vip->get_city());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Shanghai"), new_vip->get_city());
 }
 
 
@@ -48,9 +48,9 @@ TEST_FIXTURE(e2e_test_case, derived_type_singleton)
 	auto boss = service_context->create_boss_query()->execute_query().get();
 	auto boss_customer = std::dynamic_pointer_cast<Customer>(boss);
 	VERIFY_ARE_EQUAL(2, boss_customer->get_personid());
-	VERIFY_ARE_EQUAL(U("Sydney"), boss_customer->get_city());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Sydney"), boss_customer->get_city());
 
-	boss_customer->set_city(U("Shanghai"));
+	boss_customer->set_city(_XPLATSTR("Shanghai"));
 	::utility::seconds time(123);
 	boss_customer->set_timebetweenlasttwoorders(time);
 	auto status_code = service_context->update_object(boss_customer).get();
@@ -58,7 +58,7 @@ TEST_FIXTURE(e2e_test_case, derived_type_singleton)
 
 	auto check_result = service_context->create_boss_query()->execute_query().get();
 	auto new_boss = std::dynamic_pointer_cast<Customer>(check_result);
-	VERIFY_ARE_EQUAL(U("Shanghai"), new_boss->get_city());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Shanghai"), new_boss->get_city());
 }
 
 TEST_FIXTURE(e2e_test_case, singleton_with_navigation_properties)
@@ -68,29 +68,29 @@ TEST_FIXTURE(e2e_test_case, singleton_with_navigation_properties)
 
 	auto employees = company->get_employees();
 	VERIFY_ARE_EQUAL(2, employees.size());
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Employees(PersonID=3)"), employees[0]->get_edit_link());
-	VERIFY_ARE_EQUAL(U("Jacob"), employees[0]->get_firstname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Employees(PersonID=3)"), employees[0]->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Jacob"), employees[0]->get_firstname());
 
 	company->load_vipcustomer().get();
 	auto vip = company->get_vipcustomer();
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/VipCustomer"), vip->get_edit_link());
-	VERIFY_ARE_EQUAL(U("Bob"), vip->get_firstname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/VipCustomer"), vip->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Bob"), vip->get_firstname());
 }
 
 TEST_FIXTURE(e2e_test_case, singleton_with_query_options)
 {
 	auto company = service_context->create_company_query()
-		->expand(odata_query_path::creat_query_path(U("Employees"))->filter(U("PersonID eq 3")))->expand(U("VipCustomer"))
+		->expand(odata_query_path::creat_query_path(_XPLATSTR("Employees"))->filter(_XPLATSTR("PersonID eq 3")))->expand(_XPLATSTR("VipCustomer"))
 		->execute_query().get();
 
 	auto employees = company->get_employees();
 	VERIFY_ARE_EQUAL(1, employees.size());
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Employees(PersonID=3)"), employees[0]->get_edit_link());
-	VERIFY_ARE_EQUAL(U("Jacob"), employees[0]->get_firstname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Employees(PersonID=3)"), employees[0]->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Jacob"), employees[0]->get_firstname());
 
 	auto vip = company->get_vipcustomer();
-	VERIFY_ARE_EQUAL(U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/VipCustomer"), vip->get_edit_link());
-	VERIFY_ARE_EQUAL(U("Bob"), vip->get_firstname());
+	VERIFY_ARE_EQUAL(_XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/VipCustomer"), vip->get_edit_link());
+	VERIFY_ARE_EQUAL(_XPLATSTR("Bob"), vip->get_firstname());
 }
 
 }

--- a/tests/framework/TestRunner/test_module_loader.cpp
+++ b/tests/framework/TestRunner/test_module_loader.cpp
@@ -32,9 +32,9 @@ protected:
     virtual unsigned long load_impl()
     {
         // Make sure ends in .dll
-        if(*(m_dllName.end() - 1) != 'l' 
-            || *(m_dllName.end() - 2) != 'l' 
-            || *(m_dllName.end() - 3) != 'd' 
+        if(*(m_dllName.end() - 1) != 'l'
+            || *(m_dllName.end() - 2) != 'l'
+            || *(m_dllName.end() - 3) != 'd'
             || *(m_dllName.end() - 4) != '.')
         {
             return (unsigned long)-1;

--- a/tests/framework/TestRunner/test_runner.cpp
+++ b/tests/framework/TestRunner/test_runner.cpp
@@ -74,8 +74,8 @@ static std::vector<std::string> get_files_in_directory()
 
 #ifdef WIN32
 
-    char exe_directory_buffer[MAX_PATH]; 
-    GetModuleFileNameA(NULL, exe_directory_buffer, MAX_PATH); 
+    char exe_directory_buffer[MAX_PATH];
+    GetModuleFileNameA(NULL, exe_directory_buffer, MAX_PATH);
     std::string exe_directory = to_lower(exe_directory_buffer);
     auto location = exe_directory.rfind("testrunner");
     exe_directory.erase(location);
@@ -97,7 +97,7 @@ static std::vector<std::string> get_files_in_directory()
 
 #elif !defined(__APPLE__)
     using namespace boost::filesystem;
-    
+
     auto exe_directory = initial_path().string();
     for (auto it = directory_iterator(path(exe_directory)); it != directory_iterator(); ++it)
     {
@@ -108,10 +108,10 @@ static std::vector<std::string> get_files_in_directory()
     }
 #else
     auto exe_directory = getcwd(nullptr, 0);
-    
+
     DIR *dir = opendir(exe_directory);
     free(exe_directory);
-    
+
     if (dir != nullptr)
     {
         struct dirent *ent = readdir(dir);
@@ -147,7 +147,7 @@ static std::string replace_wildcard_for_regex(const std::string &str)
 static std::vector<std::string> get_matching_binaries(const std::string &dllName)
 {
     std::vector<std::string> matchingFiles;
-    
+
     // If starts with .\ remove it.
     std::string expandedDllName(dllName);
     if(expandedDllName.size() > 2 && expandedDllName[0] == '.' && expandedDllName[1] == '\\')
@@ -169,7 +169,7 @@ static std::vector<std::string> get_matching_binaries(const std::string &dllName
     expandedDllName = replace_wildcard_for_regex(expandedDllName);
 
     std::vector<std::string> allFiles = get_files_in_directory();
-    
+
     // Filter out any files that don't match.
     std::regex dllRegex(expandedDllName, std::regex_constants::icase);
 
@@ -383,7 +383,7 @@ if(pTest->m_properties.Has("Ignore:Linux")) return true;
 int CrtReportHandler(int reportType, char *message, int *returnValue)
 {
     std::cerr << "In CRT Report Handler. ReportType:" << reportType << ", message:" << message << std::endl;
-    
+
     // Cause break into debugger.
     *returnValue = 1;
     return TRUE;
@@ -438,7 +438,7 @@ int main(int argc, char* argv[])
     int totalTestCount = 0, failedTestCount = 0;
     std::vector<std::string> failedTests;
     UnitTest::TestReporterStdout testReporter;
-    
+
     bool breakOnError = false;
     if(UnitTest::GlobalSettings::Has("breakonerror"))
     {
@@ -462,7 +462,7 @@ int main(int argc, char* argv[])
     timer.Start();
 
     // Cycle through all the test binaries, load them, and perform the specified action.
-    
+
     for(auto iter = g_test_binaries.begin(); iter != g_test_binaries.end(); ++iter)
     {
         std::vector<std::string> matchingBinaries = get_matching_binaries(*iter);
@@ -527,7 +527,7 @@ int main(int argc, char* argv[])
                     else
                     {
                         testRunner.RunTestsIf(
-                            tests, 
+                            tests,
                             [&](UnitTest::Test *pTest) -> bool
                         {
                             // Combine suite and test name
@@ -538,7 +538,7 @@ int main(int argc, char* argv[])
                             if(IsTestIgnored(pTest) && !include_ignored_tests)
                                 return false;
                             else
-                                return matched_properties(pTest->m_properties) && 
+                                return matched_properties(pTest->m_properties) &&
                                 std::regex_match(fullTestName, nameRegex);
                         },
                             g_individual_test_timeout);
@@ -635,6 +635,6 @@ int main(int argc, char* argv[])
         FreeLibrary(hComBase);
     }
 #endif
-	
+
     return failedTestCount;
 }

--- a/tests/framework/UnitTestpp/src/DeferredTestReporter.h
+++ b/tests/framework/UnitTestpp/src/DeferredTestReporter.h
@@ -1,10 +1,10 @@
 /***
 * This file is based on or incorporates material from the UnitTest++ r30 open source project.
-* Microsoft is not the original author of this code but has modified it and is licensing the code under 
-* the MIT License. Microsoft reserves all other rights not expressly granted under the MIT License, 
-* whether by implication, estoppel or otherwise. 
+* Microsoft is not the original author of this code but has modified it and is licensing the code under
+* the MIT License. Microsoft reserves all other rights not expressly granted under the MIT License,
+* whether by implication, estoppel or otherwise.
 *
-* UnitTest++ r30 
+* UnitTest++ r30
 *
 * Copyright (c) 2006 Noel Llopis and Charles Nicholson
 * Portions Copyright (c) Microsoft Corporation
@@ -13,19 +13,19 @@
 *
 * MIT License
 *
-* Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
-* and associated documentation files (the "Software"), to deal in the Software without restriction, 
-* including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-* and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+* Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+* and associated documentation files (the "Software"), to deal in the Software without restriction,
+* including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
 * subject to the following conditions:
 *
-* The above copyright notice and this permission notice shall be included in all copies or 
+* The above copyright notice and this permission notice shall be included in all copies or
 * substantial portions of the Software.
 *
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
-* INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE 
-* AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-* DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+* INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+* AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+* DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ***/
 
@@ -51,7 +51,7 @@ public:
     UNITTEST_LINKAGE virtual void ReportFailure(TestDetails const& details, char const* failure);
     UNITTEST_LINKAGE virtual void ReportTestFinish(TestDetails const& details, bool passed, float secondsElapsed);
 
-    typedef std::vector< DeferredTestResult > DeferredTestResultList;
+    typedef std::vector<DeferredTestResult> DeferredTestResultList;
     UNITTEST_LINKAGE DeferredTestResultList& GetResults();
 
 private:

--- a/tests/framework/UnitTestpp/src/DeferredTestResult.h
+++ b/tests/framework/UnitTestpp/src/DeferredTestResult.h
@@ -1,10 +1,10 @@
 /***
 * This file is based on or incorporates material from the UnitTest++ r30 open source project.
-* Microsoft is not the original author of this code but has modified it and is licensing the code under 
-* the MIT License. Microsoft reserves all other rights not expressly granted under the MIT License, 
-* whether by implication, estoppel or otherwise. 
+* Microsoft is not the original author of this code but has modified it and is licensing the code under
+* the MIT License. Microsoft reserves all other rights not expressly granted under the MIT License,
+* whether by implication, estoppel or otherwise.
 *
-* UnitTest++ r30 
+* UnitTest++ r30
 *
 * Copyright (c) 2006 Noel Llopis and Charles Nicholson
 * Portions Copyright (c) Microsoft Corporation
@@ -13,19 +13,19 @@
 *
 * MIT License
 *
-* Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
-* and associated documentation files (the "Software"), to deal in the Software without restriction, 
-* including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-* and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+* Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+* and associated documentation files (the "Software"), to deal in the Software without restriction,
+* including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
 * subject to the following conditions:
 *
-* The above copyright notice and this permission notice shall be included in all copies or 
+* The above copyright notice and this permission notice shall be included in all copies or
 * substantial portions of the Software.
 *
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
-* INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE 
-* AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-* DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+* INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+* AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+* DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ***/
 
@@ -63,14 +63,14 @@ public:
 	UNITTEST_LINKAGE DeferredTestResult();
     UNITTEST_LINKAGE DeferredTestResult(char const* suite, char const* test);
     UNITTEST_LINKAGE ~DeferredTestResult();
-    
+
     std::string suiteName;
     std::string testName;
     std::string failureFile;
-    
-    typedef std::vector< DeferredTestFailure > FailureVec;
+
+    typedef std::vector<DeferredTestFailure> FailureVec;
     FailureVec failures;
-    
+
     float timeElapsed;
 	bool failed;
 };

--- a/tests/framework/UnitTestpp/src/HelperMacros.h
+++ b/tests/framework/UnitTestpp/src/HelperMacros.h
@@ -1,10 +1,10 @@
 /***
 * This file is based on or incorporates material from the UnitTest++ r30 open source project.
-* Microsoft is not the original author of this code but has modified it and is licensing the code under 
-* the MIT License. Microsoft reserves all other rights not expressly granted under the MIT License, 
-* whether by implication, estoppel or otherwise. 
+* Microsoft is not the original author of this code but has modified it and is licensing the code under
+* the MIT License. Microsoft reserves all other rights not expressly granted under the MIT License,
+* whether by implication, estoppel or otherwise.
 *
-* UnitTest++ r30 
+* UnitTest++ r30
 *
 * Copyright (c) 2006 Noel Llopis and Charles Nicholson
 * Portions Copyright (c) Microsoft Corporation
@@ -13,19 +13,19 @@
 *
 * MIT License
 *
-* Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
-* and associated documentation files (the "Software"), to deal in the Software without restriction, 
-* including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-* and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+* Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+* and associated documentation files (the "Software"), to deal in the Software without restriction,
+* including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
 * subject to the following conditions:
 *
-* The above copyright notice and this permission notice shall be included in all copies or 
+* The above copyright notice and this permission notice shall be included in all copies or
 * substantial portions of the Software.
 *
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
-* INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE 
-* AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-* DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+* INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+* AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+* DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ***/
 
@@ -59,8 +59,8 @@
 	#define UNITTEST_STDVECTOR_LINKAGE(T) \
 		__pragma(warning(push)) \
 		__pragma(warning(disable:4231)) \
-		UNITTEST_IMPEXP_TEMPLATE template class UNITTEST_LINKAGE std::allocator< T >; \
-		UNITTEST_IMPEXP_TEMPLATE template class UNITTEST_LINKAGE std::vector< T >; \
+		UNITTEST_IMPEXP_TEMPLATE template class UNITTEST_LINKAGE std::allocator<T>; \
+		UNITTEST_IMPEXP_TEMPLATE template class UNITTEST_LINKAGE std::vector<T>; \
 		__pragma(warning(pop))
 #else
 	#define UNITTEST_IMPORT

--- a/tests/framework/UnitTestpp/src/TestMacros.h
+++ b/tests/framework/UnitTestpp/src/TestMacros.h
@@ -1,10 +1,10 @@
 /***
 * This file is based on or incorporates material from the UnitTest++ r30 open source project.
-* Microsoft is not the original author of this code but has modified it and is licensing the code under 
-* the MIT License. Microsoft reserves all other rights not expressly granted under the MIT License, 
-* whether by implication, estoppel or otherwise. 
+* Microsoft is not the original author of this code but has modified it and is licensing the code under
+* the MIT License. Microsoft reserves all other rights not expressly granted under the MIT License,
+* whether by implication, estoppel or otherwise.
 *
-* UnitTest++ r30 
+* UnitTest++ r30
 *
 * Copyright (c) 2006 Noel Llopis and Charles Nicholson
 * Portions Copyright (c) Microsoft Corporation
@@ -13,19 +13,19 @@
 *
 * MIT License
 *
-* Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
-* and associated documentation files (the "Software"), to deal in the Software without restriction, 
-* including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-* and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+* Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+* and associated documentation files (the "Software"), to deal in the Software without restriction,
+* including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
 * subject to the following conditions:
 *
-* The above copyright notice and this permission notice shall be included in all copies or 
+* The above copyright notice and this permission notice shall be included in all copies or
 * substantial portions of the Software.
 *
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
-* INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE 
-* AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-* DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+* INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+* AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+* DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ***/
 
@@ -85,14 +85,14 @@ namespace UnitTest
     // {
     //     static TestList s_list;
     //     return s_list;
-    // }    
+    // }
 #else
     extern "C"
     inline _DLL_EXPORT TestList& GetTestList()
     {
         static TestList s_list;
         return s_list;
-    }    
+    }
 #endif
 }
 #endif

--- a/tests/framework/UnitTestpp/src/TestResults.cpp
+++ b/tests/framework/UnitTestpp/src/TestResults.cpp
@@ -1,10 +1,10 @@
 /***
 * This file is based on or incorporates material from the UnitTest++ r30 open source project.
-* Microsoft is not the original author of this code but has modified it and is licensing the code under 
-* the MIT License. Microsoft reserves all other rights not expressly granted under the MIT License, 
-* whether by implication, estoppel or otherwise. 
+* Microsoft is not the original author of this code but has modified it and is licensing the code under
+* the MIT License. Microsoft reserves all other rights not expressly granted under the MIT License,
+* whether by implication, estoppel or otherwise.
 *
-* UnitTest++ r30 
+* UnitTest++ r30
 *
 * Copyright (c) 2006 Noel Llopis and Charles Nicholson
 * Portions Copyright (c) Microsoft Corporation
@@ -13,19 +13,19 @@
 *
 * MIT License
 *
-* Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
-* and associated documentation files (the "Software"), to deal in the Software without restriction, 
-* including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-* and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+* Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+* and associated documentation files (the "Software"), to deal in the Software without restriction,
+* including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
 * subject to the following conditions:
 *
-* The above copyright notice and this permission notice shall be included in all copies or 
+* The above copyright notice and this permission notice shall be included in all copies or
 * substantial portions of the Software.
 *
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
-* INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE 
-* AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-* DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+* INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+* AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+* DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ***/
 

--- a/tests/functional/client_test/odata_query_builder_test.cpp
+++ b/tests/functional/client_test/odata_query_builder_test.cpp
@@ -22,106 +22,106 @@ SUITE(odata_query_builder_test_cases)
 
 TEST(no_query_test)
 {
-	auto query_builder = std::make_shared<odata_query_builder>(U("Accounts"));
-	::utility::string_t expression = query_builder->get_query_expression();
-	VERIFY_ARE_EQUAL(expression, U("Accounts"));
+	auto query_builder = ::odata::make_shared<odata_query_builder>(_XPLATSTR("Accounts"));
+	::odata::string_t expression = query_builder->get_query_expression();
+	VERIFY_ARE_EQUAL(expression, _XPLATSTR("Accounts"));
 }
 
 TEST(key_test)
 {
-	auto query_builder = std::make_shared<odata_query_builder>(U("Accounts"));
-	query_builder->key(U("101"));
-	::utility::string_t expression = query_builder->get_query_expression();
-	VERIFY_ARE_EQUAL(expression, U("Accounts(101)"));
+	auto query_builder = ::odata::make_shared<odata_query_builder>(_XPLATSTR("Accounts"));
+	query_builder->key(_XPLATSTR("101"));
+	::odata::string_t expression = query_builder->get_query_expression();
+	VERIFY_ARE_EQUAL(expression, _XPLATSTR("Accounts(101)"));
 }
 
 TEST(top_test)
 {
-	auto query_builder = std::make_shared<odata_query_builder>(U("Accounts"));
+	auto query_builder = ::odata::make_shared<odata_query_builder>(_XPLATSTR("Accounts"));
 	query_builder->top(10);
-	::utility::string_t expression = query_builder->get_query_expression();
-	VERIFY_ARE_EQUAL(expression, U("Accounts?$top=10"));
+	::odata::string_t expression = query_builder->get_query_expression();
+	VERIFY_ARE_EQUAL(expression, _XPLATSTR("Accounts?$top=10"));
 }
 
 TEST(orderby_test)
 {
-	auto query_builder = std::make_shared<odata_query_builder>(U("Accounts"));
-	query_builder->orderby(U("Name desc, Gender asc"));
-	::utility::string_t expression = query_builder->get_query_expression();
-	VERIFY_ARE_EQUAL(expression, U("Accounts?$orderby=Name%20desc,%20Gender%20asc"));
+	auto query_builder = ::odata::make_shared<odata_query_builder>(_XPLATSTR("Accounts"));
+	query_builder->orderby(_XPLATSTR("Name desc, Gender asc"));
+	::odata::string_t expression = query_builder->get_query_expression();
+	VERIFY_ARE_EQUAL(expression, _XPLATSTR("Accounts?$orderby=Name%20desc,%20Gender%20asc"));
 }
 
 TEST(select_test)
 {
-	auto query_builder = std::make_shared<odata_query_builder>(U("Accounts"));
-	query_builder->select(U("Name,OrderDate"));
-	::utility::string_t expression = query_builder->get_query_expression();
-	VERIFY_ARE_EQUAL(expression, U("Accounts?$select=Name,OrderDate"));
+	auto query_builder = ::odata::make_shared<odata_query_builder>(_XPLATSTR("Accounts"));
+	query_builder->select(_XPLATSTR("Name,OrderDate"));
+	::odata::string_t expression = query_builder->get_query_expression();
+	VERIFY_ARE_EQUAL(expression, _XPLATSTR("Accounts?$select=Name,OrderDate"));
 }
 
 TEST(expand_test)
 {
-	auto query_builder = std::make_shared<odata_query_builder>(U("Accounts"));
-	query_builder->expand(U("MyGiftCard"));
-	::utility::string_t expression = query_builder->get_query_expression();
-	VERIFY_ARE_EQUAL(expression, U("Accounts?$expand=MyGiftCard"));
+	auto query_builder = ::odata::make_shared<odata_query_builder>(_XPLATSTR("Accounts"));
+	query_builder->expand(_XPLATSTR("MyGiftCard"));
+	::odata::string_t expression = query_builder->get_query_expression();
+	VERIFY_ARE_EQUAL(expression, _XPLATSTR("Accounts?$expand=MyGiftCard"));
 }
 
 TEST(double_expand_test)
 {
-	auto query_builder = std::make_shared<odata_query_builder>(U("Accounts(101)"));
-	query_builder->expand(U("MyGiftCard"));
-	query_builder->expand(U("MyPaymentInstruments"));
-	::utility::string_t expression = query_builder->get_query_expression();
-	VERIFY_ARE_EQUAL(expression, U("Accounts(101)?$expand=MyPaymentInstruments,MyGiftCard"));
+	auto query_builder = ::odata::make_shared<odata_query_builder>(_XPLATSTR("Accounts(101)"));
+	query_builder->expand(_XPLATSTR("MyGiftCard"));
+	query_builder->expand(_XPLATSTR("MyPaymentInstruments"));
+	::odata::string_t expression = query_builder->get_query_expression();
+	VERIFY_ARE_EQUAL(expression, _XPLATSTR("Accounts(101)?$expand=MyPaymentInstruments,MyGiftCard"));
 }
 
 TEST(select_and_expand_test)
 {
-	auto query_builder = std::make_shared<odata_query_builder>(U("Accounts(101)"));
-	query_builder->expand(U("MyPaymentInstruments"));
-	query_builder->expand(U("MyGiftCard"));
-	query_builder->select(U("AccountID,CountryRegion"));
-	::utility::string_t expression = query_builder->get_query_expression();
-	VERIFY_ARE_EQUAL(expression, U("Accounts(101)?$select=AccountID,CountryRegion&$expand=MyGiftCard,MyPaymentInstruments"));
+	auto query_builder = ::odata::make_shared<odata_query_builder>(_XPLATSTR("Accounts(101)"));
+	query_builder->expand(_XPLATSTR("MyPaymentInstruments"));
+	query_builder->expand(_XPLATSTR("MyGiftCard"));
+	query_builder->select(_XPLATSTR("AccountID,CountryRegion"));
+	::odata::string_t expression = query_builder->get_query_expression();
+	VERIFY_ARE_EQUAL(expression, _XPLATSTR("Accounts(101)?$select=AccountID,CountryRegion&$expand=MyGiftCard,MyPaymentInstruments"));
 }
 
 TEST(only_nested_expand_test)
 {
-	auto query_builder = std::make_shared<odata_query_builder>(U("Accounts(101)"));
-	query_builder->expand(U("MyGiftCard"));
-	query_builder->expand(odata_query_path::creat_query_path(U("MyPaymentInstruments"))->expand(U("TheStoredPI")));
-	query_builder->select(U("AccountID,CountryRegion"));
-	::utility::string_t expression = query_builder->get_query_expression();
-	VERIFY_ARE_EQUAL(expression, U("Accounts(101)?$select=AccountID,CountryRegion&$expand=MyPaymentInstruments($expand=TheStoredPI),MyGiftCard"));
+	auto query_builder = ::odata::make_shared<odata_query_builder>(_XPLATSTR("Accounts(101)"));
+	query_builder->expand(_XPLATSTR("MyGiftCard"));
+	query_builder->expand(odata_query_path::creat_query_path(_XPLATSTR("MyPaymentInstruments"))->expand(_XPLATSTR("TheStoredPI")));
+	query_builder->select(_XPLATSTR("AccountID,CountryRegion"));
+	::odata::string_t expression = query_builder->get_query_expression();
+	VERIFY_ARE_EQUAL(expression, _XPLATSTR("Accounts(101)?$select=AccountID,CountryRegion&$expand=MyPaymentInstruments($expand=TheStoredPI),MyGiftCard"));
 }
 
 TEST(select_in_expand_test)
 {
-	auto query_builder = std::make_shared<odata_query_builder>(U("Accounts"));
-	query_builder->expand(odata_query_path::creat_query_path(U("MyPaymentInstruments"))->select(U("PaymentInstrumentID,FriendlyName")));
-	query_builder->select(U("AccountID,CountryRegion"));
-	::utility::string_t expression = query_builder->get_query_expression();
-	VERIFY_ARE_EQUAL(expression, U("Accounts?$select=AccountID,CountryRegion&$expand=MyPaymentInstruments($select=PaymentInstrumentID,FriendlyName)"));
+	auto query_builder = ::odata::make_shared<odata_query_builder>(_XPLATSTR("Accounts"));
+	query_builder->expand(odata_query_path::creat_query_path(_XPLATSTR("MyPaymentInstruments"))->select(_XPLATSTR("PaymentInstrumentID,FriendlyName")));
+	query_builder->select(_XPLATSTR("AccountID,CountryRegion"));
+	::odata::string_t expression = query_builder->get_query_expression();
+	VERIFY_ARE_EQUAL(expression, _XPLATSTR("Accounts?$select=AccountID,CountryRegion&$expand=MyPaymentInstruments($select=PaymentInstrumentID,FriendlyName)"));
 }
 
 TEST(expand_in_expand_test)
 {
-	auto query_builder = std::make_shared<odata_query_builder>(U("Accounts"));
-	query_builder->expand(odata_query_path::creat_query_path(U("MyPaymentInstruments"))->select(U("PaymentInstrumentID,FriendlyName"))->expand(odata_query_path::creat_query_path(U("TheStoredPI"))));
-	query_builder->select(U("AccountID,CountryRegion"));
-	::utility::string_t expression = query_builder->get_query_expression();
-	VERIFY_ARE_EQUAL(expression, U("Accounts?$select=AccountID,CountryRegion&$expand=MyPaymentInstruments($select=PaymentInstrumentID,FriendlyName;$expand=TheStoredPI)"));
+	auto query_builder = ::odata::make_shared<odata_query_builder>(_XPLATSTR("Accounts"));
+	query_builder->expand(odata_query_path::creat_query_path(_XPLATSTR("MyPaymentInstruments"))->select(_XPLATSTR("PaymentInstrumentID,FriendlyName"))->expand(odata_query_path::creat_query_path(_XPLATSTR("TheStoredPI"))));
+	query_builder->select(_XPLATSTR("AccountID,CountryRegion"));
+	::odata::string_t expression = query_builder->get_query_expression();
+	VERIFY_ARE_EQUAL(expression, _XPLATSTR("Accounts?$select=AccountID,CountryRegion&$expand=MyPaymentInstruments($select=PaymentInstrumentID,FriendlyName;$expand=TheStoredPI)"));
 }
 
 TEST(three_layered_expand_test)
 {
-	auto query_builder = std::make_shared<odata_query_builder>(U("Customers"));
-	query_builder->select(U("PersonID"))->expand(
-		odata_query_path::creat_query_path(U("Orders"))->select(U("OrderID"))->expand(
-		odata_query_path::creat_query_path(U("LoggedInEmployee"))->select(U("PersonID"))->expand(U("Company"))));
-	::utility::string_t expression = query_builder->get_query_expression();
-	VERIFY_ARE_EQUAL(expression, U("Customers?$select=PersonID&$expand=Orders($select=OrderID;$expand=LoggedInEmployee($select=PersonID;$expand=Company))"));
+	auto query_builder = ::odata::make_shared<odata_query_builder>(_XPLATSTR("Customers"));
+	query_builder->select(_XPLATSTR("PersonID"))->expand(
+		odata_query_path::creat_query_path(_XPLATSTR("Orders"))->select(_XPLATSTR("OrderID"))->expand(
+		odata_query_path::creat_query_path(_XPLATSTR("LoggedInEmployee"))->select(_XPLATSTR("PersonID"))->expand(_XPLATSTR("Company"))));
+	::odata::string_t expression = query_builder->get_query_expression();
+	VERIFY_ARE_EQUAL(expression, _XPLATSTR("Customers?$select=PersonID&$expand=Orders($select=OrderID;$expand=LoggedInEmployee($select=PersonID;$expand=Company))"));
 }
 
 }

--- a/tests/functional/codegen_test/codegen_test.cpp
+++ b/tests/functional/codegen_test/codegen_test.cpp
@@ -19,15 +19,15 @@ static std::shared_ptr<odata_entity_value> make_account_object()
 {
 	auto model = get_test_model();
 
-	auto complex_value = std::make_shared<odata_complex_value>(model->find_complex_type(U("AccountInfo")));
-	complex_value->set_value(U("FirstName"), U("Leo"));
-	complex_value->set_value(U("LastName"), U("Hu"));
+	auto complex_value = ::odata::make_shared<odata_complex_value>(model->find_complex_type(_XPLATSTR("AccountInfo")));
+	complex_value->set_value(_XPLATSTR("FirstName"), _XPLATSTR("Leo"));
+	complex_value->set_value(_XPLATSTR("LastName"), _XPLATSTR("Hu"));
 
-	auto entity_value = std::make_shared<odata_entity_value>(model->find_entity_type(U("Account")));
-	entity_value->set_value(U("AccountID"), (int32_t)989899);
-	entity_value->set_value(U("CountryRegion"), U("China"));
-	entity_value->set_value(U("AccountInfo"), complex_value);
-	entity_value->set_value(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_EDITLINK, U("http://0.0.0.1/Account(989899)"));
+	auto entity_value = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("Account")));
+	entity_value->set_value(_XPLATSTR("AccountID"), (int32_t)989899);
+	entity_value->set_value(_XPLATSTR("CountryRegion"), _XPLATSTR("China"));
+	entity_value->set_value(_XPLATSTR("AccountInfo"), complex_value);
+	entity_value->set_value(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_EDITLINK, _XPLATSTR("http://0.0.0.1/Account(989899)"));
 
 	return entity_value;
 }
@@ -36,9 +36,9 @@ static std::shared_ptr<odata_entity_value> make_giftcard_object()
 {
 	auto model = get_test_model();
 
-	auto entity_value = std::make_shared<odata_entity_value>(model->find_entity_type(U("GiftCard")));
-	entity_value->set_value(U("GiftCardID"), (int32_t)77566);
-	entity_value->set_value(U("GiftCardNO"), U("@@2232"));
+	auto entity_value = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("GiftCard")));
+	entity_value->set_value(_XPLATSTR("GiftCardID"), (int32_t)77566);
+	entity_value->set_value(_XPLATSTR("GiftCardNO"), _XPLATSTR("@@2232"));
 
 	return entity_value;
 }
@@ -47,7 +47,7 @@ static std::shared_ptr<odata_entity_value> make_paymentinstrument_object()
 {
 	auto model = get_test_model();
 
-	auto entity_value = std::make_shared<odata_entity_value>(model->find_entity_type(U("PaymentInstrument")));
+	auto entity_value = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("PaymentInstrument")));
 
 	return entity_value;
 }
@@ -56,7 +56,7 @@ static std::shared_ptr<odata_entity_value> make_creditcardpi_object()
 {
 	auto model = get_test_model();
 
-	auto entity_value = std::make_shared<odata_entity_value>(model->find_entity_type(U("CreditCardPI")));
+	auto entity_value = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("CreditCardPI")));
 
 	return entity_value;
 }
@@ -67,24 +67,24 @@ static std::shared_ptr<odata_entity_value> make_account_object_with_navigation()
 
 	auto entity_value = make_account_object();
 	auto giftcard_value = make_giftcard_object();
-	entity_value->set_value(U("MyGiftCard"), giftcard_value);
+	entity_value->set_value(_XPLATSTR("MyGiftCard"), giftcard_value);
 
 	auto pi_1 = make_paymentinstrument_object();
-	pi_1->set_value(U("PaymentInstrumentID"), 100000);
-	pi_1->set_value(U("FriendlyName"), U("PI 1"));
+	pi_1->set_value(_XPLATSTR("PaymentInstrumentID"), 100000);
+	pi_1->set_value(_XPLATSTR("FriendlyName"), _XPLATSTR("PI 1"));
 
-	auto pi_2 = make_creditcardpi_object(); 
-	pi_2->set_value(U("@odata.type"), "#Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI");
-	pi_2->set_value(U("PaymentInstrumentID"), 200000);
-	pi_2->set_value(U("FriendlyName"), U("PI 2"));
-	pi_2->set_value(U("CardNumber"), U("777777"));
-	pi_2->set_value(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_EDITLINK, U("http://0.0.0.1/PaymentInstrument(200000)"));
+	auto pi_2 = make_creditcardpi_object();
+	pi_2->set_value(_XPLATSTR("@odata.type"), "#Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI");
+	pi_2->set_value(_XPLATSTR("PaymentInstrumentID"), 200000);
+	pi_2->set_value(_XPLATSTR("FriendlyName"), _XPLATSTR("PI 2"));
+	pi_2->set_value(_XPLATSTR("CardNumber"), _XPLATSTR("777777"));
+	pi_2->set_value(::odata::core::odata_json_constants::PAYLOAD_ANNOTATION_EDITLINK, _XPLATSTR("http://0.0.0.1/PaymentInstrument(200000)"));
 
-	auto collection_value = std::make_shared<odata_collection_value>(model->find_entity_type(U("PaymentInstrument")));
+	auto collection_value = ::odata::make_shared<odata_collection_value>(model->find_entity_type(_XPLATSTR("PaymentInstrument")));
 	collection_value->add_collection_value(pi_1);
 	collection_value->add_collection_value(pi_2);
 
-	entity_value->set_value(U("MyPaymentInstruments"), collection_value);
+	entity_value->set_value(_XPLATSTR("MyPaymentInstruments"), collection_value);
 
 	return entity_value;
 }
@@ -93,15 +93,15 @@ static std::shared_ptr<odata_entity_value> make_person_object()
 {
 	auto model = get_test_model();
 
-	auto entity_value = std::make_shared<odata_entity_value>(model->find_entity_type(U("Person")));
-	entity_value->set_value(U("PersonID"), (int32_t)12123);
-	entity_value->set_value(U("FirstName"), U("Leo"));
-	entity_value->set_value(U("MiddleName"), U("Middle Name"));
-	auto collection_value = std::make_shared<odata_collection_value>(edm_primitive_type::STRING());
-	collection_value->add_collection_value(odata_primitive_value::make_primitive_value(U("string 1")));
-	collection_value->add_collection_value(odata_primitive_value::make_primitive_value(U("string 2")));
-	collection_value->add_collection_value(odata_primitive_value::make_primitive_value(U("string 3")));
-	entity_value->set_value(U("Numbers"), collection_value);
+	auto entity_value = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("Person")));
+	entity_value->set_value(_XPLATSTR("PersonID"), (int32_t)12123);
+	entity_value->set_value(_XPLATSTR("FirstName"), _XPLATSTR("Leo"));
+	entity_value->set_value(_XPLATSTR("MiddleName"), _XPLATSTR("Middle Name"));
+	auto collection_value = ::odata::make_shared<odata_collection_value>(edm_primitive_type::STRING());
+	collection_value->add_collection_value(odata_primitive_value::make_primitive_value(_XPLATSTR("string 1")));
+	collection_value->add_collection_value(odata_primitive_value::make_primitive_value(_XPLATSTR("string 2")));
+	collection_value->add_collection_value(odata_primitive_value::make_primitive_value(_XPLATSTR("string 3")));
+	entity_value->set_value(_XPLATSTR("Numbers"), collection_value);
 
 	return entity_value;
 }
@@ -110,9 +110,9 @@ static std::shared_ptr<odata_complex_value> make_accountinfo_object()
 {
 	auto model = get_test_model();
 
-	auto complex_value = std::make_shared<odata_complex_value>(model->find_complex_type(U("AccountInfo")));
-	complex_value->set_value(U("FirstName"), U("Leo  "));
-	complex_value->set_value(U("LastName"), U("  Hu"));
+	auto complex_value = ::odata::make_shared<odata_complex_value>(model->find_complex_type(_XPLATSTR("AccountInfo")));
+	complex_value->set_value(_XPLATSTR("FirstName"), _XPLATSTR("Leo  "));
+	complex_value->set_value(_XPLATSTR("LastName"), _XPLATSTR("  Hu"));
 
 	return complex_value;
 }
@@ -121,23 +121,23 @@ static std::shared_ptr<odata_complex_value> make_address_object()
 {
 	auto model = get_test_model();
 
-	auto complex_value = std::make_shared<odata_complex_value>(model->find_complex_type(U("Address")));
-	complex_value->set_value(U("Street"), U("Road 1111"));
-	complex_value->set_value(U("City"), U("Shang Hai"));
-	complex_value->set_value(U("Code"), 12123);
-	auto collection_value = std::make_shared<odata_collection_value>(edm_primitive_type::INT32());
+	auto complex_value = ::odata::make_shared<odata_complex_value>(model->find_complex_type(_XPLATSTR("Address")));
+	complex_value->set_value(_XPLATSTR("Street"), _XPLATSTR("Road 1111"));
+	complex_value->set_value(_XPLATSTR("City"), _XPLATSTR("Shang Hai"));
+	complex_value->set_value(_XPLATSTR("Code"), 12123);
+	auto collection_value = ::odata::make_shared<odata_collection_value>(edm_primitive_type::INT32());
 	collection_value->add_collection_value(odata_primitive_value::make_primitive_value(2213213));
 	collection_value->add_collection_value(odata_primitive_value::make_primitive_value(-212312));
 	collection_value->add_collection_value(odata_primitive_value::make_primitive_value(0));
-	complex_value->set_value(U("Numbers"), collection_value);
+	complex_value->set_value(_XPLATSTR("Numbers"), collection_value);
 
-	complex_value->set_value(U("Color"), std::make_shared<odata_enum_value>(model->find_enum_type(U("Color")), U("Red")));
+	complex_value->set_value(_XPLATSTR("Color"), ::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("Color")), _XPLATSTR("Red")));
 
-	auto enum_collection_value = std::make_shared<odata_collection_value>(model->find_complex_type(U("Color")));
-	enum_collection_value->add_collection_value(std::make_shared<odata_enum_value>(model->find_enum_type(U("Color")), U("Red")));
-	enum_collection_value->add_collection_value(std::make_shared<odata_enum_value>(model->find_enum_type(U("Color")), U("Blue")));
-	enum_collection_value->add_collection_value(std::make_shared<odata_enum_value>(model->find_enum_type(U("Color")), U("Green")));
-	complex_value->set_value(U("CoverColors"), enum_collection_value);
+	auto enum_collection_value = ::odata::make_shared<odata_collection_value>(model->find_complex_type(_XPLATSTR("Color")));
+	enum_collection_value->add_collection_value(::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("Color")), _XPLATSTR("Red")));
+	enum_collection_value->add_collection_value(::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("Color")), _XPLATSTR("Blue")));
+	enum_collection_value->add_collection_value(::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("Color")), _XPLATSTR("Green")));
+	complex_value->set_value(_XPLATSTR("CoverColors"), enum_collection_value);
 
 	return complex_value;
 }
@@ -146,24 +146,24 @@ static std::shared_ptr<odata_entity_value> make_employee_object()
 {
 	auto model = get_test_model();
 
-	auto entity_value = std::make_shared<odata_entity_value>(model->find_entity_type(U("Employee")));
-	entity_value->set_value(U("PersonID"), (int32_t)10001);
-	entity_value->set_value(U("FirstName"), U("Henry"));
-	auto complex_type = model->find_complex_type(U("Microsoft.Test.OData.Services.ODataWCFService.Address"));
-	auto collection_value = std::make_shared<odata_collection_value>(complex_type);
-	auto complex_value_1 = std::make_shared<odata_complex_value>(complex_type);
-	complex_value_1->set_value(U("Street"), U("Street 1"));
-	complex_value_1->set_value(U("City"), U("City 1"));
-	auto complex_value_2 = std::make_shared<odata_complex_value>(complex_type);
-	complex_value_2->set_value(U("Street"), U("Street 2"));
-	complex_value_2->set_value(U("City"), U("City 2"));
-	auto complex_value_3 = std::make_shared<odata_complex_value>(complex_type);
-	complex_value_3->set_value(U("Street"), U("Street 3"));
-	complex_value_3->set_value(U("City"), U("City 3"));
+	auto entity_value = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("Employee")));
+	entity_value->set_value(_XPLATSTR("PersonID"), (int32_t)10001);
+	entity_value->set_value(_XPLATSTR("FirstName"), _XPLATSTR("Henry"));
+	auto complex_type = model->find_complex_type(_XPLATSTR("Microsoft.Test.OData.Services.ODataWCFService.Address"));
+	auto collection_value = ::odata::make_shared<odata_collection_value>(complex_type);
+	auto complex_value_1 = ::odata::make_shared<odata_complex_value>(complex_type);
+	complex_value_1->set_value(_XPLATSTR("Street"), _XPLATSTR("Street 1"));
+	complex_value_1->set_value(_XPLATSTR("City"), _XPLATSTR("City 1"));
+	auto complex_value_2 = ::odata::make_shared<odata_complex_value>(complex_type);
+	complex_value_2->set_value(_XPLATSTR("Street"), _XPLATSTR("Street 2"));
+	complex_value_2->set_value(_XPLATSTR("City"), _XPLATSTR("City 2"));
+	auto complex_value_3 = ::odata::make_shared<odata_complex_value>(complex_type);
+	complex_value_3->set_value(_XPLATSTR("Street"), _XPLATSTR("Street 3"));
+	complex_value_3->set_value(_XPLATSTR("City"), _XPLATSTR("City 3"));
 	collection_value->add_collection_value(complex_value_1);
 	collection_value->add_collection_value(complex_value_2);
 	collection_value->add_collection_value(complex_value_3);
-	entity_value->set_value(U("WorkAddresses"), collection_value);
+	entity_value->set_value(_XPLATSTR("WorkAddresses"), collection_value);
 
 	return entity_value;
 }
@@ -172,23 +172,23 @@ static std::shared_ptr<odata_entity_value> make_product_object()
 {
 	auto model = get_test_model();
 
-	auto entity_value = std::make_shared<odata_entity_value>(model->find_entity_type(U("Product")));
-	entity_value->set_value(U("ProductID"), (int32_t)64454);
-	entity_value->set_value(U("Name"), U("Henry"));
-	entity_value->set_value(U("UserAccess"), std::make_shared<odata_enum_value>(model->find_enum_type(U("AccessLevel")), U("ReadWrite")));
+	auto entity_value = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("Product")));
+	entity_value->set_value(_XPLATSTR("ProductID"), (int32_t)64454);
+	entity_value->set_value(_XPLATSTR("Name"), _XPLATSTR("Henry"));
+	entity_value->set_value(_XPLATSTR("UserAccess"), ::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("AccessLevel")), _XPLATSTR("ReadWrite")));
 
-	auto collection_value = std::make_shared<odata_collection_value>(model->find_complex_type(U("Color")));
-	collection_value->add_collection_value(std::make_shared<odata_enum_value>(model->find_enum_type(U("Color")), U("Red")));
-	collection_value->add_collection_value(std::make_shared<odata_enum_value>(model->find_enum_type(U("Color")), U("Blue")));
-	collection_value->add_collection_value(std::make_shared<odata_enum_value>(model->find_enum_type(U("Color")), U("Green")));
+	auto collection_value = ::odata::make_shared<odata_collection_value>(model->find_complex_type(_XPLATSTR("Color")));
+	collection_value->add_collection_value(::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("Color")), _XPLATSTR("Red")));
+	collection_value->add_collection_value(::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("Color")), _XPLATSTR("Blue")));
+	collection_value->add_collection_value(::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("Color")), _XPLATSTR("Green")));
 
-	entity_value->set_value(U("CoverColors"), collection_value);
+	entity_value->set_value(_XPLATSTR("CoverColors"), collection_value);
 
 	unsigned char ini_binary[] = {'Q', 'B', 'A', 'B', 'A', 'C', 'X', '1', '2', '*', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'p'};
 	std::vector<unsigned char> binary(ini_binary, ini_binary + 25);
-	entity_value->set_value(U("Picture"), binary);
+	entity_value->set_value(_XPLATSTR("Picture"), binary);
 
-	entity_value->set_value(U("NullPicture"), binary);
+	entity_value->set_value(_XPLATSTR("NullPicture"), binary);
 
 	return entity_value;
 }
@@ -200,67 +200,67 @@ TEST(map_primitive_to_entity)
 {
 	auto test_value = make_account_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto account = std::make_shared<Account>(service_context);
+	auto account = ::odata::make_shared<Account>(service_context);
 	account->from_value(test_value);
 
 	VERIFY_ARE_EQUAL(account->get_accountid(), 989899);
-	VERIFY_ARE_EQUAL(account->get_countryregion(), U("China"));
+	VERIFY_ARE_EQUAL(account->get_countryregion(), _XPLATSTR("China"));
 }
 
 TEST(map_collection_primitive_to_entity)
 {
 	auto test_value = make_person_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto person = std::make_shared<Person>(service_context);
+	auto person = ::odata::make_shared<Person>(service_context);
 	person->from_value(test_value);
 
 	VERIFY_ARE_EQUAL(person->get_personid(), 12123);
-	VERIFY_ARE_EQUAL(person->get_firstname(), U("Leo"));
+	VERIFY_ARE_EQUAL(person->get_firstname(), _XPLATSTR("Leo"));
 	VERIFY_ARE_EQUAL(person->get_numbers().size(), 3);
-	VERIFY_ARE_EQUAL(person->get_numbers()[0], U("string 1"));
-	VERIFY_ARE_EQUAL(person->get_numbers()[1], U("string 2"));
-	VERIFY_ARE_EQUAL(person->get_numbers()[2], U("string 3"));
+	VERIFY_ARE_EQUAL(person->get_numbers()[0], _XPLATSTR("string 1"));
+	VERIFY_ARE_EQUAL(person->get_numbers()[1], _XPLATSTR("string 2"));
+	VERIFY_ARE_EQUAL(person->get_numbers()[2], _XPLATSTR("string 3"));
 }
 
 TEST(map_nullable_primitive_to_entity)
 {
 	auto test_value = make_person_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto person = std::make_shared<Person>(service_context);
+	auto person = ::odata::make_shared<Person>(service_context);
 	person->from_value(test_value);
 
 	VERIFY_ARE_EQUAL(person->get_personid(), 12123);
-	VERIFY_ARE_EQUAL(person->get_firstname(), U("Leo"));
+	VERIFY_ARE_EQUAL(person->get_firstname(), _XPLATSTR("Leo"));
 	VERIFY_IS_NOT_NULL(person->get_middlename());
-	VERIFY_ARE_EQUAL(*(person->get_middlename()), U("Middle Name"));
+	VERIFY_ARE_EQUAL(*(person->get_middlename()), _XPLATSTR("Middle Name"));
 }
 
 TEST(map_primitive_to_complex)
 {
 	auto test_value = make_accountinfo_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto accountinfo = std::make_shared<AccountInfo>(service_context);
+	auto accountinfo = ::odata::make_shared<AccountInfo>(service_context);
 	accountinfo->from_value(test_value);
 
-	VERIFY_ARE_EQUAL(accountinfo->get_firstname(), U("Leo  "));
-	VERIFY_ARE_EQUAL(accountinfo->get_lastname(), U("  Hu"));
+	VERIFY_ARE_EQUAL(accountinfo->get_firstname(), _XPLATSTR("Leo  "));
+	VERIFY_ARE_EQUAL(accountinfo->get_lastname(), _XPLATSTR("  Hu"));
 }
 
 TEST(map_collection_primitive_to_complex)
 {
 	auto test_value = make_address_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto address = std::make_shared<Address>(service_context);
+	auto address = ::odata::make_shared<Address>(service_context);
 	address->from_value(test_value);
 
 	VERIFY_ARE_EQUAL(address->get_numbers().size(), 3);
@@ -273,9 +273,9 @@ TEST(map_nullable_primitive_to_complex)
 {
 	auto test_value = make_address_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto address = std::make_shared<Address>(service_context);
+	auto address = ::odata::make_shared<Address>(service_context);
 	VERIFY_IS_NULL(address->get_code());
 	address->from_value(test_value);
 	VERIFY_IS_NOT_NULL(address->get_code());
@@ -286,67 +286,67 @@ TEST(map_complex_to_entity)
 {
 	auto test_value = make_account_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto account = std::make_shared<Account>(service_context);
+	auto account = ::odata::make_shared<Account>(service_context);
 	account->from_value(test_value);
 
 	auto account_info = account->get_accountinfo();
-	VERIFY_ARE_EQUAL(account_info->get_firstname(), U("Leo"));
-	VERIFY_ARE_EQUAL(account_info->get_lastname(), U("Hu"));
+	VERIFY_ARE_EQUAL(account_info->get_firstname(), _XPLATSTR("Leo"));
+	VERIFY_ARE_EQUAL(account_info->get_lastname(), _XPLATSTR("Hu"));
 }
 
 TEST(map_derived_complex_to_entity)
 {
 	auto test_value = make_account_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto complex_value = std::make_shared<odata_complex_value>(get_test_model()->find_complex_type(U("VIPAccountInfo")));
-	complex_value->set_value(U("VIP_Info"), U("Diamond"));
-	complex_value->set_value(U("FirstName"), U("Henry"));
-	complex_value->set_value(U("LastName"), U("Yin"));
+	auto complex_value = ::odata::make_shared<odata_complex_value>(get_test_model()->find_complex_type(_XPLATSTR("VIPAccountInfo")));
+	complex_value->set_value(_XPLATSTR("VIP_Info"), _XPLATSTR("Diamond"));
+	complex_value->set_value(_XPLATSTR("FirstName"), _XPLATSTR("Henry"));
+	complex_value->set_value(_XPLATSTR("LastName"), _XPLATSTR("Yin"));
 
-	test_value->set_value(U("VIPAccountInfo"), complex_value);
+	test_value->set_value(_XPLATSTR("VIPAccountInfo"), complex_value);
 
-	auto account = std::make_shared<Account>(service_context);
+	auto account = ::odata::make_shared<Account>(service_context);
 	account->from_value(test_value);
 
 	auto account_info = account->get_accountinfo();
-	VERIFY_ARE_EQUAL(account_info->get_firstname(), U("Leo"));
-	VERIFY_ARE_EQUAL(account_info->get_lastname(), U("Hu"));
+	VERIFY_ARE_EQUAL(account_info->get_firstname(), _XPLATSTR("Leo"));
+	VERIFY_ARE_EQUAL(account_info->get_lastname(), _XPLATSTR("Hu"));
 
 	auto vip_info = account->get_vipinfo();
-	VERIFY_ARE_EQUAL(vip_info->get_firstname(), U("Henry"));
-	VERIFY_ARE_EQUAL(vip_info->get_lastname(), U("Yin"));
-	VERIFY_ARE_EQUAL(vip_info->get_vipinfo(), U("Diamond"));
+	VERIFY_ARE_EQUAL(vip_info->get_firstname(), _XPLATSTR("Henry"));
+	VERIFY_ARE_EQUAL(vip_info->get_lastname(), _XPLATSTR("Yin"));
+	VERIFY_ARE_EQUAL(vip_info->get_vipinfo(), _XPLATSTR("Diamond"));
 }
 
 TEST(map_collection_complex_to_entity)
 {
 	auto test_value = make_employee_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
-	
-	auto employee = std::make_shared<Employee>(service_context);
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
+
+	auto employee = ::odata::make_shared<Employee>(service_context);
 	employee->from_value(test_value);
 
 	VERIFY_ARE_EQUAL(employee->get_addresses().size(), 3);
-	VERIFY_ARE_EQUAL(employee->get_addresses()[0]->get_street(), U("Street 1"));
-	VERIFY_ARE_EQUAL(employee->get_addresses()[0]->get_city(), U("City 1"));
-	VERIFY_ARE_EQUAL(employee->get_addresses()[1]->get_street(), U("Street 2"));
-	VERIFY_ARE_EQUAL(employee->get_addresses()[1]->get_city(), U("City 2"));
-	VERIFY_ARE_EQUAL(employee->get_addresses()[2]->get_street(), U("Street 3"));
-	VERIFY_ARE_EQUAL(employee->get_addresses()[2]->get_city(), U("City 3"));
+	VERIFY_ARE_EQUAL(employee->get_addresses()[0]->get_street(), _XPLATSTR("Street 1"));
+	VERIFY_ARE_EQUAL(employee->get_addresses()[0]->get_city(), _XPLATSTR("City 1"));
+	VERIFY_ARE_EQUAL(employee->get_addresses()[1]->get_street(), _XPLATSTR("Street 2"));
+	VERIFY_ARE_EQUAL(employee->get_addresses()[1]->get_city(), _XPLATSTR("City 2"));
+	VERIFY_ARE_EQUAL(employee->get_addresses()[2]->get_street(), _XPLATSTR("Street 3"));
+	VERIFY_ARE_EQUAL(employee->get_addresses()[2]->get_city(), _XPLATSTR("City 3"));
 }
 
 TEST(map_nullable_complex_to_entity_with_null_value)
 {
 	auto test_value = make_person_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto person = std::make_shared<Person>(service_context);
+	auto person = ::odata::make_shared<Person>(service_context);
 	person->from_value(test_value);
 
 	VERIFY_IS_NULL(person->get_address());
@@ -356,26 +356,26 @@ TEST(map_nullable_complex_to_entity_with_value)
 {
 	auto test_value = make_person_object();
 	auto address = make_address_object();
-	test_value->set_value(U("HomeAddress"), address);
+	test_value->set_value(_XPLATSTR("HomeAddress"), address);
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto person = std::make_shared<Person>(service_context);
+	auto person = ::odata::make_shared<Person>(service_context);
 	person->from_value(test_value);
 
 	auto address_member = person->get_address();
 	VERIFY_IS_NOT_NULL(address_member);
-	VERIFY_ARE_EQUAL(address_member->get_city(), U("Shang Hai"));
-	VERIFY_ARE_EQUAL(address_member->get_street(), U("Road 1111"));
+	VERIFY_ARE_EQUAL(address_member->get_city(), _XPLATSTR("Shang Hai"));
+	VERIFY_ARE_EQUAL(address_member->get_street(), _XPLATSTR("Road 1111"));
 }
 
 TEST(map_binary_to_entity)
 {
 	auto test_value = make_product_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto product = std::make_shared<Product>(service_context);
+	auto product = ::odata::make_shared<Product>(service_context);
 	product->from_value(test_value);
 
 	auto binary = product->get_pic();
@@ -391,9 +391,9 @@ TEST(map_enum_to_entity)
 {
 	auto test_value = make_product_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto product = std::make_shared<Product>(service_context);
+	auto product = ::odata::make_shared<Product>(service_context);
 	product->from_value(test_value);
 
 	VERIFY_ARE_EQUAL(product->get_useraccess(), AccessLevel::ReadWrite);
@@ -403,9 +403,9 @@ TEST(map_collection_enum_to_entity)
 {
 	auto test_value = make_product_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto product = std::make_shared<Product>(service_context);
+	auto product = ::odata::make_shared<Product>(service_context);
 	product->from_value(test_value);
 
 	VERIFY_ARE_EQUAL(product->get_covercolors().size(), 3);
@@ -418,9 +418,9 @@ TEST(map_nullable_enum_to_entity_with_null)
 {
 	auto test_value = make_product_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto product = std::make_shared<Product>(service_context);
+	auto product = ::odata::make_shared<Product>(service_context);
 	product->from_value(test_value);
 
 	VERIFY_IS_NULL(product->get_skincolor());
@@ -431,10 +431,10 @@ TEST(map_nullable_enum_to_entity_with_value)
 	auto test_value = make_product_object();
 	VERIFY_IS_NOT_NULL(test_value);
 	auto model = get_test_model();
-	test_value->set_value(U("SkinColor"), std::make_shared<odata_enum_value>(model->find_enum_type(U("Color")), U("Red")));
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	test_value->set_value(_XPLATSTR("SkinColor"), ::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("Color")), _XPLATSTR("Red")));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto product = std::make_shared<Product>(service_context);
+	auto product = ::odata::make_shared<Product>(service_context);
 	product->from_value(test_value);
 
 	VERIFY_IS_NOT_NULL(product->get_skincolor());
@@ -445,9 +445,9 @@ TEST(map_enum_to_complex)
 {
 	auto test_value = make_address_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto address = std::make_shared<Address>(service_context);
+	auto address = ::odata::make_shared<Address>(service_context);
 	address->from_value(test_value);
 
 	VERIFY_ARE_EQUAL(address->get_color(), Color::Red);
@@ -457,9 +457,9 @@ TEST(map_collection_enum_to_complex)
 {
 	auto test_value = make_address_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto address = std::make_shared<Address>(service_context);
+	auto address = ::odata::make_shared<Address>(service_context);
 	address->from_value(test_value);
 
 	VERIFY_ARE_EQUAL(address->get_covercolors().size(), 3);
@@ -472,9 +472,9 @@ TEST(map_nullable_enum_to_complex_with_null)
 {
 	auto test_value = make_address_object();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto address = std::make_shared<Address>(service_context);
+	auto address = ::odata::make_shared<Address>(service_context);
 	address->from_value(test_value);
 
 	VERIFY_IS_NULL(address->get_skincolor());
@@ -485,10 +485,10 @@ TEST(map_nullable_enum_to_complex_with_value)
 	auto test_value = make_address_object();
 	VERIFY_IS_NOT_NULL(test_value);
 	auto model = get_test_model();
-	test_value->set_value(U("SkinColor"), std::make_shared<odata_enum_value>(model->find_enum_type(U("Color")), U("Red")));
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	test_value->set_value(_XPLATSTR("SkinColor"), ::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("Color")), _XPLATSTR("Red")));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto address = std::make_shared<Address>(service_context);
+	auto address = ::odata::make_shared<Address>(service_context);
 	address->from_value(test_value);
 
 	VERIFY_IS_NOT_NULL(address->get_skincolor());
@@ -499,41 +499,41 @@ TEST(map_navigation_to_entity)
 {
 	auto test_value = make_account_object_with_navigation();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto account = std::make_shared<Account>(service_context);
+	auto account = ::odata::make_shared<Account>(service_context);
 	account->from_value(test_value);
 
 	auto giftcard = account->get_giftcard();
 	VERIFY_IS_NOT_NULL(giftcard);
-	VERIFY_ARE_EQUAL(giftcard->get_edit_link(), U(""));
+	VERIFY_ARE_EQUAL(giftcard->get_edit_link(), _XPLATSTR(""));
 	VERIFY_ARE_EQUAL(giftcard->get_giftcardid(), 77566);
-	VERIFY_ARE_EQUAL(giftcard->get_giftcardno(), U("@@2232"));
+	VERIFY_ARE_EQUAL(giftcard->get_giftcardno(), _XPLATSTR("@@2232"));
 }
 
 TEST(map_collection_navigation_to_entity)
 {
 	auto test_value = make_account_object_with_navigation();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto account = std::make_shared<Account>(service_context);
+	auto account = ::odata::make_shared<Account>(service_context);
 	account->from_value(test_value);
 
 	auto pis = account->get_mypaymentinstruments();
 	VERIFY_ARE_EQUAL(pis.size(), 2);
-	VERIFY_ARE_EQUAL(pis[0]->get_edit_link(), U(""));
+	VERIFY_ARE_EQUAL(pis[0]->get_edit_link(), _XPLATSTR(""));
 	VERIFY_ARE_EQUAL(pis[0]->get_paymentinstrumentid(), 100000);
-	VERIFY_ARE_EQUAL(pis[0]->get_friendlyname(), U("PI 1"));
+	VERIFY_ARE_EQUAL(pis[0]->get_friendlyname(), _XPLATSTR("PI 1"));
 }
 
 TEST(map_derived_navigation_to_entity)
 {
 	auto test_value = make_account_object_with_navigation();
 	VERIFY_IS_NOT_NULL(test_value);
-	auto service_context = std::make_shared<InMemoryEntities>(U("http://0.0.0.1"));
+	auto service_context = ::odata::make_shared<InMemoryEntities>(_XPLATSTR("http://0.0.0.1"));
 
-	auto account = std::make_shared<Account>(service_context);
+	auto account = ::odata::make_shared<Account>(service_context);
 	account->from_value(test_value);
 
 	auto pis = account->get_mypaymentinstruments();
@@ -541,16 +541,16 @@ TEST(map_derived_navigation_to_entity)
 
 	auto credpi = std::dynamic_pointer_cast<CreditCardPI>(pis[1]);
 	VERIFY_IS_NOT_NULL(credpi);
-	VERIFY_ARE_EQUAL(credpi->get_edit_link(), U("http://0.0.0.1/PaymentInstrument(200000)"));
+	VERIFY_ARE_EQUAL(credpi->get_edit_link(), _XPLATSTR("http://0.0.0.1/PaymentInstrument(200000)"));
 	VERIFY_ARE_EQUAL(credpi->get_paymentinstrumentid(), 200000);
-	VERIFY_ARE_EQUAL(credpi->get_friendlyname(), U("PI 2"));
-	VERIFY_ARE_EQUAL(credpi->get_cardnumber(), U("777777"));
+	VERIFY_ARE_EQUAL(credpi->get_friendlyname(), _XPLATSTR("PI 2"));
+	VERIFY_ARE_EQUAL(credpi->get_cardnumber(), _XPLATSTR("777777"));
 }
 
 class test_service_context : public InMemoryEntities
 {
 public:
-	test_service_context(const ::utility::string_t& baseAddress, client_options options = client_options()) 
+	test_service_context(const ::odata::string_t& baseAddress, client_options options = client_options())
 		: InMemoryEntities(baseAddress, options)
 	{
 		m_model = get_test_model();
@@ -558,79 +558,79 @@ public:
 
 	~test_service_context()
 	{
-		std::wcout << U("destroy test_service_context") << std::endl;
+		std::wcout << _XPLATSTR("destroy test_service_context") << std::endl;
 	}
 };
 
 TEST(get_primitive_value_from_entity_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto account = std::make_shared<Account>(service_context);
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto account = ::odata::make_shared<Account>(service_context);
 	account->set_accountid(1001212);
 
 	auto entity_value = account->to_value();
 	int32_t id;
-	auto ok = entity_value->try_get(U("AccountID"), id);
+	auto ok = entity_value->try_get(_XPLATSTR("AccountID"), id);
 	VERIFY_ARE_EQUAL(ok, true);
 	VERIFY_ARE_EQUAL(id, 1001212);
 }
 
 TEST(get_collection_primitive_value_from_entity_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto account = std::make_shared<Person>(service_context);
-	std::vector<::utility::string_t> numbers;
-	numbers.push_back(U("1"));
-	numbers.push_back(U("2"));
-	numbers.push_back(U("3"));
-	numbers.push_back(U("4"));
-	numbers.push_back(U("567890"));
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto account = ::odata::make_shared<Person>(service_context);
+	std::vector<::odata::string_t> numbers;
+	numbers.push_back(_XPLATSTR("1"));
+	numbers.push_back(_XPLATSTR("2"));
+	numbers.push_back(_XPLATSTR("3"));
+	numbers.push_back(_XPLATSTR("4"));
+	numbers.push_back(_XPLATSTR("567890"));
 	account->set_numbers(numbers);
 
 	auto entity_value = account->to_value();
 	std::shared_ptr<::odata::core::odata_value> value;
-	auto ok = entity_value->get_property_value(U("Numbers"), value);
+	auto ok = entity_value->get_property_value(_XPLATSTR("Numbers"), value);
 	auto collection_value = std::dynamic_pointer_cast<::odata::core::odata_collection_value>(value);
 	VERIFY_IS_NOT_NULL(collection_value);
 	VERIFY_ARE_EQUAL(collection_value->get_collection_values().size(), 5);
 	auto v1 =  std::dynamic_pointer_cast<::odata::core::odata_primitive_value>(collection_value->get_collection_values()[0]);
 	VERIFY_IS_NOT_NULL(v1);
-	VERIFY_ARE_EQUAL(v1->to_string(), U("1"));
+	VERIFY_ARE_EQUAL(v1->to_string(), _XPLATSTR("1"));
 	auto v5 =  std::dynamic_pointer_cast<::odata::core::odata_primitive_value>(collection_value->get_collection_values()[4]);
 	VERIFY_IS_NOT_NULL(v5);
-	VERIFY_ARE_EQUAL(v5->to_string(), U("567890"));
+	VERIFY_ARE_EQUAL(v5->to_string(), _XPLATSTR("567890"));
 }
 
 TEST(get_nullable_primitive_value_from_entity_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto account = std::make_shared<Person>(service_context);
-	account->set_middlename(U("Middle Name"));
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto account = ::odata::make_shared<Person>(service_context);
+	account->set_middlename(_XPLATSTR("Middle Name"));
 
 	auto entity_value = account->to_value();
-	::utility::string_t middlename;
-	auto ok = entity_value->try_get(U("MiddleName"), middlename);
+	::odata::string_t middlename;
+	auto ok = entity_value->try_get(_XPLATSTR("MiddleName"), middlename);
 	VERIFY_ARE_EQUAL(ok, true);
-	VERIFY_ARE_EQUAL(middlename, U("Middle Name"));
+	VERIFY_ARE_EQUAL(middlename, _XPLATSTR("Middle Name"));
 }
 
 TEST(get_primitive_value_from_complex_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto address = std::make_shared<Address>(service_context);
-	address->set_city(U("Shangh Hai"));
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto address = ::odata::make_shared<Address>(service_context);
+	address->set_city(_XPLATSTR("Shangh Hai"));
 
 	auto entity_value = address->to_value();
-	::utility::string_t city;
-	auto ok = entity_value->try_get(U("City"), city);
+	::odata::string_t city;
+	auto ok = entity_value->try_get(_XPLATSTR("City"), city);
 	VERIFY_ARE_EQUAL(ok, true);
-	VERIFY_ARE_EQUAL(city, U("Shangh Hai"));
+	VERIFY_ARE_EQUAL(city, _XPLATSTR("Shangh Hai"));
 }
 
 TEST(get_collection_primitive_value_from_complex_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto address = std::make_shared<Address>(service_context);
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto address = ::odata::make_shared<Address>(service_context);
 	std::vector<int32_t> numbers;
 	numbers.push_back(100);
 	numbers.push_back(2100);
@@ -641,143 +641,143 @@ TEST(get_collection_primitive_value_from_complex_class)
 
 	auto entity_value = address->to_value();
 	std::shared_ptr<::odata::core::odata_value> value;
-	auto ok = entity_value->get_property_value(U("Numbers"), value);
+	auto ok = entity_value->get_property_value(_XPLATSTR("Numbers"), value);
 	auto collection_value = std::dynamic_pointer_cast<::odata::core::odata_collection_value>(value);
 	VERIFY_IS_NOT_NULL(collection_value);
 	VERIFY_ARE_EQUAL(collection_value->get_collection_values().size(), 5);
 	auto v1 =  std::dynamic_pointer_cast<::odata::core::odata_primitive_value>(collection_value->get_collection_values()[0]);
 	VERIFY_IS_NOT_NULL(v1);
-	VERIFY_ARE_EQUAL(v1->to_string(), U("100"));
+	VERIFY_ARE_EQUAL(v1->to_string(), _XPLATSTR("100"));
 	auto v5 =  std::dynamic_pointer_cast<::odata::core::odata_primitive_value>(collection_value->get_collection_values()[4]);
 	VERIFY_IS_NOT_NULL(v5);
-	VERIFY_ARE_EQUAL(v5->to_string(), U("567890"));
+	VERIFY_ARE_EQUAL(v5->to_string(), _XPLATSTR("567890"));
 }
 
 TEST(get_nullable_primitive_value_from_complex_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto address = std::make_shared<Address>(service_context);
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto address = ::odata::make_shared<Address>(service_context);
 	address->set_code(-1231233);
 
 	auto entity_value = address->to_value();
 	int32_t code;
-	auto ok = entity_value->try_get(U("Code"), code);
+	auto ok = entity_value->try_get(_XPLATSTR("Code"), code);
 	VERIFY_ARE_EQUAL(ok, true);
 	VERIFY_ARE_EQUAL(code, -1231233);
 }
 
 TEST(get_complex_value_from_entity_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto account = std::make_shared<Account>(service_context);
-	auto accountinfo = std::make_shared<AccountInfo>(service_context); 
-	accountinfo->set_firstname(U("Leo"));
-	accountinfo->set_lastname(U("Hu"));
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto account = ::odata::make_shared<Account>(service_context);
+	auto accountinfo = ::odata::make_shared<AccountInfo>(service_context);
+	accountinfo->set_firstname(_XPLATSTR("Leo"));
+	accountinfo->set_lastname(_XPLATSTR("Hu"));
 	account->set_accountinfo(accountinfo);
 
 	auto entity_value = account->to_value();
 	std::shared_ptr<::odata::core::odata_value> value;
-	auto ok = entity_value->get_property_value(U("AccountInfo"), value);
+	auto ok = entity_value->get_property_value(_XPLATSTR("AccountInfo"), value);
 	auto complex_value = std::dynamic_pointer_cast<::odata::core::odata_complex_value>(value);
 	VERIFY_IS_NOT_NULL(complex_value);
-	::utility::string_t firstname, lastname;
-	complex_value->try_get(U("FirstName"), firstname);
-	complex_value->try_get(U("LastName"), lastname);
-	VERIFY_ARE_EQUAL(firstname, U("Leo"));
-	VERIFY_ARE_EQUAL(lastname, U("Hu"));
+	::odata::string_t firstname, lastname;
+	complex_value->try_get(_XPLATSTR("FirstName"), firstname);
+	complex_value->try_get(_XPLATSTR("LastName"), lastname);
+	VERIFY_ARE_EQUAL(firstname, _XPLATSTR("Leo"));
+	VERIFY_ARE_EQUAL(lastname, _XPLATSTR("Hu"));
 }
 
 TEST(get_derived_complex_value_from_entity_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto account = std::make_shared<Account>(service_context);
-	auto  vipinfo = std::make_shared<VipAccountInfo>(service_context);
-	vipinfo->set_firstname(U("Leo"));
-	vipinfo->set_lastname(U("Hu"));
-	vipinfo->set_vipinfo(U("Gold"));
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto account = ::odata::make_shared<Account>(service_context);
+	auto  vipinfo = ::odata::make_shared<VipAccountInfo>(service_context);
+	vipinfo->set_firstname(_XPLATSTR("Leo"));
+	vipinfo->set_lastname(_XPLATSTR("Hu"));
+	vipinfo->set_vipinfo(_XPLATSTR("Gold"));
 	account->set_vipinfo(vipinfo);
 
 	auto entity_value = account->to_value();
 	std::shared_ptr<::odata::core::odata_value> value;
-	auto ok = entity_value->get_property_value(U("VIPAccountInfo"), value);
+	auto ok = entity_value->get_property_value(_XPLATSTR("VIPAccountInfo"), value);
 	auto complex_value = std::dynamic_pointer_cast<::odata::core::odata_complex_value>(value);
 	VERIFY_IS_NOT_NULL(complex_value);
-	::utility::string_t firstname, lastname, vip;
-	complex_value->try_get(U("FirstName"), firstname);
-	complex_value->try_get(U("LastName"), lastname);
-	complex_value->try_get(U("VIP_Info"), vip);
-	VERIFY_ARE_EQUAL(firstname, U("Leo"));
-	VERIFY_ARE_EQUAL(lastname, U("Hu"));
-	VERIFY_ARE_EQUAL(vip, U("Gold"));
+	::odata::string_t firstname, lastname, vip;
+	complex_value->try_get(_XPLATSTR("FirstName"), firstname);
+	complex_value->try_get(_XPLATSTR("LastName"), lastname);
+	complex_value->try_get(_XPLATSTR("VIP_Info"), vip);
+	VERIFY_ARE_EQUAL(firstname, _XPLATSTR("Leo"));
+	VERIFY_ARE_EQUAL(lastname, _XPLATSTR("Hu"));
+	VERIFY_ARE_EQUAL(vip, _XPLATSTR("Gold"));
 }
 
 TEST(get_collection_complex_value_from_entity_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto employee = std::make_shared<Employee>(service_context);
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto employee = ::odata::make_shared<Employee>(service_context);
   	std::vector<std::shared_ptr<Address>> addresses;
-	auto address_1 = std::make_shared<Address>(service_context);
-	address_1->set_street(U("zixinglu"));
+	auto address_1 = ::odata::make_shared<Address>(service_context);
+	address_1->set_street(_XPLATSTR("zixinglu"));
 	addresses.push_back(address_1);
-	auto address_2 = std::make_shared<Address>(service_context);
-	address_2->set_street(U("dongchuanlu"));
+	auto address_2 = ::odata::make_shared<Address>(service_context);
+	address_2->set_street(_XPLATSTR("dongchuanlu"));
 	addresses.push_back(address_2);
-	employee->set_addresses(addresses); 
+	employee->set_addresses(addresses);
 
 	auto entity_value = employee->to_value();
 	std::shared_ptr<::odata::core::odata_value> value;
-	auto ok = entity_value->get_property_value(U("WorkAddresses"), value);
+	auto ok = entity_value->get_property_value(_XPLATSTR("WorkAddresses"), value);
 	auto collection_value = std::dynamic_pointer_cast<::odata::core::odata_collection_value>(value);
 	VERIFY_IS_NOT_NULL(collection_value);
 	VERIFY_ARE_EQUAL(collection_value->get_collection_values().size(), 2);
-	::utility::string_t street;
+	::odata::string_t street;
 	auto c1 =  std::dynamic_pointer_cast<::odata::core::odata_complex_value>(collection_value->get_collection_values()[0]);
 	VERIFY_IS_NOT_NULL(c1);
-	c1->try_get(U("Street"), street);
-	VERIFY_ARE_EQUAL(street, U("zixinglu"));
+	c1->try_get(_XPLATSTR("Street"), street);
+	VERIFY_ARE_EQUAL(street, _XPLATSTR("zixinglu"));
 	auto c2 =  std::dynamic_pointer_cast<::odata::core::odata_complex_value>(collection_value->get_collection_values()[1]);
 	VERIFY_IS_NOT_NULL(c2);
-	c2->try_get(U("Street"), street);
-	VERIFY_ARE_EQUAL(street, U("dongchuanlu"));
+	c2->try_get(_XPLATSTR("Street"), street);
+	VERIFY_ARE_EQUAL(street, _XPLATSTR("dongchuanlu"));
 }
 
 TEST(get_nullable_complex_value_from_entity_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto person = std::make_shared<Person>(service_context);
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto person = ::odata::make_shared<Person>(service_context);
   	std::vector<std::shared_ptr<Address>> addresses;
-	auto address = std::make_shared<Address>(service_context);
-	address->set_street(U("zixinglu 999"));
+	auto address = ::odata::make_shared<Address>(service_context);
+	address->set_street(_XPLATSTR("zixinglu 999"));
 	person->set_address(address);
 
 	auto entity_value = person->to_value();
 	std::shared_ptr<::odata::core::odata_value> value;
-	auto ok = entity_value->get_property_value(U("HomeAddress"), value);
+	auto ok = entity_value->get_property_value(_XPLATSTR("HomeAddress"), value);
 	auto complex_value = std::dynamic_pointer_cast<::odata::core::odata_complex_value>(value);
 	VERIFY_IS_NOT_NULL(complex_value);
-	::utility::string_t street;
-	complex_value->try_get(U("Street"), street);
-	VERIFY_ARE_EQUAL(street, U("zixinglu 999"));
+	::odata::string_t street;
+	complex_value->try_get(_XPLATSTR("Street"), street);
+	VERIFY_ARE_EQUAL(street, _XPLATSTR("zixinglu 999"));
 }
 
 TEST(get_enum_value_from_entity_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto product = std::make_shared<Product>(service_context);
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto product = ::odata::make_shared<Product>(service_context);
 	product->set_useraccess(AccessLevel::Write);
 
 	auto entity_value = product->to_value();
 	std::shared_ptr<::odata::core::odata_value> value;
-	auto ok = entity_value->get_property_value(U("UserAccess"), value);
+	auto ok = entity_value->get_property_value(_XPLATSTR("UserAccess"), value);
 	auto enum_value = std::dynamic_pointer_cast<::odata::core::odata_enum_value>(value);
 	VERIFY_IS_NOT_NULL(enum_value);
-	VERIFY_ARE_EQUAL(enum_value->to_string(), U("Write"));
+	VERIFY_ARE_EQUAL(enum_value->to_string(), _XPLATSTR("Write"));
 }
 
 TEST(get_collection_enum_value_from_entity_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto product = std::make_shared<Product>(service_context);
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto product = ::odata::make_shared<Product>(service_context);
 	std::vector<Color> colors;
 	colors.push_back(Color::Red);
 	colors.push_back(Color::Blue);
@@ -785,49 +785,49 @@ TEST(get_collection_enum_value_from_entity_class)
 
 	auto entity_value = product->to_value();
 	std::shared_ptr<::odata::core::odata_value> value;
-	auto ok = entity_value->get_property_value(U("CoverColors"), value);
+	auto ok = entity_value->get_property_value(_XPLATSTR("CoverColors"), value);
 	auto collection_value = std::dynamic_pointer_cast<::odata::core::odata_collection_value>(value);
 	VERIFY_IS_NOT_NULL(collection_value);
 	VERIFY_ARE_EQUAL(collection_value->get_collection_values().size(), 2);
 	auto e1 =  std::dynamic_pointer_cast<::odata::core::odata_enum_value>(collection_value->get_collection_values()[0]);
 	VERIFY_ARE_EQUAL(e1->get_value_type()->get_type_kind(), edm_type_kind_t::Enum);
-	VERIFY_ARE_EQUAL(e1->to_string(), U("Red"));
+	VERIFY_ARE_EQUAL(e1->to_string(), _XPLATSTR("Red"));
 	auto e2 =  std::dynamic_pointer_cast<::odata::core::odata_enum_value>(collection_value->get_collection_values()[1]);
-	VERIFY_ARE_EQUAL(e2->to_string(), U("Blue"));
+	VERIFY_ARE_EQUAL(e2->to_string(), _XPLATSTR("Blue"));
 }
 
 TEST(get_nullable_enum_value_from_entity_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto product = std::make_shared<Product>(service_context);
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto product = ::odata::make_shared<Product>(service_context);
 	product->set_skincolor(Color::Green);
 
 	auto entity_value = product->to_value();
 	std::shared_ptr<::odata::core::odata_value> value;
-	auto ok = entity_value->get_property_value(U("SkinColor"), value);
+	auto ok = entity_value->get_property_value(_XPLATSTR("SkinColor"), value);
 	auto enum_value = std::dynamic_pointer_cast<::odata::core::odata_enum_value>(value);
 	VERIFY_IS_NOT_NULL(enum_value);
-	VERIFY_ARE_EQUAL(enum_value->to_string(), U("Green"));
+	VERIFY_ARE_EQUAL(enum_value->to_string(), _XPLATSTR("Green"));
 }
 
 TEST(get_enum_value_from_complex_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto address = std::make_shared<Address>(service_context);
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto address = ::odata::make_shared<Address>(service_context);
 	address->set_color(Color::Red);
 
 	auto entity_value = address->to_value();
 	std::shared_ptr<::odata::core::odata_value> value;
-	auto ok = entity_value->get_property_value(U("Color"), value);
+	auto ok = entity_value->get_property_value(_XPLATSTR("Color"), value);
 	auto enum_value = std::dynamic_pointer_cast<::odata::core::odata_enum_value>(value);
 	VERIFY_IS_NOT_NULL(enum_value);
-	VERIFY_ARE_EQUAL(enum_value->to_string(), U("Red"));
+	VERIFY_ARE_EQUAL(enum_value->to_string(), _XPLATSTR("Red"));
 }
 
 TEST(get_collection_enum_value_from_complex_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto address = std::make_shared<Address>(service_context);
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto address = ::odata::make_shared<Address>(service_context);
 	std::vector<Color> colors;
 	colors.push_back(Color::Red);
 	colors.push_back(Color::Blue);
@@ -835,103 +835,103 @@ TEST(get_collection_enum_value_from_complex_class)
 
 	auto entity_value = address->to_value();
 	std::shared_ptr<::odata::core::odata_value> value;
-	auto ok = entity_value->get_property_value(U("CoverColors"), value);
+	auto ok = entity_value->get_property_value(_XPLATSTR("CoverColors"), value);
 	auto collection_value = std::dynamic_pointer_cast<::odata::core::odata_collection_value>(value);
 	VERIFY_IS_NOT_NULL(collection_value);
 	VERIFY_ARE_EQUAL(collection_value->get_collection_values().size(), 2);
 	auto e1 =  std::dynamic_pointer_cast<::odata::core::odata_enum_value>(collection_value->get_collection_values()[0]);
-	VERIFY_ARE_EQUAL(e1->to_string(), U("Red"));
+	VERIFY_ARE_EQUAL(e1->to_string(), _XPLATSTR("Red"));
 	auto e2 =  std::dynamic_pointer_cast<::odata::core::odata_enum_value>(collection_value->get_collection_values()[1]);
-	VERIFY_ARE_EQUAL(e2->to_string(), U("Blue"));
+	VERIFY_ARE_EQUAL(e2->to_string(), _XPLATSTR("Blue"));
 }
 
 TEST(get_nullable_enum_value_from_complex_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto address = std::make_shared<Address>(service_context);
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto address = ::odata::make_shared<Address>(service_context);
 	address->set_skincolor(Color::Green);
 
 	auto entity_value = address->to_value();
 	std::shared_ptr<::odata::core::odata_value> value;
-	auto ok = entity_value->get_property_value(U("SkinColor"), value);
+	auto ok = entity_value->get_property_value(_XPLATSTR("SkinColor"), value);
 	auto enum_value = std::dynamic_pointer_cast<::odata::core::odata_enum_value>(value);
 	VERIFY_IS_NOT_NULL(enum_value);
-	VERIFY_ARE_EQUAL(enum_value->to_string(), U("Green"));
+	VERIFY_ARE_EQUAL(enum_value->to_string(), _XPLATSTR("Green"));
 }
 
 TEST(get_key_string_with_one_key)
 {
-    auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto product = std::make_shared<Product>(service_context);
+    auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto product = ::odata::make_shared<Product>(service_context);
 	product->set_productid(10001);
 
 	auto key_string = product->get_key_property_string();
-	VERIFY_ARE_EQUAL(key_string, U("10001"));
+	VERIFY_ARE_EQUAL(key_string, _XPLATSTR("10001"));
 }
 
 TEST(get_key_string_with_double_key)
 {
-    auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto productdetail = std::make_shared<ProductDetail>(service_context);
+    auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto productdetail = ::odata::make_shared<ProductDetail>(service_context);
 	productdetail->set_productid(10001);
 	productdetail->set_productdetailedid(20002);
 
 	auto key_string = productdetail->get_key_property_string();
-	VERIFY_ARE_EQUAL(key_string, U("ProductID=10001,ProductDetailID=20002"));
+	VERIFY_ARE_EQUAL(key_string, _XPLATSTR("ProductID=10001,ProductDetailID=20002"));
 }
 
 TEST(get_key_string_with_one_key_from_base_class)
 {
-    auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto employee = std::make_shared<Employee>(service_context);
+    auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto employee = ::odata::make_shared<Employee>(service_context);
 	employee->set_personid(10101);
 
 	auto key_string = employee->get_key_property_string();
-	VERIFY_ARE_EQUAL(key_string, U("10101"));
+	VERIFY_ARE_EQUAL(key_string, _XPLATSTR("10101"));
 }
 
 TEST(get_double_key_string_with_one_key_from_base_class)
 {
-    auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto customer = std::make_shared<Customer>(service_context);
+    auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto customer = ::odata::make_shared<Customer>(service_context);
 	customer->set_personid(10101);
-	customer->set_city(U("Shang Hai"));
+	customer->set_city(_XPLATSTR("Shang Hai"));
 
 	auto key_string = customer->get_key_property_string();
-	VERIFY_ARE_EQUAL(key_string, U("PersonID=10101,City=Shang Hai"));
+	VERIFY_ARE_EQUAL(key_string, _XPLATSTR("PersonID=10101,City=Shang Hai"));
 }
 
 TEST(get_fourfold_key_string_with_two_key_from_base_class)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1"));
-	auto vip = std::make_shared<VipCustomer>(service_context);
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto vip = ::odata::make_shared<VipCustomer>(service_context);
 	vip->set_personid(10101);
-	vip->set_city(U("Shang Hai"));
+	vip->set_city(_XPLATSTR("Shang Hai"));
 	vip->set_vipid(70000);
-	vip->set_viptype(U("Gold"));
+	vip->set_viptype(_XPLATSTR("Gold"));
 
 	auto key_string = vip->get_key_property_string();
-	VERIFY_ARE_EQUAL(key_string, U("PersonID=10101,City=Shang HaiVIPID=70000,VIPType=Gold"));
+	VERIFY_ARE_EQUAL(key_string, _XPLATSTR("PersonID=10101,City=Shang HaiVIPID=70000,VIPType=Gold"));
 }
 
 TEST (change_entity_mapping_array)
 {
-	auto service_context = std::make_shared<test_service_context>(U("http://0.0.0.1")); 
-	auto vip = std::make_shared<VipCustomer>(service_context);
+	auto service_context = ::odata::make_shared<test_service_context>(_XPLATSTR("http://0.0.0.1"));
+	auto vip = ::odata::make_shared<VipCustomer>(service_context);
 	vip->set_personid(10101);
-	vip->set_city(U("Shang Hai"));
+	vip->set_city(_XPLATSTR("Shang Hai"));
 	vip->set_vipid(70000);
-	vip->set_viptype(U("Gold"));
+	vip->set_viptype(_XPLATSTR("Gold"));
 
-	auto vip2 = std::make_shared<VipCustomer>(service_context);
+	auto vip2 = ::odata::make_shared<VipCustomer>(service_context);
 	vip2->set_personid(10102);
-	vip2->set_city(U("Shen Yang"));
+	vip2->set_city(_XPLATSTR("Shen Yang"));
 	vip2->set_vipid(90000);
-	vip2->set_viptype(U("White Gold"));
+	vip2->set_viptype(_XPLATSTR("White Gold"));
 
-	PROPMAP_ENTRY_IN_ENTITY _to_entity_map[] = 
+	PROPMAP_ENTRY_IN_ENTITY _to_entity_map[] =
 	{
-		{(PROP_MAP_CALL_IN_ENTITY)0} 
+		{(PROP_MAP_CALL_IN_ENTITY)0}
 	};
 
 	auto vip_map = vip->get_to_entity_map();
@@ -946,26 +946,26 @@ TEST (change_entity_mapping_array)
 	vip->set_to_entity_map(vip_map);
 	entity_value = vip->to_value();
 	VERIFY_ARE_EQUAL(entity_value->properties().size(), 3);
-	::utility::string_t vip_type;
-	entity_value->try_get(U("VIPType"), vip_type);
-	VERIFY_ARE_EQUAL(vip_type, U("Gold"));
+	::odata::string_t vip_type;
+	entity_value->try_get(_XPLATSTR("VIPType"), vip_type);
+	VERIFY_ARE_EQUAL(vip_type, _XPLATSTR("Gold"));
 
 	(std::dynamic_pointer_cast<Customer>(vip))->set_to_entity_map(customer_map);
 	entity_value = vip->to_value();
 	VERIFY_ARE_EQUAL(entity_value->properties().size(), 4);
-	VERIFY_ARE_EQUAL(entity_value->has_property(U("PersonID")), false);
+	VERIFY_ARE_EQUAL(entity_value->has_property(_XPLATSTR("PersonID")), false);
 
 	(std::dynamic_pointer_cast<Person>(vip))->set_to_entity_map(person_map);
 	entity_value = vip->to_value();
 	VERIFY_ARE_EQUAL(entity_value->properties().size(), 8);
 	int32_t persion_id;
-	entity_value->try_get(U("PersonID"), persion_id);
+	entity_value->try_get(_XPLATSTR("PersonID"), persion_id);
 	VERIFY_ARE_EQUAL(persion_id, 10101);
 
 	auto entity_value_2 = vip2->to_value();
 	VERIFY_ARE_EQUAL(entity_value_2->properties().size(), 8);
-	entity_value_2->try_get(U("VIPType"), vip_type);
-	VERIFY_ARE_EQUAL(vip_type, U("White Gold"));
+	entity_value_2->try_get(_XPLATSTR("VIPType"), vip_type);
+	VERIFY_ARE_EQUAL(vip_type, _XPLATSTR("White Gold"));
 }
 
 }

--- a/tests/functional/codegen_test/codegen_test_service.cpp
+++ b/tests/functional/codegen_test/codegen_test_service.cpp
@@ -7,7 +7,7 @@
 #include "codegen_test_service.h"
 #include "odata/core/odata_json_writer.h"
 
-namespace tests { namespace functional { namespace _odata { 
+namespace tests { namespace functional { namespace _odata {
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, productid, ProductID, int32_t);
 IMPLEMENT_ENUM_PROPERTY_IN_ENTITY_MAPPING(Product, useraccess, UserAccess, AccessLevel);
@@ -17,23 +17,23 @@ IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, pic, Picture, std::vecto
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, nullpic, NullPicture, std::vector<unsigned char>);
 
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo, firstname, FirstName, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo, lastname, LastName, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo, firstname, FirstName, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo, lastname, LastName, ::odata::string_t);
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, giftcardid, GiftCardID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, giftcardno, GiftCardNO, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, giftcardno, GiftCardNO, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, amount, Amount, double);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, experationdate, ExperationDate, ::utility::datetime);
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PaymentInstrument, paymentinstrumentid, PaymentInstrumentID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PaymentInstrument, friendlyname, FriendlyName, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PaymentInstrument, friendlyname, FriendlyName, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PaymentInstrument, createdate, CreatedDate, ::utility::datetime);
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, cardnumber, CardNumber, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, cvv, CVV, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, cardnumber, CardNumber, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, cvv, CVV, ::odata::string_t);
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Account, accountid, AccountID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Account, countryregion, CountryRegion, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Account, countryregion, CountryRegion, ::odata::string_t);
 IMPLEMENT_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Account, accountinfo, AccountInfo, AccountInfo);
 IMPLEMENT_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Account, vipinfo, VIPAccountInfo, VipAccountInfo);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Account, giftcard, MyGiftCard, GiftCard);
@@ -42,33 +42,33 @@ IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Account, mypaymentins
 void Account::get_mypaymentinstruments_from_entity(const shared_ptr<::odata::core::odata_entity_value>& pentity)
 {
     std::shared_ptr<::odata::core::odata_value> property_value;
-    
+
     if (!pentity->get_property_value(L"MyPaymentInstruments", property_value) || !property_value)
     { return ; }
-    
+
     auto property_collection_value = static_pointer_cast<::odata::core::odata_collection_value>(property_value);
     if (!property_collection_value) { return ; }
-    
+
     for (auto iter = property_collection_value->get_collection_values().cbegin(); iter != property_collection_value->get_collection_values().cend(); iter++)
     {
         auto entity_value = std::dynamic_pointer_cast<::odata::core::odata_entity_value>(*iter);
         if (!entity_value) { continue ; }
-        ::utility::string_t real_type_name = entity_value->get_value_type()->get_name();
-        ::utility::string_t expected_type_name = PaymentInstrument::get_type_name();
+        ::odata::string_t real_type_name = entity_value->get_value_type()->get_name();
+        ::odata::string_t expected_type_name = PaymentInstrument::get_type_name();
         if (expected_type_name != real_type_name)
         {
             auto create_pfn = PaymentInstrument::_derived_entity_creator_map[real_type_name];
             if (!create_pfn) return ;
-            
+
             auto p_derived = (*create_pfn)(m_service_context);
             if (!p_derived) return ;
-            p_derived->set_edit_link(odata_entity_model_builder::compute_edit_link(get_root_url(), entity_value, m_edit_link + U("/MyPaymentInstruments"), true));
+            p_derived->set_edit_link(odata_entity_model_builder::compute_edit_link(get_root_url(), entity_value, m_edit_link + _XPLATSTR("/MyPaymentInstruments"), true));
             p_derived->from_value(entity_value); mypaymentinstruments.push_back(std::dynamic_pointer_cast<PaymentInstrument>(p_derived));
         }
         else
         {
-            auto collection_element = std::make_shared<PaymentInstrument>(m_service_context);
-            collection_element->set_edit_link(odata_entity_model_builder::compute_edit_link(get_root_url(), entity_value, m_edit_link + U("/") + U("MyPaymentInstruments"), true));
+            auto collection_element = ::odata::make_shared<PaymentInstrument>(m_service_context);
+            collection_element->set_edit_link(odata_entity_model_builder::compute_edit_link(get_root_url(), entity_value, m_edit_link + _XPLATSTR("/") + _XPLATSTR("MyPaymentInstruments"), true));
             collection_element->from_value(entity_value);
             mypaymentinstruments.push_back(collection_element);
         }
@@ -78,15 +78,15 @@ void Account::get_mypaymentinstruments_from_entity(const shared_ptr<::odata::cor
 {
     if (m_service_context)
     {
-        ::utility::string_t path = m_service_context->get_relative_path(m_edit_link) + L"/" + L"MyPaymentInstruments";
-        ::utility::string_t edit_link = m_edit_link + L"/" + L"MyPaymentInstruments";
+        ::odata::string_t path = m_service_context->get_relative_path(m_edit_link) + L"/" + L"MyPaymentInstruments";
+        ::odata::string_t edit_link = m_edit_link + L"/" + L"MyPaymentInstruments";
         auto query = m_service_context->create_query<odata_entityset_query_executor<PaymentInstrument>, odata_query_builder>(path);
         if (builder) { query->set_query_builder(builder); }
         return query->execute_query().then( [this, edit_link] (const std::vector<std::shared_ptr<PaymentInstrument>>& ret_values) -> void
         {
             for (auto iter = ret_values.cbegin(); iter != ret_values.cend(); iter++)
             {
-                ::utility::string_t edit_link_placeholder = L"{edit_link}";
+                ::odata::string_t edit_link_placeholder = L"{edit_link}";
                 if ((*iter)->get_edit_link().empty() || (*iter)->get_edit_link().substr(0, edit_link_placeholder.size()) == edit_link_placeholder)
                 {
                     if ((*iter)->get_edit_link().empty()) { (*iter)->set_edit_link(edit_link + L"(" + (*iter)->get_key_property_string() + L")");
@@ -100,11 +100,11 @@ void Account::get_mypaymentinstruments_from_entity(const shared_ptr<::odata::cor
     return ::pplx::task_from_result();
 };
 */
-    
-    
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, street, Street, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, city, City, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, postalcode, PostalCode, ::utility::string_t);
+
+
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, street, Street, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, city, City, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, postalcode, PostalCode, ::odata::string_t);
 IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, numbers, Numbers, int32_t);
 IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, code, Code, int32_t);
 IMPLEMENT_ENUM_PROPERTY_IN_COMPLEX_MAPPING(Address, color, Color, Color);
@@ -112,43 +112,43 @@ IMPLEMENT_COLLECTION_ENUM_PROPERTY_IN_COMPLEX_MAPPING(Address, covercolors, Cove
 IMPLEMENT_NULLABLE_ENUM_PROPERTY_IN_COMPLEX_MAPPING(Address, skincolor, SkinColor, Color);
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, personid, PersonID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, firstname, FirstName, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, lastname, LastName, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, middlename, MiddleName, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, firstname, FirstName, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, lastname, LastName, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, middlename, MiddleName, ::odata::string_t);
 IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Person, address, HomeAddress, Address);
-IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, numbers, Numbers, ::utility::string_t);
-IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, emails, Emails, ::utility::string_t);
+IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, numbers, Numbers, ::odata::string_t);
+IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, emails, Emails, ::odata::string_t);
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Employee, datehired, DateHired, ::utility::datetime);
 IMPLEMENT_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Employee, addresses, WorkAddresses, Address);
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Customer, city, City, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Customer, city, City, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Customer, birthday, Birthday, ::utility::datetime);
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, productid, ProductID, int32_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, productdetailedid, ProductDetailID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, productname, ProductName, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, description, Description, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, productname, ProductName, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, description, Description, ::odata::string_t);
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(VipCustomer, vipid, VIPID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(VipCustomer, viptype, VIPType, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(VipCustomer, viptype, VIPType, ::odata::string_t);
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(VipAccountInfo, vipinfo, VIP_Info, ::utility::string_t);
- //   void VipAccountInfo::get_vipinfo_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) 
-	//{ 
-	//    std::shared_ptr<::odata::core::odata_value> property_value; 
- //       if (!pcomplex->get_property_value(U("VIP_Info"), property_value) || !property_value) 
-	//    { 
-	//		return ; 
-	//	} 
-	//	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value); 
-	//    if (primitive_value) 
-	//    { 
- //           vipinfo = primitive_value->as<::utility::string_t>(); 
- //       } 
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(VipAccountInfo, vipinfo, VIP_Info, ::odata::string_t);
+ //   void VipAccountInfo::get_vipinfo_from_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex)
+	//{
+	//    std::shared_ptr<::odata::core::odata_value> property_value;
+ //       if (!pcomplex->get_property_value(_XPLATSTR("VIP_Info"), property_value) || !property_value)
+	//    {
+	//		return ;
+	//	}
+	//	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value);
+	//    if (primitive_value)
+	//    {
+ //           vipinfo = primitive_value->as<::odata::string_t>();
+ //       }
  //   }
-	//void VipAccountInfo::set_vipinfo_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex) 
-	//{ 
+	//void VipAccountInfo::set_vipinfo_to_complex(const shared_ptr<::odata::core::odata_complex_value>& pcomplex)
+	//{
 	//}
 
 BEGIN_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo)
@@ -310,8 +310,8 @@ BEGIN_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Person)
 END_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Person)
 
 BEGIN_ENTITY_CONSTRUCTOR(Person, type_base)
-    ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(middlename, nullptr) 
-    ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(address, nullptr)   
+    ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(middlename, nullptr)
+    ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(address, nullptr)
 END_ENTITY_CONSTRUCTOR(Person, type_base)
 
 BEGIN_ENTITY_DESTRUCTOR(Person)
@@ -339,9 +339,9 @@ BEGIN_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Product)
 END_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Product)
 
 BEGIN_ENTITY_CONSTRUCTOR(Product, type_base)
-    ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(useraccess, AccessLevel::None) 
-    ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(skincolor, nullptr)  
-    ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(productid, 0)  
+    ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(useraccess, AccessLevel::None)
+    ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(skincolor, nullptr)
+    ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(productid, 0)
 END_ENTITY_CONSTRUCTOR(Product, type_base)
 
 BEGIN_ENTITY_DESTRUCTOR(Product)

--- a/tests/functional/codegen_test/codegen_test_service.h
+++ b/tests/functional/codegen_test/codegen_test_service.h
@@ -21,7 +21,7 @@ using namespace ::odata::core;
 using namespace ::odata::edm;
 using namespace ::odata::codegen;
 
-namespace tests { namespace functional { namespace _odata { 
+namespace tests { namespace functional { namespace _odata {
 
 enum AccessLevel
 {
@@ -43,10 +43,10 @@ enum Color
 class enum_type_resolver
 {
 public:
-    DECLARE_FUNCTION_ENUM_TYPE_FROM_STRING(AccessLevel);
-    DECLARE_FUNCTION_STRING_FROM_ENUM_TYPE(AccessLevel);
-    DECLARE_FUNCTION_ENUM_TYPE_FROM_STRING(Color);
-    DECLARE_FUNCTION_STRING_FROM_ENUM_TYPE(Color);
+	DECLARE_FUNCTION_ENUM_TYPE_FROM_STRING(AccessLevel);
+	DECLARE_FUNCTION_STRING_FROM_ENUM_TYPE(AccessLevel);
+	DECLARE_FUNCTION_ENUM_TYPE_FROM_STRING(Color);
+	DECLARE_FUNCTION_STRING_FROM_ENUM_TYPE(Color);
 };
 
 class Product : public type_base
@@ -60,9 +60,9 @@ public:
 	DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, ProductID, productid);
 
 	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productid, ProductID, int32_t);
-	// enum 
+	// enum
 	DECLARE_ENUM_PROPERTY_IN_ENTITY_MAPPING(useraccess, UserAccess, AccessLevel);
-	// collection of enum 
+	// collection of enum
 	DECLARE_COLLECTION_ENUM_PROPERTY_IN_ENTITY_MAPPING(covercolors, CoverColors, Color);
 	// nullable enum
 	DECLARE_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(skincolor, SkinColor, Color);
@@ -79,8 +79,8 @@ public:
 	DECLARE_EDM_INFO();
 	ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-	DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(firstname, FirstName, ::utility::string_t);
-	DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(lastname, LastName, ::utility::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(firstname, FirstName, ::odata::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(lastname, LastName, ::odata::string_t);
 
 	// todo add support for enum in complex type
 };
@@ -92,7 +92,7 @@ public:
 	DECLARE_EDM_INFO();
 	ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-	DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(vipinfo, VIP_Info, ::utility::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(vipinfo, VIP_Info, ::odata::string_t);
 };
 
 class GiftCard : public type_base
@@ -105,7 +105,7 @@ public:
 	DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, GiftCardID, giftcardid);
 
 	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(giftcardid, GiftCardID, int32_t);
-	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(giftcardno, GiftCardNO, ::utility::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(giftcardno, GiftCardNO, ::odata::string_t);
 	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(amount, Amount, double);
 	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(experationdate, ExperationDate, ::utility::datetime);
 };
@@ -120,7 +120,7 @@ public:
 	DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, PaymentInstrumentID, paymentinstrumentid);
 
 	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(paymentinstrumentid, PaymentInstrumentID, int32_t);
-	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(friendlyname, FriendlyName, ::utility::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(friendlyname, FriendlyName, ::odata::string_t);
 	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(createdate, CreatedDate, ::utility::datetime);
 };
 
@@ -133,8 +133,8 @@ public:
 
 	DECLARE_GET_KEY_PROPERTY_STRING_NO_PARAM(PaymentInstrument);
 
-	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(cardnumber, CardNumber, ::utility::string_t);
-	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(cvv, CVV, ::utility::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(cardnumber, CardNumber, ::odata::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(cvv, CVV, ::odata::string_t);
 
 	// todo support navigation in navigation
 };
@@ -144,13 +144,13 @@ class Account : public type_base
 public:
 	DECLARE_ENTITY_CONSTRUCTOR(Account);
 	DECLARE_EDM_INFO();
-    ENABLE_PROPERTY_IN_ENTITY_MAPPING();
+	ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
 	DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, AccountID, accountid);
 
 	// primitive property
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(accountid, AccountID, int32_t);
-	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(countryregion, CountryRegion, ::utility::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(accountid, AccountID, int32_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(countryregion, CountryRegion, ::odata::string_t);
 	// complex property
 	DECLARE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(accountinfo, AccountInfo, AccountInfo);
 	DECLARE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(vipinfo, VIPAccountInfo, VipAccountInfo);
@@ -159,7 +159,7 @@ public:
 	// collection of navigation property
 	DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(mypaymentinstruments, MyPaymentInstruments, PaymentInstrument);
 
-	// todo add support for collection of complex 
+	// todo add support for collection of complex
 };
 
 class Address : public type_base
@@ -169,15 +169,15 @@ public:
 	DECLARE_COMPLEX_DESTRUCTOR(Address);
 	DECLARE_EDM_INFO();
 	ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
-	DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(street, Street, ::utility::string_t);
-	DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(city, City, ::utility::string_t);
-	DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(postalcode, PostalCode, ::utility::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(street, Street, ::odata::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(city, City, ::odata::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(postalcode, PostalCode, ::odata::string_t);
 	DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(numbers, Numbers, int32_t);
 	DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(code, Code, int32_t);
 
-	// enum 
+	// enum
 	DECLARE_ENUM_PROPERTY_IN_COMPLEX_MAPPING(color, Color, Color);
-	// collection of enum 
+	// collection of enum
 	DECLARE_COLLECTION_ENUM_PROPERTY_IN_COMPLEX_MAPPING(covercolors, CoverColors, Color);
 	// nullable enum
 	DECLARE_NULLABLE_ENUM_PROPERTY_IN_COMPLEX_MAPPING(skincolor, SkinColor, Color);
@@ -193,17 +193,17 @@ public:
 
 	DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, PersonID, personid);
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(personid, PersonID, int32_t);
-	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(firstname, FirstName, ::utility::string_t);
-	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(lastname, LastName, ::utility::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(personid, PersonID, int32_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(firstname, FirstName, ::odata::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(lastname, LastName, ::odata::string_t);
 
 	// nullable property
-	DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(middlename, MiddleName, ::utility::string_t);
+	DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(middlename, MiddleName, ::odata::string_t);
 	DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(address, HomeAddress, Address);
 
 	// collection of primitive
-	DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(numbers, Numbers, ::utility::string_t);
-	DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(emails, Emails, ::utility::string_t);
+	DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(numbers, Numbers, ::odata::string_t);
+	DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(emails, Emails, ::odata::string_t);
 };
 
 class Employee : public Person
@@ -228,7 +228,7 @@ public:
 
 	DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(Person, City, city)
 
-	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(city, City, ::utility::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(city, City, ::odata::string_t);
 	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(birthday, Birthday, ::utility::datetime);
 };
 
@@ -241,8 +241,8 @@ public:
 
 	DECLARE_GET_KEY_PROPERTY_STRING_TWO_PARAM(Customer, VIPID, vipid, VIPType, viptype);
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(vipid, VIPID, int32_t);
-	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(viptype, VIPType, ::utility::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(vipid, VIPID, int32_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(viptype, VIPType, ::odata::string_t);
 };
 
 class ProductDetail : public type_base
@@ -254,38 +254,38 @@ public:
 
 	DECLARE_GET_KEY_PROPERTY_STRING_TWO_PARAM(type_base,  ProductID, productid, ProductDetailID, productdetailedid);
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productid, ProductID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productdetailedid, ProductDetailID, int32_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productid, ProductID, int32_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productdetailedid, ProductDetailID, int32_t);
 
-	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productname, ProductName, ::utility::string_t);
-	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(description, Description, ::utility::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productname, ProductName, ::odata::string_t);
+	DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(description, Description, ::odata::string_t);
 };
 
 class InMemoryEntities : public odata_service_context
 {
 public:
-	InMemoryEntities(const ::utility::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)
+	InMemoryEntities(const ::odata::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)
 	{
 	}
 
-	std::shared_ptr<odata_service_query<odata_entityset_query_executor<Product>, odata_query_builder>> create_products_query() 
-	{ 
-		return create_query<odata_entityset_query_executor<Product>, odata_query_builder>(U("Products"));
-	}
-
-	std::shared_ptr<odata_service_query<odata_entityset_query_executor<Person>, odata_query_builder>> create_people_query() 
-	{ 
-		return create_query<odata_entityset_query_executor<Person>, odata_query_builder>(U("People"));
-	}
-
-	std::shared_ptr<odata_service_query<odata_entityset_query_executor<Account>, odata_query_builder>> create_accounts_query() 
-	{ 
-		return create_query<odata_entityset_query_executor<Account>, odata_query_builder>(U("Accounts"));
-	}
-
-	::web::http::status_code add_account_object(std::shared_ptr<Account> account_object)
+	std::shared_ptr<odata_service_query<odata_entityset_query_executor<Product>, odata_query_builder>> create_products_query()
 	{
-		return m_client->create_entity(U("Accounts"), std::dynamic_pointer_cast<odata_entity_value>(account_object->to_value())).get();
+		return create_query<odata_entityset_query_executor<Product>, odata_query_builder>(_XPLATSTR("Products"));
+	}
+
+	std::shared_ptr<odata_service_query<odata_entityset_query_executor<Person>, odata_query_builder>> create_people_query()
+	{
+		return create_query<odata_entityset_query_executor<Person>, odata_query_builder>(_XPLATSTR("People"));
+	}
+
+	std::shared_ptr<odata_service_query<odata_entityset_query_executor<Account>, odata_query_builder>> create_accounts_query()
+	{
+		return create_query<odata_entityset_query_executor<Account>, odata_query_builder>(_XPLATSTR("Accounts"));
+	}
+
+	::odata::client::http_result add_account_object(std::shared_ptr<Account> account_object)
+	{
+		return m_client->create_entity(_XPLATSTR("Accounts"), std::dynamic_pointer_cast<odata_entity_value>(account_object->to_value())).get();
 	}
 };
 

--- a/tests/functional/codegen_tool_test/baseline/default_service_test_baseline.cpp
+++ b/tests/functional/codegen_tool_test/baseline/default_service_test_baseline.cpp
@@ -60,8 +60,8 @@ END_COMPLEX_CONSTRUCTOR(AccountInfo, type_base)
 BEGIN_COMPLEX_DESTRUCTOR(AccountInfo)
 END_COMPLEX_DESTRUCTOR(AccountInfo)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo, firstname, FirstName, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo, lastname, LastName, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo, firstname, FirstName, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo, lastname, LastName, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(AccountInfo, Microsoft.Test.OData.Services.ODataWCFService, AccountInfo)
 
@@ -81,9 +81,9 @@ END_COMPLEX_CONSTRUCTOR(Address, type_base)
 BEGIN_COMPLEX_DESTRUCTOR(Address)
 END_COMPLEX_DESTRUCTOR(Address)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, street, Street, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, city, City, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, postalcode, PostalCode, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, street, Street, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, city, City, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(Address, postalcode, PostalCode, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Address, Microsoft.Test.OData.Services.ODataWCFService, Address)
 
@@ -106,7 +106,7 @@ BEGIN_COMPLEX_DESTRUCTOR(HomeAddress)
     ON_PROPERTY_IN_COMPLEX_DESTRUCTOR(familyname)
 END_COMPLEX_DESTRUCTOR(HomeAddress)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(HomeAddress, familyname, FamilyName, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(HomeAddress, familyname, FamilyName, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(HomeAddress, Microsoft.Test.OData.Services.ODataWCFService, HomeAddress)
 
@@ -123,7 +123,7 @@ END_COMPLEX_CONSTRUCTOR(CompanyAddress, Address)
 BEGIN_COMPLEX_DESTRUCTOR(CompanyAddress)
 END_COMPLEX_DESTRUCTOR(CompanyAddress)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(CompanyAddress, companyname, CompanyName, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(CompanyAddress, companyname, CompanyName, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(CompanyAddress, Microsoft.Test.OData.Services.ODataWCFService, CompanyAddress)
 
@@ -141,7 +141,7 @@ END_COMPLEX_CONSTRUCTOR(CityInformation, type_base)
 BEGIN_COMPLEX_DESTRUCTOR(CityInformation)
 END_COMPLEX_DESTRUCTOR(CityInformation)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(CityInformation, countryregion, CountryRegion, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(CityInformation, countryregion, CountryRegion, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(CityInformation, iscapital, IsCapital, bool);
 
 IMPLEMENT_EDM_INFO(CityInformation, Microsoft.Test.OData.Services.ODataWCFService, CityInformation)
@@ -166,12 +166,12 @@ BEGIN_ENTITY_DESTRUCTOR(Person)
 END_ENTITY_DESTRUCTOR(Person)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, personid, PersonID, int32_t);
-IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, numbers, Numbers, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, firstname, FirstName, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, lastname, LastName, ::utility::string_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, middlename, MiddleName, ::utility::string_t);
+IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, numbers, Numbers, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, firstname, FirstName, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, lastname, LastName, ::odata::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, middlename, MiddleName, ::odata::string_t);
 IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Person, homeaddress, HomeAddress, Address);
-IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, emails, Emails, ::utility::string_t);
+IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Person, emails, Emails, ::odata::string_t);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Person, parent, Parent, Person);
 IMPLEMENT_ACTION_P2(Person, ResetAddress, odata_entityset_query_executor<Person>, addresses, std::vector<Address>, addresses, index, int32_t, index);
 IMPLEMENT_FUNCTION_P0(Person, GetHomeAddress, odata_complex_query_executor<HomeAddress>);
@@ -208,9 +208,9 @@ BEGIN_ENTITY_DESTRUCTOR(Statement)
 END_ENTITY_DESTRUCTOR(Statement)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Statement, statementid, StatementID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Statement, transactiontype, TransactionType, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Statement, transactiontype, TransactionType, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Statement, amount, Amount, double);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Statement, transactiondescription, TransactionDescription, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Statement, transactiondescription, TransactionDescription, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Statement, Microsoft.Test.OData.Services.ODataWCFService, Statement)
 
@@ -241,8 +241,8 @@ BEGIN_ENTITY_DESTRUCTOR(Product)
 END_ENTITY_DESTRUCTOR(Product)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, productid, ProductID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, name, Name, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, quantityperunit, QuantityPerUnit, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, name, Name, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, quantityperunit, QuantityPerUnit, ::odata::string_t);
 IMPLEMENT_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(Product, skincolor, SkinColor, Color);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, unitprice, UnitPrice, float);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Product, discontinued, Discontinued, bool);
@@ -289,9 +289,9 @@ BEGIN_ENTITY_DESTRUCTOR(Department)
 END_ENTITY_DESTRUCTOR(Department)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Department, departmentid, DepartmentID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Department, name, Name, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Department, name, Name, ::odata::string_t);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Department, company, Company, Company);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Department, departmentno, DepartmentNO, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Department, departmentno, DepartmentNO, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Department, Microsoft.Test.OData.Services.ODataWCFService, Department)
 
@@ -314,7 +314,7 @@ END_ENTITY_CONSTRUCTOR(Customer, Person)
 BEGIN_ENTITY_DESTRUCTOR(Customer)
 END_ENTITY_DESTRUCTOR(Customer)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Customer, city, City, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Customer, city, City, ::odata::string_t);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Customer, company, Company, Company);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Customer, birthday, Birthday, ::utility::datetime);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Customer, timebetweenlasttwoorders, TimeBetweenLastTwoOrders, ::utility::seconds);
@@ -344,9 +344,9 @@ BEGIN_ENTITY_DESTRUCTOR(ProductDetail)
 END_ENTITY_DESTRUCTOR(ProductDetail)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, productid, ProductID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, description, Description, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, description, Description, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, productdetailid, ProductDetailID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, productname, ProductName, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, productname, ProductName, ::odata::string_t);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, relatedproduct, RelatedProduct, Product);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(ProductDetail, reviews, Reviews, ProductReview);
 IMPLEMENT_FUNCTION_P0(ProductDetail, GetRelatedProduct, odata_entityset_query_executor<Product>);
@@ -400,9 +400,9 @@ END_ENTITY_DESTRUCTOR(ProductReview)
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, productid, ProductID, int32_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, revisionid, RevisionID, int32_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, productdetailid, ProductDetailID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, reviewtitle, ReviewTitle, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, comment, Comment, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, author, Author, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, reviewtitle, ReviewTitle, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, comment, Comment, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ProductReview, author, Author, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(ProductReview, Microsoft.Test.OData.Services.ODataWCFService, ProductReview)
 
@@ -511,7 +511,7 @@ END_ENTITY_DESTRUCTOR(Company)
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Company, companyid, CompanyID, int32_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Company, revenue, Revenue, int64_t);
 IMPLEMENT_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(Company, companycategory, CompanyCategory, CompanyCategory);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Company, name, Name, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Company, name, Name, ::odata::string_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Company, departments, Departments, Department);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Company, coredepartment, CoreDepartment, Department);
 IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Company, address, Address, Address);
@@ -549,7 +549,7 @@ BEGIN_ENTITY_DESTRUCTOR(PublicCompany)
     ON_PROPERTY_IN_ENTITY_DESTRUCTOR(stockexchange)
 END_ENTITY_DESTRUCTOR(PublicCompany)
 
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PublicCompany, stockexchange, StockExchange, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PublicCompany, stockexchange, StockExchange, ::odata::string_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(PublicCompany, assets, Assets, Asset);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(PublicCompany, club, Club, Club);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(PublicCompany, labourunion, LabourUnion, LabourUnion);
@@ -576,7 +576,7 @@ BEGIN_ENTITY_DESTRUCTOR(Asset)
 END_ENTITY_DESTRUCTOR(Asset)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Asset, assetid, AssetID, int32_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Asset, name, Name, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Asset, name, Name, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Asset, number, Number, int32_t);
 
 IMPLEMENT_EDM_INFO(Asset, Microsoft.Test.OData.Services.ODataWCFService, Asset)
@@ -603,11 +603,11 @@ BEGIN_ENTITY_DESTRUCTOR(GiftCard)
 END_ENTITY_DESTRUCTOR(GiftCard)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, giftcardid, GiftCardID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, giftcardno, GiftCardNO, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, giftcardno, GiftCardNO, ::odata::string_t);
 IMPLEMENT_FUNCTION_P1(GiftCard, GetActualAmount, odata_primitive_query_executor<double>, bonusRate, double, bonusRate);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, amount, Amount, double);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, experationdate, ExperationDate, ::utility::datetime);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, ownername, OwnerName, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(GiftCard, ownername, OwnerName, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(GiftCard, Microsoft.Test.OData.Services.ODataWCFService, GiftCard)
 
@@ -636,7 +636,7 @@ BEGIN_ENTITY_DESTRUCTOR(Club)
 END_ENTITY_DESTRUCTOR(Club)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Club, clubid, ClubID, int32_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Club, name, Name, ::utility::string_t);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Club, name, Name, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(Club, Microsoft.Test.OData.Services.ODataWCFService, Club)
 
@@ -659,8 +659,8 @@ BEGIN_ENTITY_DESTRUCTOR(LabourUnion)
 END_ENTITY_DESTRUCTOR(LabourUnion)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(LabourUnion, labourunionid, LabourUnionID, int32_t);
-IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(LabourUnion, name, Name, ::utility::string_t);
-IMPLEMENT_ACTION_P1(LabourUnion, ChangeLabourUnionName, odata_void_query_executor, name, ::utility::string_t, name);
+IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(LabourUnion, name, Name, ::odata::string_t);
+IMPLEMENT_ACTION_P1(LabourUnion, ChangeLabourUnionName, odata_void_query_executor, name, ::odata::string_t, name);
 
 IMPLEMENT_EDM_INFO(LabourUnion, Microsoft.Test.OData.Services.ODataWCFService, LabourUnion)
 
@@ -686,7 +686,7 @@ IMPLEMENT_FUNCTION_P0(Account, GetDefaultPI, odata_entityset_query_executor<Paym
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Account, accountid, AccountID, int32_t);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Account, mygiftcard, MyGiftCard, GiftCard);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Account, activesubscriptions, ActiveSubscriptions, Subscription);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Account, countryregion, CountryRegion, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Account, countryregion, CountryRegion, ::odata::string_t);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(Account, mypaymentinstruments, MyPaymentInstruments, PaymentInstrument);
 IMPLEMENT_ACTION_P1(Account, RefreshDefaultPI, odata_entityset_query_executor<PaymentInstrument>, newDate, ::utility::datetime, newDate);
 IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(Account, accountinfo, AccountInfo, AccountInfo);
@@ -719,7 +719,7 @@ BEGIN_ENTITY_DESTRUCTOR(PaymentInstrument)
 END_ENTITY_DESTRUCTOR(PaymentInstrument)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PaymentInstrument, paymentinstrumentid, PaymentInstrumentID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PaymentInstrument, friendlyname, FriendlyName, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PaymentInstrument, friendlyname, FriendlyName, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(PaymentInstrument, createddate, CreatedDate, ::utility::datetime);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(PaymentInstrument, backupstoredpi, BackupStoredPI, StoredPI);
 IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(PaymentInstrument, thestoredpi, TheStoredPI, StoredPI);
@@ -752,7 +752,7 @@ END_ENTITY_DESTRUCTOR(CreditRecord)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditRecord, creditrecordid, CreditRecordID, int32_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditRecord, isgood, IsGood, bool);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditRecord, reason, Reason, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditRecord, reason, Reason, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditRecord, createddate, CreatedDate, ::utility::datetime);
 
 IMPLEMENT_EDM_INFO(CreditRecord, Microsoft.Test.OData.Services.ODataWCFService, CreditRecord)
@@ -778,9 +778,9 @@ END_ENTITY_CONSTRUCTOR(CreditCardPI, PaymentInstrument)
 BEGIN_ENTITY_DESTRUCTOR(CreditCardPI)
 END_ENTITY_DESTRUCTOR(CreditCardPI)
 
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, cardnumber, CardNumber, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, holdername, HolderName, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, cvv, CVV, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, cardnumber, CardNumber, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, holdername, HolderName, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, cvv, CVV, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, experationdate, ExperationDate, ::utility::datetime);
 IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, creditrecords, CreditRecords, CreditRecord);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, balance, Balance, double);
@@ -811,8 +811,8 @@ BEGIN_ENTITY_DESTRUCTOR(StoredPI)
 END_ENTITY_DESTRUCTOR(StoredPI)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(StoredPI, storedpiid, StoredPIID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(StoredPI, piname, PIName, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(StoredPI, pitype, PIType, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(StoredPI, piname, PIName, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(StoredPI, pitype, PIType, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(StoredPI, createddate, CreatedDate, ::utility::datetime);
 
 IMPLEMENT_EDM_INFO(StoredPI, Microsoft.Test.OData.Services.ODataWCFService, StoredPI)
@@ -839,9 +839,9 @@ BEGIN_ENTITY_DESTRUCTOR(Subscription)
 END_ENTITY_DESTRUCTOR(Subscription)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Subscription, subscriptionid, SubscriptionID, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Subscription, templateguid, TemplateGuid, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Subscription, title, Title, ::utility::string_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Subscription, category, Category, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Subscription, templateguid, TemplateGuid, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Subscription, title, Title, ::odata::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Subscription, category, Category, ::odata::string_t);
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(Subscription, createddate, CreatedDate, ::utility::datetime);
 
 IMPLEMENT_EDM_INFO(Subscription, Microsoft.Test.OData.Services.ODataWCFService, Subscription)
@@ -862,9 +862,9 @@ BEGIN_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Subscription)
     ON_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Subscription, createddate)
 END_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Subscription)
 
-IMPLEMENT_FUNCTION_IMPORT_P2(InMemoryEntities, GetBossEmails, odata_primitive_query_executor<::utility::string_t>, start, int32_t, start, count, int32_t, count);
+IMPLEMENT_FUNCTION_IMPORT_P2(InMemoryEntities, GetBossEmails, odata_primitive_query_executor<::odata::string_t>, start, int32_t, start, count, int32_t, count);
 
-IMPLEMENT_ACTION_IMPORT_P1(InMemoryEntities, ResetBossEmail, odata_primitive_query_executor<::utility::string_t>, emails, std::vector<::utility::string_t>, emails);
+IMPLEMENT_ACTION_IMPORT_P1(InMemoryEntities, ResetBossEmail, odata_primitive_query_executor<::odata::string_t>, emails, std::vector<::odata::string_t>, emails);
 
 IMPLEMENT_ACTION_IMPORT_P1(InMemoryEntities, Discount, odata_void_query_executor, percentage, int32_t, percentage);
 
@@ -878,9 +878,9 @@ IMPLEMENT_ACTION_IMPORT_P0(InMemoryEntities, ResetDataSource, odata_void_query_e
 
 IMPLEMENT_FUNCTION_IMPORT_P1(InMemoryEntities, GetPerson, odata_entityset_query_executor<Person>, address, Address, address);
 
-IMPLEMENT_FUNCTION_IMPORT_P1(InMemoryEntities, GetPerson2, odata_entityset_query_executor<Person>, city, ::utility::string_t, city);
+IMPLEMENT_FUNCTION_IMPORT_P1(InMemoryEntities, GetPerson2, odata_entityset_query_executor<Person>, city, ::odata::string_t, city);
 
-IMPLEMENT_FUNCTION_IMPORT_P1(InMemoryEntities, GetProductsByAccessLevel, odata_primitive_query_executor<::utility::string_t>, accessLevel, AccessLevel, accessLevel);
+IMPLEMENT_FUNCTION_IMPORT_P1(InMemoryEntities, GetProductsByAccessLevel, odata_primitive_query_executor<::odata::string_t>, accessLevel, AccessLevel, accessLevel);
 
 DECLARE_DERIVED_COMPLEX_CREATOR_FUNC(HomeAddress, homeaddress)
 DECLARE_DERIVED_COMPLEX_CREATOR_FUNC(CompanyAddress, companyaddress)

--- a/tests/functional/codegen_tool_test/baseline/default_service_test_baseline.h
+++ b/tests/functional/codegen_tool_test/baseline/default_service_test_baseline.h
@@ -102,8 +102,8 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(firstname, FirstName, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(lastname, LastName, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(firstname, FirstName, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(lastname, LastName, ::odata::string_t);
 };
 
 class Address : public type_base
@@ -114,9 +114,9 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(street, Street, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(city, City, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(postalcode, PostalCode, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(street, Street, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(city, City, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(postalcode, PostalCode, ::odata::string_t);
 };
 
 class HomeAddress : public Address
@@ -127,7 +127,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(familyname, FamilyName, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(familyname, FamilyName, ::odata::string_t);
 };
 
 class CompanyAddress : public Address
@@ -138,7 +138,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(companyname, CompanyName, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(companyname, CompanyName, ::odata::string_t);
 };
 
 class CityInformation : public type_base
@@ -149,7 +149,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(countryregion, CountryRegion, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(countryregion, CountryRegion, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(iscapital, IsCapital, bool);
 };
 
@@ -162,12 +162,12 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(personid, PersonID, int32_t);
-    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(numbers, Numbers, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(firstname, FirstName, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(lastname, LastName, ::utility::string_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(middlename, MiddleName, ::utility::string_t);
+    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(numbers, Numbers, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(firstname, FirstName, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(lastname, LastName, ::odata::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(middlename, MiddleName, ::odata::string_t);
     DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(homeaddress, HomeAddress, Address);
-    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(emails, Emails, ::utility::string_t);
+    DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(emails, Emails, ::odata::string_t);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(parent, Parent, Person);
     DECLARE_ACTION_P2(Person, ResetAddress, odata_entityset_query_executor<Person>, addresses, std::vector<Address>, addresses, index, int32_t, index);
     DECLARE_FUNCTION_P0(Person, GetHomeAddress, odata_complex_query_executor<HomeAddress>);
@@ -184,9 +184,9 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(statementid, StatementID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(transactiontype, TransactionType, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(transactiontype, TransactionType, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(amount, Amount, double);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(transactiondescription, TransactionDescription, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(transactiondescription, TransactionDescription, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, StatementID, statementid);
 };
@@ -200,8 +200,8 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productid, ProductID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(quantityperunit, QuantityPerUnit, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(quantityperunit, QuantityPerUnit, ::odata::string_t);
     DECLARE_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(skincolor, SkinColor, Color);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(unitprice, UnitPrice, float);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(discontinued, Discontinued, bool);
@@ -225,9 +225,9 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(departmentid, DepartmentID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(company, Company, Company);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(departmentno, DepartmentNO, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(departmentno, DepartmentNO, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, DepartmentID, departmentid);
 };
@@ -240,7 +240,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(city, City, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(city, City, ::odata::string_t);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(company, Company, Company);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(birthday, Birthday, ::utility::datetime);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(timebetweenlasttwoorders, TimeBetweenLastTwoOrders, ::utility::seconds);
@@ -258,9 +258,9 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productid, ProductID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(description, Description, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(description, Description, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productdetailid, ProductDetailID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productname, ProductName, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productname, ProductName, ::odata::string_t);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(relatedproduct, RelatedProduct, Product);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(reviews, Reviews, ProductReview);
     DECLARE_FUNCTION_P0(ProductDetail, GetRelatedProduct, odata_entityset_query_executor<Product>);
@@ -293,9 +293,9 @@ public:
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productid, ProductID, int32_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(revisionid, RevisionID, int32_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(productdetailid, ProductDetailID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(reviewtitle, ReviewTitle, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(comment, Comment, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(author, Author, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(reviewtitle, ReviewTitle, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(comment, Comment, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(author, Author, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_FOUR_PARAM(type_base, ProductID, productid, RevisionID, revisionid, ProductDetailID, productdetailid, ReviewTitle, reviewtitle);
 };
@@ -349,7 +349,7 @@ public:
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(companyid, CompanyID, int32_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(revenue, Revenue, int64_t);
     DECLARE_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(companycategory, CompanyCategory, CompanyCategory);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(departments, Departments, Department);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(coredepartment, CoreDepartment, Department);
     DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(address, Address, Address);
@@ -369,7 +369,7 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(stockexchange, StockExchange, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(stockexchange, StockExchange, ::odata::string_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(assets, Assets, Asset);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(club, Club, Club);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(labourunion, LabourUnion, LabourUnion);
@@ -386,7 +386,7 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(assetid, AssetID, int32_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(number, Number, int32_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, AssetID, assetid);
@@ -401,11 +401,11 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(giftcardid, GiftCardID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(giftcardno, GiftCardNO, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(giftcardno, GiftCardNO, ::odata::string_t);
     DECLARE_FUNCTION_P1(GiftCard, GetActualAmount, odata_primitive_query_executor<double>, bonusRate, double, bonusRate);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(amount, Amount, double);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(experationdate, ExperationDate, ::utility::datetime);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ownername, OwnerName, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(ownername, OwnerName, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, GiftCardID, giftcardid);
 };
@@ -419,7 +419,7 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(clubid, ClubID, int32_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, ClubID, clubid);
 };
@@ -433,8 +433,8 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(labourunionid, LabourUnionID, int32_t);
-    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::utility::string_t);
-    DECLARE_ACTION_P1(LabourUnion, ChangeLabourUnionName, odata_void_query_executor, name, ::utility::string_t, name);
+    DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(name, Name, ::odata::string_t);
+    DECLARE_ACTION_P1(LabourUnion, ChangeLabourUnionName, odata_void_query_executor, name, ::odata::string_t, name);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, LabourUnionID, labourunionid);
 };
@@ -451,7 +451,7 @@ public:
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(accountid, AccountID, int32_t);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(mygiftcard, MyGiftCard, GiftCard);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(activesubscriptions, ActiveSubscriptions, Subscription);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(countryregion, CountryRegion, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(countryregion, CountryRegion, ::odata::string_t);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(mypaymentinstruments, MyPaymentInstruments, PaymentInstrument);
     DECLARE_ACTION_P1(Account, RefreshDefaultPI, odata_entityset_query_executor<PaymentInstrument>, newDate, ::utility::datetime, newDate);
     DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(accountinfo, AccountInfo, AccountInfo);
@@ -470,7 +470,7 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(paymentinstrumentid, PaymentInstrumentID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(friendlyname, FriendlyName, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(friendlyname, FriendlyName, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(createddate, CreatedDate, ::utility::datetime);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(backupstoredpi, BackupStoredPI, StoredPI);
     DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(thestoredpi, TheStoredPI, StoredPI);
@@ -489,7 +489,7 @@ public:
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(creditrecordid, CreditRecordID, int32_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(isgood, IsGood, bool);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(reason, Reason, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(reason, Reason, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(createddate, CreatedDate, ::utility::datetime);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, CreditRecordID, creditrecordid);
@@ -503,9 +503,9 @@ public:
     DECLARE_EDM_INFO();
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(cardnumber, CardNumber, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(holdername, HolderName, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(cvv, CVV, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(cardnumber, CardNumber, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(holdername, HolderName, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(cvv, CVV, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(experationdate, ExperationDate, ::utility::datetime);
     DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(creditrecords, CreditRecords, CreditRecord);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(balance, Balance, double);
@@ -522,8 +522,8 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(storedpiid, StoredPIID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(piname, PIName, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(pitype, PIType, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(piname, PIName, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(pitype, PIType, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(createddate, CreatedDate, ::utility::datetime);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, StoredPIID, storedpiid);
@@ -538,9 +538,9 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(subscriptionid, SubscriptionID, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(templateguid, TemplateGuid, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(title, Title, ::utility::string_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(category, Category, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(templateguid, TemplateGuid, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(title, Title, ::odata::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(category, Category, ::odata::string_t);
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(createddate, CreatedDate, ::utility::datetime);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, SubscriptionID, subscriptionid);
@@ -549,106 +549,106 @@ public:
 class InMemoryEntities : public odata_service_context
 {
 public:
-    InMemoryEntities(const ::utility::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)
+    InMemoryEntities(const ::odata::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)
     {
     }
 
-    DECLARE_FUNCTION_IMPORT_P2(InMemoryEntities, GetBossEmails, odata_primitive_query_executor<::utility::string_t>, start, int32_t, start, count, int32_t, count);
+    DECLARE_FUNCTION_IMPORT_P2(InMemoryEntities, GetBossEmails, odata_primitive_query_executor<::odata::string_t>, start, int32_t, start, count, int32_t, count);
 
-    DECLARE_ACTION_IMPORT_P1(InMemoryEntities, ResetBossEmail, odata_primitive_query_executor<::utility::string_t>, emails, std::vector<::utility::string_t>, emails);
+    DECLARE_ACTION_IMPORT_P1(InMemoryEntities, ResetBossEmail, odata_primitive_query_executor<::odata::string_t>, emails, std::vector<::odata::string_t>, emails);
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Person>, odata_query_builder>> create_people_query()
     {
-        return create_query<odata_entityset_query_executor<Person>, odata_query_builder>(U("People"));
+        return create_query<odata_entityset_query_executor<Person>, odata_query_builder>(_XPLATSTR("People"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Customer>, odata_query_builder>> create_customers_query()
     {
-        return create_query<odata_entityset_query_executor<Customer>, odata_query_builder>(U("Customers"));
+        return create_query<odata_entityset_query_executor<Customer>, odata_query_builder>(_XPLATSTR("Customers"));
     }
 
     std::shared_ptr<odata_service_query<odata_singleton_query_executor<Company>, odata_query_builder>> create_company_query()
     {
-        return create_query<odata_singleton_query_executor<Company>, odata_query_builder>(U("Company"));
+        return create_query<odata_singleton_query_executor<Company>, odata_query_builder>(_XPLATSTR("Company"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Department>, odata_query_builder>> create_departments_query()
     {
-        return create_query<odata_entityset_query_executor<Department>, odata_query_builder>(U("Departments"));
+        return create_query<odata_entityset_query_executor<Department>, odata_query_builder>(_XPLATSTR("Departments"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<StoredPI>, odata_query_builder>> create_storedpis_query()
     {
-        return create_query<odata_entityset_query_executor<StoredPI>, odata_query_builder>(U("StoredPIs"));
+        return create_query<odata_entityset_query_executor<StoredPI>, odata_query_builder>(_XPLATSTR("StoredPIs"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Employee>, odata_query_builder>> create_employees_query()
     {
-        return create_query<odata_entityset_query_executor<Employee>, odata_query_builder>(U("Employees"));
+        return create_query<odata_entityset_query_executor<Employee>, odata_query_builder>(_XPLATSTR("Employees"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<ProductDetail>, odata_query_builder>> create_productdetails_query()
     {
-        return create_query<odata_entityset_query_executor<ProductDetail>, odata_query_builder>(U("ProductDetails"));
+        return create_query<odata_entityset_query_executor<ProductDetail>, odata_query_builder>(_XPLATSTR("ProductDetails"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Product>, odata_query_builder>> create_products_query()
     {
-        return create_query<odata_entityset_query_executor<Product>, odata_query_builder>(U("Products"));
+        return create_query<odata_entityset_query_executor<Product>, odata_query_builder>(_XPLATSTR("Products"));
     }
 
     DECLARE_ACTION_IMPORT_P1(InMemoryEntities, Discount, odata_void_query_executor, percentage, int32_t, percentage);
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<ProductReview>, odata_query_builder>> create_productreviews_query()
     {
-        return create_query<odata_entityset_query_executor<ProductReview>, odata_query_builder>(U("ProductReviews"));
+        return create_query<odata_entityset_query_executor<ProductReview>, odata_query_builder>(_XPLATSTR("ProductReviews"));
     }
 
     std::shared_ptr<odata_service_query<odata_singleton_query_executor<Person>, odata_query_builder>> create_boss_query()
     {
-        return create_query<odata_singleton_query_executor<Person>, odata_query_builder>(U("Boss"));
+        return create_query<odata_singleton_query_executor<Person>, odata_query_builder>(_XPLATSTR("Boss"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Order>, odata_query_builder>> create_orders_query()
     {
-        return create_query<odata_entityset_query_executor<Order>, odata_query_builder>(U("Orders"));
+        return create_query<odata_entityset_query_executor<Order>, odata_query_builder>(_XPLATSTR("Orders"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<OrderDetail>, odata_query_builder>> create_orderdetails_query()
     {
-        return create_query<odata_entityset_query_executor<OrderDetail>, odata_query_builder>(U("OrderDetails"));
+        return create_query<odata_entityset_query_executor<OrderDetail>, odata_query_builder>(_XPLATSTR("OrderDetails"));
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Account>, odata_query_builder>> create_accounts_query()
     {
-        return create_query<odata_entityset_query_executor<Account>, odata_query_builder>(U("Accounts"));
+        return create_query<odata_entityset_query_executor<Account>, odata_query_builder>(_XPLATSTR("Accounts"));
     }
 
     DECLARE_FUNCTION_IMPORT_P0(InMemoryEntities, GetAllProducts, odata_entityset_query_executor<Product>);
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<Subscription>, odata_query_builder>> create_subscriptiontemplates_query()
     {
-        return create_query<odata_entityset_query_executor<Subscription>, odata_query_builder>(U("SubscriptionTemplates"));
+        return create_query<odata_entityset_query_executor<Subscription>, odata_query_builder>(_XPLATSTR("SubscriptionTemplates"));
     }
 
     std::shared_ptr<odata_service_query<odata_singleton_query_executor<Customer>, odata_query_builder>> create_vipcustomer_query()
     {
-        return create_query<odata_singleton_query_executor<Customer>, odata_query_builder>(U("VipCustomer"));
+        return create_query<odata_singleton_query_executor<Customer>, odata_query_builder>(_XPLATSTR("VipCustomer"));
     }
 
     std::shared_ptr<odata_service_query<odata_singleton_query_executor<Company>, odata_query_builder>> create_publiccompany_query()
     {
-        return create_query<odata_singleton_query_executor<Company>, odata_query_builder>(U("PublicCompany"));
+        return create_query<odata_singleton_query_executor<Company>, odata_query_builder>(_XPLATSTR("PublicCompany"));
     }
 
     std::shared_ptr<odata_service_query<odata_singleton_query_executor<LabourUnion>, odata_query_builder>> create_labourunion_query()
     {
-        return create_query<odata_singleton_query_executor<LabourUnion>, odata_query_builder>(U("LabourUnion"));
+        return create_query<odata_singleton_query_executor<LabourUnion>, odata_query_builder>(_XPLATSTR("LabourUnion"));
     }
 
     std::shared_ptr<odata_service_query<odata_singleton_query_executor<StoredPI>, odata_query_builder>> create_defaultstoredpi_query()
     {
-        return create_query<odata_singleton_query_executor<StoredPI>, odata_query_builder>(U("DefaultStoredPI"));
+        return create_query<odata_singleton_query_executor<StoredPI>, odata_query_builder>(_XPLATSTR("DefaultStoredPI"));
     }
 
     DECLARE_ACTION_IMPORT_P1(InMemoryEntities, ResetBossAddress, odata_complex_query_executor<Address>, address, Address, address);
@@ -660,9 +660,9 @@ public:
 
     DECLARE_FUNCTION_IMPORT_P1(InMemoryEntities, GetPerson, odata_entityset_query_executor<Person>, address, Address, address);
 
-    DECLARE_FUNCTION_IMPORT_P1(InMemoryEntities, GetPerson2, odata_entityset_query_executor<Person>, city, ::utility::string_t, city);
+    DECLARE_FUNCTION_IMPORT_P1(InMemoryEntities, GetPerson2, odata_entityset_query_executor<Person>, city, ::odata::string_t, city);
 
-    DECLARE_FUNCTION_IMPORT_P1(InMemoryEntities, GetProductsByAccessLevel, odata_primitive_query_executor<::utility::string_t>, accessLevel, AccessLevel, accessLevel);
+    DECLARE_FUNCTION_IMPORT_P1(InMemoryEntities, GetProductsByAccessLevel, odata_primitive_query_executor<::odata::string_t>, accessLevel, AccessLevel, accessLevel);
 
 };
 

--- a/tests/functional/codegen_tool_test/baseline/simple_model_test_baseline.cpp
+++ b/tests/functional/codegen_tool_test/baseline/simple_model_test_baseline.cpp
@@ -17,7 +17,7 @@ BEGIN_ENTITY_DESTRUCTOR(TestType)
 END_ENTITY_DESTRUCTOR(TestType)
 
 IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(TestType, keyprop, KeyProp, int32_t);
-IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(TestType, valueprop, ValueProp, ::utility::string_t);
+IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(TestType, valueprop, ValueProp, ::odata::string_t);
 
 IMPLEMENT_EDM_INFO(TestType, Simple, TestType)
 

--- a/tests/functional/codegen_tool_test/baseline/simple_model_test_baseline.h
+++ b/tests/functional/codegen_tool_test/baseline/simple_model_test_baseline.h
@@ -44,7 +44,7 @@ public:
     ENABLE_PROPERTY_IN_ENTITY_MAPPING();
 
     DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(keyprop, KeyProp, int32_t);
-    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(valueprop, ValueProp, ::utility::string_t);
+    DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(valueprop, ValueProp, ::odata::string_t);
 
     DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, KeyProp, keyprop);
 };
@@ -52,13 +52,13 @@ public:
 class DefaultContainer : public odata_service_context
 {
 public:
-    DefaultContainer(const ::utility::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)
+    DefaultContainer(const ::odata::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)
     {
     }
 
     std::shared_ptr<odata_service_query<odata_entityset_query_executor<TestType>, odata_query_builder>> create_testtypeset_query()
     {
-        return create_query<odata_entityset_query_executor<TestType>, odata_query_builder>(U("TestTypeSet"));
+        return create_query<odata_entityset_query_executor<TestType>, odata_query_builder>(_XPLATSTR("TestTypeSet"));
     }
 
 };

--- a/tests/functional/common_test/common_utility_test.cpp
+++ b/tests/functional/common_test/common_utility_test.cpp
@@ -18,51 +18,51 @@ SUITE(common_utility_test)
 
 TEST(strip_string_empty_test)
 {
-	::utility::string_t case_string = U("");
+	::odata::string_t case_string = _XPLATSTR("");
 	auto ret = strip_string(case_string);
-	VERIFY_ARE_EQUAL(ret, U(""));
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR(""));
 }
 
 TEST(strip_string_empty_quote_test)
 {
-	::utility::string_t case_string = U("\"\"");
+	::odata::string_t case_string = _XPLATSTR("\"\"");
 	auto ret = strip_string(case_string);
-	VERIFY_ARE_EQUAL(ret, U(""));
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR(""));
 }
 
 TEST(strip_string_with_quote_test)
 {
-	::utility::string_t case_string = U("\"121232123\"");
+	::odata::string_t case_string = _XPLATSTR("\"121232123\"");
 	auto ret = strip_string(case_string);
-	VERIFY_ARE_EQUAL(ret, U("121232123"));
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR("121232123"));
 }
 
 TEST(strip_string_without_quote_test)
 {
-	::utility::string_t case_string = U("121232123");
+	::odata::string_t case_string = _XPLATSTR("121232123");
 	auto ret = strip_string(case_string);
-	VERIFY_ARE_EQUAL(ret, U("121232123"));
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR("121232123"));
 }
 
 TEST(strip_string_with_single_left_quote_test)
 {
-	::utility::string_t case_string = U("\"121232123");
+	::odata::string_t case_string = _XPLATSTR("\"121232123");
 	auto ret = strip_string(case_string);
-	VERIFY_ARE_EQUAL(ret, U("121232123"));
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR("121232123"));
 }
 
 TEST(strip_string_with_single_right_quote_test)
 {
-	::utility::string_t case_string = U("121232123\"");
+	::odata::string_t case_string = _XPLATSTR("121232123\"");
 	auto ret = strip_string(case_string);
-	VERIFY_ARE_EQUAL(ret, U("121232123"));
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR("121232123"));
 }
 
 TEST(split_string_empty_src_with_empty_delim_test)
 {
-	::utility::string_t case_string = U("");
-	::utility::string_t delim_string = U("");
-	std::list<::utility::string_t> ret;
+	::odata::string_t case_string = _XPLATSTR("");
+	::odata::string_t delim_string = _XPLATSTR("");
+	std::list<::odata::string_t> ret;
 
 	split_string(case_string, delim_string, ret);
 	VERIFY_ARE_EQUAL(ret.size(), 1);
@@ -70,14 +70,14 @@ TEST(split_string_empty_src_with_empty_delim_test)
 
 TEST(split_string_with_no_empty_input_test)
 {
-	::utility::string_t case_string = U("23123.23232.32323");
-	::utility::string_t delim_string = U(".");
-	std::list<::utility::string_t> ret;
-	ret.push_back(U("1"));
-	ret.push_back(U("2"));
-	ret.push_back(U("3"));
-	ret.push_back(U("4"));
-	ret.push_back(U("5"));
+	::odata::string_t case_string = _XPLATSTR("23123.23232.32323");
+	::odata::string_t delim_string = _XPLATSTR(".");
+	std::list<::odata::string_t> ret;
+	ret.push_back(_XPLATSTR("1"));
+	ret.push_back(_XPLATSTR("2"));
+	ret.push_back(_XPLATSTR("3"));
+	ret.push_back(_XPLATSTR("4"));
+	ret.push_back(_XPLATSTR("5"));
 
 	split_string(case_string, delim_string, ret);
 	VERIFY_ARE_EQUAL(ret.size(), 3);
@@ -85,9 +85,9 @@ TEST(split_string_with_no_empty_input_test)
 
 TEST(split_string_empty_src_with_delim_test)
 {
-	::utility::string_t case_string = U("");
-	::utility::string_t delim_string = U("..");
-	std::list<::utility::string_t> ret;
+	::odata::string_t case_string = _XPLATSTR("");
+	::odata::string_t delim_string = _XPLATSTR("..");
+	std::list<::odata::string_t> ret;
 
 	split_string(case_string, delim_string, ret);
 	VERIFY_ARE_EQUAL(ret.size(), 1);
@@ -95,9 +95,9 @@ TEST(split_string_empty_src_with_delim_test)
 
 TEST(split_string_src_with_empty_delim_test)
 {
-	::utility::string_t case_string = U("adfadfadfdas");
-	::utility::string_t delim_string = U("");
-	std::list<::utility::string_t> ret;
+	::odata::string_t case_string = _XPLATSTR("adfadfadfdas");
+	::odata::string_t delim_string = _XPLATSTR("");
+	std::list<::odata::string_t> ret;
 
 	split_string(case_string, delim_string, ret);
 	VERIFY_ARE_EQUAL(ret.size(), 1);
@@ -105,9 +105,9 @@ TEST(split_string_src_with_empty_delim_test)
 
 TEST(split_string_src_with_delim_notfind_test)
 {
-	::utility::string_t case_string = U("adfadfadfdas");
-	::utility::string_t delim_string = U("..");
-	std::list<::utility::string_t> ret;
+	::odata::string_t case_string = _XPLATSTR("adfadfadfdas");
+	::odata::string_t delim_string = _XPLATSTR("..");
+	std::list<::odata::string_t> ret;
 
 	split_string(case_string, delim_string, ret);
 	VERIFY_ARE_EQUAL(ret.size(), 1);
@@ -115,9 +115,9 @@ TEST(split_string_src_with_delim_notfind_test)
 
 TEST(split_string_src_with_delim_find_test)
 {
-	::utility::string_t case_string = U("..adf..ad..fa..dfdas..");
-	::utility::string_t delim_string = U("..");
-	std::list<::utility::string_t> ret;
+	::odata::string_t case_string = _XPLATSTR("..adf..ad..fa..dfdas..");
+	::odata::string_t delim_string = _XPLATSTR("..");
+	std::list<::odata::string_t> ret;
 
 	split_string(case_string, delim_string, ret);
 	VERIFY_ARE_EQUAL(ret.size(), 6);
@@ -125,9 +125,9 @@ TEST(split_string_src_with_delim_find_test)
 
 TEST(split_string_src_with_duplicated_delim_test)
 {
-	::utility::string_t case_string = U("...adf..ad....fa..dfdas...");
-	::utility::string_t delim_string = U("..");
-	std::list<::utility::string_t> ret;
+	::odata::string_t case_string = _XPLATSTR("...adf..ad....fa..dfdas...");
+	::odata::string_t delim_string = _XPLATSTR("..");
+	std::list<::odata::string_t> ret;
 
 	split_string(case_string, delim_string, ret);
 	VERIFY_ARE_EQUAL(ret.size(), 7);
@@ -135,9 +135,9 @@ TEST(split_string_src_with_duplicated_delim_test)
 
 TEST(split_string_src_with_single_char_delim_test)
 {
-	::utility::string_t case_string = U("...adf..ad....fa..dfdas...f");
-	::utility::string_t delim_string = U("f");
-	std::list<::utility::string_t> ret;
+	::odata::string_t case_string = _XPLATSTR("...adf..ad....fa..dfdas...f");
+	::odata::string_t delim_string = _XPLATSTR("f");
+	std::list<::odata::string_t> ret;
 
 	split_string(case_string, delim_string, ret);
 	VERIFY_ARE_EQUAL(ret.size(), 5);
@@ -145,9 +145,9 @@ TEST(split_string_src_with_single_char_delim_test)
 
 TEST(split_string_src_with_equal_delim_test)
 {
-	::utility::string_t case_string = U("...adf..ad....fa..dfdas...f");
-	::utility::string_t delim_string = U("...adf..ad....fa..dfdas...f");
-	std::list<::utility::string_t> ret;
+	::odata::string_t case_string = _XPLATSTR("...adf..ad....fa..dfdas...f");
+	::odata::string_t delim_string = _XPLATSTR("...adf..ad....fa..dfdas...f");
+	std::list<::odata::string_t> ret;
 
 	split_string(case_string, delim_string, ret);
 	VERIFY_ARE_EQUAL(ret.size(), 2);
@@ -155,19 +155,19 @@ TEST(split_string_src_with_equal_delim_test)
 
 TEST(split_string_src_with_exceed_length_delim_test)
 {
-	::utility::string_t case_string = U("...adf..ad....fa..dfdas...f");
-	::utility::string_t delim_string = U("...adf..ad....fa..dfdas...fdfdfdfdf");
-	std::list<::utility::string_t> ret;
+	::odata::string_t case_string = _XPLATSTR("...adf..ad....fa..dfdas...f");
+	::odata::string_t delim_string = _XPLATSTR("...adf..ad....fa..dfdas...fdfdfdfdf");
+	std::list<::odata::string_t> ret;
 
 	split_string(case_string, delim_string, ret);
 	VERIFY_ARE_EQUAL(ret.size(), 1);
-	VERIFY_ARE_EQUAL(ret.front(), U("...adf..ad....fa..dfdas...f"));
+	VERIFY_ARE_EQUAL(ret.front(), _XPLATSTR("...adf..ad....fa..dfdas...f"));
 }
 
 TEST(is_relative_path_empty_root_wity_empty_path)
 {
-	::utility::string_t root_string = U("");
-	::utility::string_t path_string = U("");
+	::odata::string_t root_string = _XPLATSTR("");
+	::odata::string_t path_string = _XPLATSTR("");
 
     bool ret = is_relative_path(root_string, path_string);
 	VERIFY_ARE_EQUAL(ret, false);
@@ -175,8 +175,8 @@ TEST(is_relative_path_empty_root_wity_empty_path)
 
 TEST(is_relative_path_empty_root)
 {
-	::utility::string_t root_string = U("");
-	::utility::string_t path_string = U("Accounts");
+	::odata::string_t root_string = _XPLATSTR("");
+	::odata::string_t path_string = _XPLATSTR("Accounts");
 
     bool ret = is_relative_path(root_string, path_string);
 	VERIFY_ARE_EQUAL(ret, false);
@@ -184,8 +184,8 @@ TEST(is_relative_path_empty_root)
 
 TEST(is_relative_path_empty_path)
 {
-	::utility::string_t root_string = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService");
-	::utility::string_t path_string = U("");
+	::odata::string_t root_string = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService");
+	::odata::string_t path_string = _XPLATSTR("");
 
     bool ret = is_relative_path(root_string, path_string);
 	VERIFY_ARE_EQUAL(ret, false);
@@ -193,8 +193,8 @@ TEST(is_relative_path_empty_path)
 
 TEST(is_relative_path_valid_root_wity_full_path)
 {
-	::utility::string_t root_string = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService");
-	::utility::string_t path_string = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts");
+	::odata::string_t root_string = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService");
+	::odata::string_t path_string = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts");
 
     bool ret = is_relative_path(root_string, path_string);
 	VERIFY_ARE_EQUAL(ret, false);
@@ -202,8 +202,8 @@ TEST(is_relative_path_valid_root_wity_full_path)
 
 TEST(is_relative_path_valid_root_wity_relative_path)
 {
-	::utility::string_t root_string = U("http://http://odatae2etest.azurewebsites.net/cpptest/DefaultService");
-	::utility::string_t path_string = U("http");
+	::odata::string_t root_string = _XPLATSTR("http://http://odatae2etest.azurewebsites.net/cpptest/DefaultService");
+	::odata::string_t path_string = _XPLATSTR("http");
 
     bool ret = is_relative_path(root_string, path_string);
 	VERIFY_ARE_EQUAL(ret, true);
@@ -211,8 +211,8 @@ TEST(is_relative_path_valid_root_wity_relative_path)
 
 TEST(is_relative_path_valid_root_wity_uppercase_full_path)
 {
-	::utility::string_t root_string = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService");
-	::utility::string_t path_string = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts");
+	::odata::string_t root_string = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService");
+	::odata::string_t path_string = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts");
 
     bool ret = is_relative_path(root_string, path_string);
 	VERIFY_ARE_EQUAL(ret, false);
@@ -221,93 +221,93 @@ TEST(is_relative_path_valid_root_wity_uppercase_full_path)
 TEST(print_double_zero_input)
 {
 	double zero = 0.0;
-	::utility::string_t ret = print_double(zero);
-	VERIFY_ARE_EQUAL(ret, U("0.0"));
+	::odata::string_t ret = print_double(zero);
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR("0.0"));
 }
 
 TEST(print_double_zero_input_2)
 {
 	double zero = 0;
-	::utility::string_t ret = print_double(zero);
-	VERIFY_ARE_EQUAL(ret, U("0.0"));
+	::odata::string_t ret = print_double(zero);
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR("0.0"));
 }
 
 TEST(print_double_minus_zero_input)
 {
 	double zero = -0.0;
-	::utility::string_t ret = print_double(zero);
-	VERIFY_ARE_EQUAL(ret, U("-0.0"));
+	::odata::string_t ret = print_double(zero);
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR("-0.0"));
 }
 
 TEST(print_double_minus_zero_input_2)
 {
 	double zero = -0;
-	::utility::string_t ret = print_double(zero);
-	VERIFY_ARE_EQUAL(ret, U("0.0"));
+	::odata::string_t ret = print_double(zero);
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR("0.0"));
 }
 
 TEST(print_double_valid_input)
 {
 	double zero = 212.1234;
-	::utility::string_t ret = print_double(zero, 4);
-	VERIFY_ARE_EQUAL(ret, U("212.1234"));
+	::odata::string_t ret = print_double(zero, 4);
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR("212.1234"));
 }
 
 TEST(print_double_right_exceed_precision_input)
 {
 	double zero = 123123123.1111222323;
-	::utility::string_t ret = print_double(zero, 8);
-	VERIFY_ARE_EQUAL(ret, U("123123123.11112224"));
+	::odata::string_t ret = print_double(zero, 8);
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR("123123123.11112224"));
 }
 
 TEST(print_double_set_right_precision_input)
 {
 	double zero = -4212.1111222323;
-	::utility::string_t ret = print_double(zero, 13);
-	VERIFY_ARE_EQUAL(ret, U("-4212.1111222322997"));
+	::odata::string_t ret = print_double(zero, 13);
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR("-4212.1111222322997"));
 }
 
 TEST(print_double_zero_precision_input)
 {
 	double zero = -4212.1111222323;
-	::utility::string_t ret = print_double(zero, 0);
-	VERIFY_ARE_EQUAL(ret, U("-4212"));
+	::odata::string_t ret = print_double(zero, 0);
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR("-4212"));
 }
 
 TEST(print_double_minux_precision_input)
 {
 	double zero = -4212.11;
-	::utility::string_t ret = print_double(zero, 9);
-	VERIFY_ARE_EQUAL(ret, U("-4212.11"));
+	::odata::string_t ret = print_double(zero, 9);
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR("-4212.11"));
 }
 
 TEST(print_double_large_double_input)
 {
 	double zero = -12123123123213124212.11;
-	::utility::string_t ret = print_double(zero, 1);
+	::odata::string_t ret = print_double(zero, 1);
 #ifdef WIN32
-	VERIFY_ARE_EQUAL(ret, U("-12123123123213124000.0"));
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR("-12123123123213124000.0"));
 #else
-    VERIFY_ARE_EQUAL(ret, U("-12123123123213123584.0"));
+    VERIFY_ARE_EQUAL(ret, _XPLATSTR("-12123123123213123584.0"));
 #endif
 }
 
 TEST(print_double_large_double_input_2)
 {
 	double zero = 1234567891234567.7674567611117999;
-	::utility::string_t ret = print_double(zero, 1);
+	::odata::string_t ret = print_double(zero, 1);
 #ifdef WIN32
-	VERIFY_ARE_EQUAL(ret, U("1234567891234567.7"));
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR("1234567891234567.7"));
 #else
-    VERIFY_ARE_EQUAL(ret, U("1234567891234567.8"));
+    VERIFY_ARE_EQUAL(ret, _XPLATSTR("1234567891234567.8"));
 #endif
 }
 
 TEST(print_double_large_double_input_3)
 {
 	double zero = -12345.7674567611117999;
-	::utility::string_t ret = print_double(zero, 12);
-	VERIFY_ARE_EQUAL(ret, U("-12345.767456761112"));
+	::odata::string_t ret = print_double(zero, 12);
+	VERIFY_ARE_EQUAL(ret, _XPLATSTR("-12345.767456761112"));
 }
 
 }

--- a/tests/functional/core_test/odata_collection_value_test.cpp
+++ b/tests/functional/core_test/odata_collection_value_test.cpp
@@ -21,8 +21,8 @@ SUITE(odata_collection_value_test_cases)
 TEST(collection_of_primitive_value)
 {
 	shared_ptr<edm_primitive_type> int_type = edm_primitive_type::INT32();
-	shared_ptr<edm_collection_type> collection_type = std::make_shared<edm_collection_type>(U("collection type"), int_type);
-	shared_ptr<odata_collection_value> collection_value = std::make_shared<odata_collection_value>(collection_type);
+	shared_ptr<edm_collection_type> collection_type = ::odata::make_shared<edm_collection_type>(_XPLATSTR("collection type"), int_type);
+	shared_ptr<odata_collection_value> collection_value = ::odata::make_shared<odata_collection_value>(collection_type);
 	collection_value->add_collection_value(odata_primitive_value::make_primitive_value(10));
 	collection_value->add_collection_value(odata_primitive_value::make_primitive_value(-10));
 
@@ -33,12 +33,12 @@ TEST(collection_of_primitive_value)
 
 TEST(collection_of_enum_value)
 {
-	shared_ptr<edm_enum_type> enum_type = make_shared<edm_enum_type>(U("Color"), U("namespace"), U("Edm.Int32"), false);
-	auto collection_type = std::make_shared<edm_collection_type>(U("collection type"), enum_type);
-	auto collection_value = std::make_shared<odata_collection_value>(collection_type);
+	shared_ptr<edm_enum_type> enum_type = make_shared<edm_enum_type>(_XPLATSTR("Color"), _XPLATSTR("namespace"), _XPLATSTR("Edm.Int32"), false);
+	auto collection_type = ::odata::make_shared<edm_collection_type>(_XPLATSTR("collection type"), enum_type);
+	auto collection_value = ::odata::make_shared<odata_collection_value>(collection_type);
 
-	collection_value->add_collection_value(make_shared<odata_enum_value>(enum_type, U("Blue")));
-	collection_value->add_collection_value(make_shared<odata_enum_value>(enum_type, U("Red")));
+	collection_value->add_collection_value(make_shared<odata_enum_value>(enum_type, _XPLATSTR("Blue")));
+	collection_value->add_collection_value(make_shared<odata_enum_value>(enum_type, _XPLATSTR("Red")));
 
 	VERIFY_ARE_EQUAL(edm_type_kind_t::Collection, collection_value->get_value_type()->get_type_kind());
 

--- a/tests/functional/core_test/odata_context_url_parser_test.cpp
+++ b/tests/functional/core_test/odata_context_url_parser_test.cpp
@@ -22,227 +22,227 @@ TEST(single_entity_test)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t single_entity_string = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts/$entity");
+	::odata::string_t single_entity_string = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts/$entity");
 	auto return_type = context_url_parser->get_payload_content_type(single_entity_string);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Entity);
-	VERIFY_ARE_EQUAL(return_type->get_name(), U("Account"));
+	VERIFY_ARE_EQUAL(return_type->get_name(), _XPLATSTR("Account"));
 }
 
 TEST(entities_test)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _entities_string = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts");
+	::odata::string_t _entities_string = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts");
 	auto return_type = context_url_parser->get_payload_content_type(_entities_string);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Entity);
-	VERIFY_ARE_EQUAL(return_type->get_name(), U("Account"));
+	VERIFY_ARE_EQUAL(return_type->get_name(), _XPLATSTR("Account"));
 }
 
 TEST(derived_entity)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _entities_string = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#People/Microsoft.Test.OData.Services.ODataWCFService.Customer/$entity");
+	::odata::string_t _entities_string = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#People/Microsoft.Test.OData.Services.ODataWCFService.Customer/$entity");
 	auto return_type = context_url_parser->get_payload_content_type(_entities_string);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Entity);
-	VERIFY_ARE_EQUAL(return_type->get_name(), U("Customer"));
+	VERIFY_ARE_EQUAL(return_type->get_name(), _XPLATSTR("Customer"));
 }
 
 TEST(project_entity)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _entities_string = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Customers(PersonID,Orders)/$entity");
+	::odata::string_t _entities_string = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Customers(PersonID,Orders)/$entity");
 	auto return_type = context_url_parser->get_payload_content_type(_entities_string);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Entity);
-	VERIFY_ARE_EQUAL(return_type->get_name(), U("Customer"));
+	VERIFY_ARE_EQUAL(return_type->get_name(), _XPLATSTR("Customer"));
 }
 
 TEST(collection_project_entities)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _entities_string = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Customers(PersonID,Orders)");
+	::odata::string_t _entities_string = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Customers(PersonID,Orders)");
 	auto return_type = context_url_parser->get_payload_content_type(_entities_string);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Entity);
-	VERIFY_ARE_EQUAL(return_type->get_name(), U("Customer"));
+	VERIFY_ARE_EQUAL(return_type->get_name(), _XPLATSTR("Customer"));
 }
 
 TEST(collection_project_expand_entity)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _entities_string = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Customers(PersonID,Orders,Orders(OrderID,OrderDate))/$entity");
+	::odata::string_t _entities_string = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Customers(PersonID,Orders,Orders(OrderID,OrderDate))/$entity");
 	auto return_type = context_url_parser->get_payload_content_type(_entities_string);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Entity);
-	VERIFY_ARE_EQUAL(return_type->get_name(), U("Customer"));
+	VERIFY_ARE_EQUAL(return_type->get_name(), _XPLATSTR("Customer"));
 }
 
 TEST(collection_project_expand_entities)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _entities_string = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Customers(PersonID,Orders,Orders(OrderID,OrderDate))");
+	::odata::string_t _entities_string = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Customers(PersonID,Orders,Orders(OrderID,OrderDate))");
 	auto return_type = context_url_parser->get_payload_content_type(_entities_string);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Entity);
-	VERIFY_ARE_EQUAL(return_type->get_name(), U("Customer"));
+	VERIFY_ARE_EQUAL(return_type->get_name(), _XPLATSTR("Customer"));
 }
 
 TEST(single_complex_test)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _single_complex = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(102)/AccountInfo");
+	::odata::string_t _single_complex = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(102)/AccountInfo");
 	auto return_type = context_url_parser->get_payload_content_type(_single_complex);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Complex);
-	VERIFY_ARE_EQUAL(return_type->get_name(), U("AccountInfo"));
+	VERIFY_ARE_EQUAL(return_type->get_name(), _XPLATSTR("AccountInfo"));
 }
 
 TEST(single_complex_test_2)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _single_complex = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Microsoft.Test.OData.Services.ODataWCFService.HomeAddress");
+	::odata::string_t _single_complex = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Microsoft.Test.OData.Services.ODataWCFService.HomeAddress");
 	auto return_type = context_url_parser->get_payload_content_type(_single_complex);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Complex);
-	VERIFY_ARE_EQUAL(return_type->get_name(), U("HomeAddress"));
+	VERIFY_ARE_EQUAL(return_type->get_name(), _XPLATSTR("HomeAddress"));
 }
 
 TEST(derived_complex_test)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _single_complex = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#People(1)/HomeAddress/Microsoft.Test.OData.Services.ODataWCFService.HomeAddress");
+	::odata::string_t _single_complex = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#People(1)/HomeAddress/Microsoft.Test.OData.Services.ODataWCFService.HomeAddress");
 	auto return_type = context_url_parser->get_payload_content_type(_single_complex);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Complex);
-	VERIFY_ARE_EQUAL(return_type->get_name(), U("HomeAddress"));
+	VERIFY_ARE_EQUAL(return_type->get_name(), _XPLATSTR("HomeAddress"));
 }
 
 TEST(single_primitive_test_double)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
 
-	::utility::string_t _single_primitive = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Edm.Double");
+	::odata::string_t _single_primitive = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Edm.Double");
 	auto return_type = context_url_parser->get_payload_content_type(_single_primitive);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Primitive);
-	VERIFY_ARE_EQUAL(return_type->get_name(), U("Edm.Double"));
+	VERIFY_ARE_EQUAL(return_type->get_name(), _XPLATSTR("Edm.Double"));
 }
 
 TEST(single_primitive_test_binary)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
 
-	::utility::string_t _single_primitive = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Edm.Binary");
+	::odata::string_t _single_primitive = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Edm.Binary");
 	auto return_type = context_url_parser->get_payload_content_type(_single_primitive);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Primitive);
-	VERIFY_ARE_EQUAL(return_type->get_name(), U("Edm.Binary"));
+	VERIFY_ARE_EQUAL(return_type->get_name(), _XPLATSTR("Edm.Binary"));
 }
 
 TEST(collection_of_primitive_test)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _multiple_primitive = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#People(2)/Numbers");
+	::odata::string_t _multiple_primitive = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#People(2)/Numbers");
 	auto return_type = context_url_parser->get_payload_content_type(_multiple_primitive);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Collection);
 	auto element_type = edm_model_utility::get_collection_element_type(return_type);
 	VERIFY_ARE_EQUAL(element_type->get_type_kind(), edm_type_kind_t::Primitive);
-	VERIFY_ARE_EQUAL(element_type->get_name(), U("Edm.String"));
+	VERIFY_ARE_EQUAL(element_type->get_name(), _XPLATSTR("Edm.String"));
 }
 
 TEST(collection_of_primitive_test_string)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _multiple_primitive = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Collection(Edm.String)");
+	::odata::string_t _multiple_primitive = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Collection(Edm.String)");
 	auto return_type = context_url_parser->get_payload_content_type(_multiple_primitive);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Collection);
 	auto element_type = edm_model_utility::get_collection_element_type(return_type);
 	VERIFY_ARE_EQUAL(element_type->get_type_kind(), edm_type_kind_t::Primitive);
-	VERIFY_ARE_EQUAL(element_type->get_name(), U("Edm.String"));
+	VERIFY_ARE_EQUAL(element_type->get_name(), _XPLATSTR("Edm.String"));
 }
 
 TEST(collection_of_primitive_test_int32)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _multiple_primitive = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Collection(Edm.Int32)");
+	::odata::string_t _multiple_primitive = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Collection(Edm.Int32)");
 	auto return_type = context_url_parser->get_payload_content_type(_multiple_primitive);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Collection);
 	auto element_type = edm_model_utility::get_collection_element_type(return_type);
 	VERIFY_ARE_EQUAL(element_type->get_type_kind(), edm_type_kind_t::Primitive);
-	VERIFY_ARE_EQUAL(element_type->get_name(), U("Edm.Int32"));
+	VERIFY_ARE_EQUAL(element_type->get_name(), _XPLATSTR("Edm.Int32"));
 }
 
 TEST(collection_of_primitive_test_single)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _multiple_primitive = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Collection(Edm.Single)");
+	::odata::string_t _multiple_primitive = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Collection(Edm.Single)");
 	auto return_type = context_url_parser->get_payload_content_type(_multiple_primitive);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Collection);
 	auto element_type = edm_model_utility::get_collection_element_type(return_type);
 	VERIFY_ARE_EQUAL(element_type->get_type_kind(), edm_type_kind_t::Primitive);
-	VERIFY_ARE_EQUAL(element_type->get_name(), U("Edm.Single"));
+	VERIFY_ARE_EQUAL(element_type->get_name(), _XPLATSTR("Edm.Single"));
 }
 
 TEST(single_enum_test)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _text_url = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/SkinColor");
+	::odata::string_t _text_url = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/SkinColor");
 	auto return_type = context_url_parser->get_payload_content_type(_text_url);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Enum);
@@ -252,9 +252,9 @@ TEST(collection_of_enum_test)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _text_url = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/CoverColors");
+	::odata::string_t _text_url = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/CoverColors");
 	auto return_type = context_url_parser->get_payload_content_type(_text_url);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Collection);
@@ -266,9 +266,9 @@ TEST(single_entity_with_single_navigation_test)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _text_url = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyGiftCard/$entity");
+	::odata::string_t _text_url = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyGiftCard/$entity");
 	auto return_type = context_url_parser->get_payload_content_type(_text_url);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Navigation);
@@ -280,9 +280,9 @@ TEST(single_entity_with_collection_of_navigation_test)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _text_url = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyPaymentInstruments");
+	::odata::string_t _text_url = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyPaymentInstruments");
 	auto return_type = context_url_parser->get_payload_content_type(_text_url);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Navigation);
@@ -296,9 +296,9 @@ TEST(single_entity_with_collection_of_navigation_and_select_test)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _text_url = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyPaymentInstruments(PaymentInstrumentID,FriendlyName)");
+	::odata::string_t _text_url = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyPaymentInstruments(PaymentInstrumentID,FriendlyName)");
 	auto return_type = context_url_parser->get_payload_content_type(_text_url);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Navigation);
@@ -312,9 +312,9 @@ TEST(navigation_of_navigation_test)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto context_url_parser = std::make_shared<odata_contex_url_parser>(model, g_service_root_url);
+	auto context_url_parser = ::odata::make_shared<odata_contex_url_parser>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(context_url_parser);
-	::utility::string_t _text_url = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyPaymentInstruments(101901)/BillingStatements");
+	::odata::string_t _text_url = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyPaymentInstruments(101901)/BillingStatements");
 	auto return_type = context_url_parser->get_payload_content_type(_text_url);
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Navigation);

--- a/tests/functional/core_test/odata_entity_value_test.cpp
+++ b/tests/functional/core_test/odata_entity_value_test.cpp
@@ -22,14 +22,14 @@ TEST(get_entity_key_string)
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
 
-	auto entity_value = std::make_shared<odata_entity_value>(model->find_entity_type(U("ProductReview")));
-	entity_value->set_value(U("ProductID"), 1);
-	entity_value->set_value(U("ProductDetailID"), 2);
-    entity_value->set_value(U("ReviewTitle"), U("title"));
-    entity_value->set_value(U("RevisionID"), 3);
+	auto entity_value = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("ProductReview")));
+	entity_value->set_value(_XPLATSTR("ProductID"), 1);
+	entity_value->set_value(_XPLATSTR("ProductDetailID"), 2);
+    entity_value->set_value(_XPLATSTR("ReviewTitle"), _XPLATSTR("title"));
+    entity_value->set_value(_XPLATSTR("RevisionID"), 3);
 
     auto key =  entity_value->get_entity_key_string();
-    VERIFY_ARE_EQUAL(U("(ProductID=1,ProductDetailID=2,ReviewTitle='title',RevisionID=3)"), key);
+    VERIFY_ARE_EQUAL(_XPLATSTR("(ProductID=1,ProductDetailID=2,ReviewTitle='title',RevisionID=3)"), key);
 }
 }
 

--- a/tests/functional/core_test/odata_json_reader_test.cpp
+++ b/tests/functional/core_test/odata_json_reader_test.cpp
@@ -19,7 +19,7 @@ static std::shared_ptr<odata_json_reader> get_json_reader()
 	auto model = get_test_model();
 	if (model)
 	{
-		return std::make_shared<odata_json_reader>(model, g_service_root_url);
+		return ::odata::make_shared<odata_json_reader>(model, g_service_root_url);
 	}
 
 	return nullptr;
@@ -33,30 +33,30 @@ TEST(single_entity_test)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload = U(
+	::odata::string_t _entity_payload = _XPLATSTR(
 		"{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts/$entity\", \
 		\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)\", \
 		\"AccountID\":101,\"CountryRegion\":\"US\",\"AccountInfo\":{\"FirstName\":\"Alex\",\"LastName\":\"Green\"}}"
 		);
 
 	web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	VERIFY_IS_NOT_NULL(return_payload);
 	auto entity_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
 	VERIFY_IS_NOT_NULL(entity_value);
 	int account_id = 0;
-	VERIFY_ARE_EQUAL(entity_value->try_get(U("AccountID"), account_id), true);
+	VERIFY_ARE_EQUAL(entity_value->try_get(_XPLATSTR("AccountID"), account_id), true);
 	VERIFY_ARE_EQUAL(account_id, 101);
 	std::shared_ptr<odata_value> property_value;
-	VERIFY_ARE_EQUAL(entity_value->try_get(U("AccountInfo"), property_value), true);
+	VERIFY_ARE_EQUAL(entity_value->try_get(_XPLATSTR("AccountInfo"), property_value), true);
 	VERIFY_IS_NOT_NULL(property_value);
 	auto complex_value = std::dynamic_pointer_cast<odata_complex_value>(property_value);
 	VERIFY_IS_NOT_NULL(complex_value);
-	::utility::string_t first_name;
-	VERIFY_ARE_EQUAL(complex_value->try_get(U("FirstName"), first_name), true);
-	VERIFY_ARE_EQUAL(first_name, U("Alex"));
+	::odata::string_t first_name;
+	VERIFY_ARE_EQUAL(complex_value->try_get(_XPLATSTR("FirstName"), first_name), true);
+	VERIFY_ARE_EQUAL(first_name, _XPLATSTR("Alex"));
 }
 
 TEST(entities_test)
@@ -64,7 +64,7 @@ TEST(entities_test)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-    ::utility::string_t _entity_payload = U(
+    ::odata::string_t _entity_payload = _XPLATSTR(
 	   "{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Departments\", \
 		\"value\":[{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Departments(1)\", \
 		\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Departments(1)\", \
@@ -74,17 +74,17 @@ TEST(entities_test)
 		);
 
 	web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
-	VERIFY_IS_NOT_NULL(return_payload);	
+	auto return_payload = json_reader->deserialize(json_payload);
+	VERIFY_IS_NOT_NULL(return_payload);
 	auto entity_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(entity_values.size(), 2);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[1]);
 	VERIFY_IS_NOT_NULL(entity_value);
-	::utility::string_t name;
-	VERIFY_ARE_EQUAL(entity_value->try_get(U("Name"), name), true);
-	VERIFY_ARE_EQUAL(name, U("D2"));
+	::odata::string_t name;
+	VERIFY_ARE_EQUAL(entity_value->try_get(_XPLATSTR("Name"), name), true);
+	VERIFY_ARE_EQUAL(name, _XPLATSTR("D2"));
 	int32_t id;
-	VERIFY_ARE_EQUAL(entity_value->try_get(U("DepartmentID"), id), true);
+	VERIFY_ARE_EQUAL(entity_value->try_get(_XPLATSTR("DepartmentID"), id), true);
 	VERIFY_ARE_EQUAL(id, 2);
 }
 
@@ -93,7 +93,7 @@ TEST(derived_entity_test)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#People\", \
+	::odata::string_t _entity_payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#People\", \
 		\"value\":[{\"@odata.type\":\"#Microsoft.Test.OData.Services.ODataWCFService.Customer\",\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(1)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(1)/Microsoft.Test.OData.Services.ODataWCFService.Customer\",\"PersonID\":1,\"FirstName\":\"Bob\",\"LastName\":\"Cat\",\"MiddleName\":null,\"HomeAddress\":{\"Street\":\"1 Microsoft Way\",\"City\":\"London\",\"PostalCode\":\"98052\"},\"Home\":{\"type\":\"Point\",\"coordinates\":[23.1,32.1],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}},\"Numbers\":[\"111-111-1111\"],\"Emails\":[\"abc@abc.com\"],\"City\":\"London\",\"Birthday\":\"1957-04-03T00:00:00Z\",\"TimeBetweenLastTwoOrders\":\"PT0.0000001S\"}, \
 	{\"@odata.type\":\"#Microsoft.Test.OData.Services.ODataWCFService.Customer\",\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(2)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(2)/Microsoft.Test.OData.Services.ODataWCFService.Customer\",\"PersonID\":2,\"FirstName\":\"Jill\",\"LastName\":\"Jones\",\"MiddleName\":null,\"HomeAddress\":null,\"Home\":{\"type\":\"Point\",\"coordinates\":[161.8,15.0],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}},\"Numbers\":[],\"Emails\":[],\"City\":\"Sydney\",\"Birthday\":\"1983-01-15T00:00:00Z\",\"TimeBetweenLastTwoOrders\":\"PT0.0000002S\"}, \
 	{\"@odata.type\":\"#Microsoft.Test.OData.Services.ODataWCFService.Employee\",\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(3)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(3)/Microsoft.Test.OData.Services.ODataWCFService.Employee\",\"PersonID\":3,\"FirstName\":\"Jacob\",\"LastName\":\"Zip\",\"MiddleName\":null,\"HomeAddress\":null,\"Home\":{\"type\":\"Point\",\"coordinates\":[161.8,15.0],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}},\"Numbers\":[\"333-333-3333\"],\"Emails\":[null],\"DateHired\":\"2010-12-13T00:00:00Z\",\"Office\":{\"type\":\"Point\",\"coordinates\":[162.0,15.0],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}}, \
@@ -101,61 +101,61 @@ TEST(derived_entity_test)
 	{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(5)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/People(5)\",\"PersonID\":5,\"FirstName\":\"Peter\",\"LastName\":\"Bee\",\"MiddleName\":null,\"HomeAddress\":null,\"Home\":{\"type\":\"Point\",\"coordinates\":[-261.8,-16.0],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}},\"Numbers\":[\"555-555-5555\"],\"Emails\":[\"def@test.msn\"]}]}");
 
 	web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_values = json_reader->deserilize(json_payload)->get_values();
+	auto return_values = json_reader->deserialize(json_payload)->get_values();
 	VERIFY_ARE_EQUAL(return_values.size(), 5);
 
 	auto entity_value_1 = std::dynamic_pointer_cast<odata_entity_value>(return_values[0]);
 	VERIFY_IS_NOT_NULL(entity_value_1);
 	auto entity_type_1 = std::dynamic_pointer_cast<edm_entity_type>(entity_value_1->get_value_type());
 	VERIFY_IS_NOT_NULL(entity_type_1);
-	VERIFY_ARE_EQUAL(entity_type_1->get_name(), U("Customer"));
-	::utility::string_t city_1;
-	VERIFY_ARE_EQUAL(entity_value_1->try_get(U("City"), city_1), true);
-	VERIFY_ARE_EQUAL(city_1, U("London"));
+	VERIFY_ARE_EQUAL(entity_type_1->get_name(), _XPLATSTR("Customer"));
+	::odata::string_t city_1;
+	VERIFY_ARE_EQUAL(entity_value_1->try_get(_XPLATSTR("City"), city_1), true);
+	VERIFY_ARE_EQUAL(city_1, _XPLATSTR("London"));
 	std::shared_ptr<odata_value> _value;
-	entity_value_1->get_property_value(U("HomeAddress"), _value);
+	entity_value_1->get_property_value(_XPLATSTR("HomeAddress"), _value);
 	auto complex_value_1 = std::dynamic_pointer_cast<odata_complex_value>(_value);
 	VERIFY_IS_NOT_NULL(complex_value_1);
-	::utility::string_t street_1;
-	VERIFY_ARE_EQUAL(complex_value_1->try_get(U("City"), city_1), true);
-	VERIFY_ARE_EQUAL(city_1, U("London"));
-	VERIFY_ARE_EQUAL(complex_value_1->try_get(U("Street"), street_1), true);
-	VERIFY_ARE_EQUAL(street_1, U("1 Microsoft Way"));
+	::odata::string_t street_1;
+	VERIFY_ARE_EQUAL(complex_value_1->try_get(_XPLATSTR("City"), city_1), true);
+	VERIFY_ARE_EQUAL(city_1, _XPLATSTR("London"));
+	VERIFY_ARE_EQUAL(complex_value_1->try_get(_XPLATSTR("Street"), street_1), true);
+	VERIFY_ARE_EQUAL(street_1, _XPLATSTR("1 Microsoft Way"));
 
 	auto entity_value_2 = std::dynamic_pointer_cast<odata_entity_value>(return_values[2]);
 	VERIFY_IS_NOT_NULL(entity_value_2);
 	auto entity_type_2 = std::dynamic_pointer_cast<edm_entity_type>(entity_value_2->get_value_type());
 	VERIFY_IS_NOT_NULL(entity_type_2);
-	VERIFY_ARE_EQUAL(entity_type_2->get_name(), U("Employee"));
+	VERIFY_ARE_EQUAL(entity_type_2->get_name(), _XPLATSTR("Employee"));
 	::utility::datetime dt;
-	VERIFY_ARE_EQUAL(entity_value_2->try_get(U("DateHired"), dt), true);
-	VERIFY_ARE_EQUAL(dt.to_string(::utility::datetime::date_format::ISO_8601), U("2010-12-13T00:00:00Z"));
+	VERIFY_ARE_EQUAL(entity_value_2->try_get(_XPLATSTR("DateHired"), dt), true);
+	VERIFY_ARE_EQUAL(dt.to_string(::utility::datetime::date_format::ISO_8601), _XPLATSTR("2010-12-13T00:00:00Z"));
 }
 
 TEST(single_complex_test)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto json_reader = std::make_shared<odata_json_reader>(model, g_service_root_url);
+	auto json_reader = ::odata::make_shared<odata_json_reader>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(json_reader);
 
-    ::utility::string_t _entity_payload = U(
+    ::odata::string_t _entity_payload = _XPLATSTR(
 	   "{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/AccountInfo\", \
 		\"FirstName\":\"Alex\",\"LastName\":\"Green\"}"
 		);
 
 	web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
-	VERIFY_IS_NOT_NULL(return_payload);	
+	auto return_payload = json_reader->deserialize(json_payload);
+	VERIFY_IS_NOT_NULL(return_payload);
 	auto entity_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto complex_value = std::dynamic_pointer_cast<odata_complex_value>(entity_values[0]);
 	VERIFY_IS_NOT_NULL(complex_value);
-	::utility::string_t first_name, last_name;
-	VERIFY_ARE_EQUAL(complex_value->try_get(U("FirstName"), first_name), true);
-	VERIFY_ARE_EQUAL(first_name, U("Alex"));
-	VERIFY_ARE_EQUAL(complex_value->try_get(U("LastName"), last_name), true);
-	VERIFY_ARE_EQUAL(last_name, U("Green"));
+	::odata::string_t first_name, last_name;
+	VERIFY_ARE_EQUAL(complex_value->try_get(_XPLATSTR("FirstName"), first_name), true);
+	VERIFY_ARE_EQUAL(first_name, _XPLATSTR("Alex"));
+	VERIFY_ARE_EQUAL(complex_value->try_get(_XPLATSTR("LastName"), last_name), true);
+	VERIFY_ARE_EQUAL(last_name, _XPLATSTR("Green"));
 
 }
 
@@ -163,59 +163,59 @@ TEST(derived_complex_test)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto json_reader = std::make_shared<odata_json_reader>(model, g_service_root_url);
+	auto json_reader = ::odata::make_shared<odata_json_reader>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(json_reader);
 
-    ::utility::string_t _entity_payload = U(
+    ::odata::string_t _entity_payload = _XPLATSTR(
 	   "{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/VIPAccountInfo\", \
 		\"FirstName\":\"Alex\",\"LastName\":\"Green\",\"VIP_Info\":\"Gold\"}"
 		);
 
 	web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
-	VERIFY_IS_NOT_NULL(return_payload);	
+	auto return_payload = json_reader->deserialize(json_payload);
+	VERIFY_IS_NOT_NULL(return_payload);
 	auto entity_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto complex_value = std::dynamic_pointer_cast<odata_complex_value>(entity_values[0]);
 	VERIFY_IS_NOT_NULL(complex_value);
-	::utility::string_t first_name, last_name, vip_info;
-	VERIFY_ARE_EQUAL(complex_value->try_get(U("FirstName"), first_name), true);
-	VERIFY_ARE_EQUAL(first_name, U("Alex"));
-	VERIFY_ARE_EQUAL(complex_value->try_get(U("LastName"), last_name), true);
-	VERIFY_ARE_EQUAL(last_name, U("Green"));
-	VERIFY_ARE_EQUAL(complex_value->try_get(U("VIP_Info"), vip_info), true);
-	VERIFY_ARE_EQUAL(vip_info, U("Gold"));
+	::odata::string_t first_name, last_name, vip_info;
+	VERIFY_ARE_EQUAL(complex_value->try_get(_XPLATSTR("FirstName"), first_name), true);
+	VERIFY_ARE_EQUAL(first_name, _XPLATSTR("Alex"));
+	VERIFY_ARE_EQUAL(complex_value->try_get(_XPLATSTR("LastName"), last_name), true);
+	VERIFY_ARE_EQUAL(last_name, _XPLATSTR("Green"));
+	VERIFY_ARE_EQUAL(complex_value->try_get(_XPLATSTR("VIP_Info"), vip_info), true);
+	VERIFY_ARE_EQUAL(vip_info, _XPLATSTR("Gold"));
 }
 
 TEST(derived_complex_test_2)
 {
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto json_reader = std::make_shared<odata_json_reader>(model, g_service_root_url);
+	auto json_reader = ::odata::make_shared<odata_json_reader>(model, g_service_root_url);
 	VERIFY_IS_NOT_NULL(json_reader);
 
-    ::utility::string_t _entity_payload = U(
+    ::odata::string_t _entity_payload = _XPLATSTR(
 	   "{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/AccountInfo\", \
 		\"@odata.type\":\"#Microsoft.Test.OData.Services.ODataWCFService.VIPAccountInfo\",\"FirstName\":\"Alex\",\"LastName\":\"Green\",\"VIP_Info\":\"Gold\"}"
 		);
 
 	web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
-	VERIFY_IS_NOT_NULL(return_payload);	
+	auto return_payload = json_reader->deserialize(json_payload);
+	VERIFY_IS_NOT_NULL(return_payload);
 	auto entity_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto complex_value = std::dynamic_pointer_cast<odata_complex_value>(entity_values[0]);
 	VERIFY_IS_NOT_NULL(complex_value);
-	::utility::string_t first_name, last_name, vip_info;
-	VERIFY_ARE_EQUAL(complex_value->try_get(U("FirstName"), first_name), true);
-	VERIFY_ARE_EQUAL(first_name, U("Alex"));
-	VERIFY_ARE_EQUAL(complex_value->try_get(U("LastName"), last_name), true);
-	VERIFY_ARE_EQUAL(last_name, U("Green"));
-	VERIFY_ARE_EQUAL(complex_value->try_get(U("VIP_Info"), vip_info), true);
-	VERIFY_ARE_EQUAL(vip_info, U("Gold"));
+	::odata::string_t first_name, last_name, vip_info;
+	VERIFY_ARE_EQUAL(complex_value->try_get(_XPLATSTR("FirstName"), first_name), true);
+	VERIFY_ARE_EQUAL(first_name, _XPLATSTR("Alex"));
+	VERIFY_ARE_EQUAL(complex_value->try_get(_XPLATSTR("LastName"), last_name), true);
+	VERIFY_ARE_EQUAL(last_name, _XPLATSTR("Green"));
+	VERIFY_ARE_EQUAL(complex_value->try_get(_XPLATSTR("VIP_Info"), vip_info), true);
+	VERIFY_ARE_EQUAL(vip_info, _XPLATSTR("Gold"));
 	auto complex_type = complex_value->get_value_type();
 	VERIFY_IS_NOT_NULL(complex_type);
-	VERIFY_ARE_EQUAL(complex_type->get_name(), U("VIPAccountInfo"));
+	VERIFY_ARE_EQUAL(complex_type->get_name(), _XPLATSTR("VIPAccountInfo"));
 }
 
 TEST(single_primitive_test)
@@ -223,20 +223,20 @@ TEST(single_primitive_test)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload = U(
+	::odata::string_t _entity_payload = _XPLATSTR(
 	   "{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/AccountInfo/FirstName\", \
 		\"value\":\"Alex\"}"
 		);
 
  	web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
-	VERIFY_IS_NOT_NULL(return_payload);	
+	auto return_payload = json_reader->deserialize(json_payload);
+	VERIFY_IS_NOT_NULL(return_payload);
 	auto entity_values = return_payload->get_values();
-	VERIFY_ARE_EQUAL(entity_values.size(), 1);   
+	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(entity_values[0]);
 	VERIFY_IS_NOT_NULL(primitive_value);
 	VERIFY_ARE_EQUAL(primitive_value->get_value_type()->get_type_kind(), edm_type_kind_t::Primitive);
-	VERIFY_ARE_EQUAL(primitive_value->to_string(), U("Alex"));
+	VERIFY_ARE_EQUAL(primitive_value->to_string(), _XPLATSTR("Alex"));
 }
 
 TEST(collection_of_primitive_test)
@@ -244,28 +244,28 @@ TEST(collection_of_primitive_test)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload = U(
+	::odata::string_t _entity_payload = _XPLATSTR(
 	    "{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#People(4)/Numbers\", \
 		\"value\":[\"444-444-4444\",\"555-555-5555\",\"666-666-6666\"]}"
 		);
 
  	web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
-	VERIFY_IS_NOT_NULL(return_payload);	
+	auto return_payload = json_reader->deserialize(json_payload);
+	VERIFY_IS_NOT_NULL(return_payload);
 	auto entity_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(entity_values.size(), 3);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(entity_values[0]);
 	VERIFY_IS_NOT_NULL(primitive_value);
 	VERIFY_ARE_EQUAL(primitive_value->get_value_type()->get_type_kind(), edm_type_kind_t::Primitive);
-	VERIFY_ARE_EQUAL(primitive_value->to_string(), U("444-444-4444"));
+	VERIFY_ARE_EQUAL(primitive_value->to_string(), _XPLATSTR("444-444-4444"));
     primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(entity_values[1]);
 	VERIFY_IS_NOT_NULL(primitive_value);
 	VERIFY_ARE_EQUAL(primitive_value->get_value_type()->get_type_kind(), edm_type_kind_t::Primitive);
-	VERIFY_ARE_EQUAL(primitive_value->to_string(), U("555-555-5555"));
+	VERIFY_ARE_EQUAL(primitive_value->to_string(), _XPLATSTR("555-555-5555"));
     primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(entity_values[2]);
 	VERIFY_IS_NOT_NULL(primitive_value);
 	VERIFY_ARE_EQUAL(primitive_value->get_value_type()->get_type_kind(), edm_type_kind_t::Primitive);
-	VERIFY_ARE_EQUAL(primitive_value->to_string(), U("666-666-6666"));
+	VERIFY_ARE_EQUAL(primitive_value->to_string(), _XPLATSTR("666-666-6666"));
 }
 
 TEST(json_primitive_int16)
@@ -273,11 +273,11 @@ TEST(json_primitive_int16)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/TestInt16\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/TestInt16\", \
 		\"value\":32}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::Int16);
@@ -290,11 +290,11 @@ TEST(json_primitive_int16_max)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/TestInt16\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/TestInt16\", \
 		\"value\":32767}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::Int16);
@@ -307,11 +307,11 @@ TEST(json_primitive_int16_min)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/TestInt16\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/TestInt16\", \
 		\"value\":-32768}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::Int16);
@@ -324,11 +324,11 @@ TEST(json_primitive_int32)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/ProductID\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/ProductID\", \
 		\"value\":5}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::Int32);
@@ -341,11 +341,11 @@ TEST(json_primitive_int32_max)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/ProductID\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/ProductID\", \
 		\"value\":2147483647}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::Int32);
@@ -358,11 +358,11 @@ TEST(json_primitive_int32_min)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/ProductID\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/ProductID\", \
 		\"value\":-2147483648}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::Int32);
@@ -375,11 +375,11 @@ TEST(json_primitive_int64)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Company/Revenue\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Company/Revenue\", \
 		\"value\":100000}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::Int64);
@@ -392,11 +392,11 @@ TEST(json_primitive_int64_max)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Company/Revenue\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Company/Revenue\", \
 		\"value\":9223372036854775807}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::Int64);
@@ -409,11 +409,11 @@ TEST(json_primitive_int64_min)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Company/Revenue\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Company/Revenue\", \
 		\"value\":-9223372036854775808}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::Int64);
@@ -426,11 +426,11 @@ TEST(json_primitive_bool)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/Discontinued\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/Discontinued\", \
 		\"value\":false}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::Boolean);
@@ -443,11 +443,11 @@ TEST(json_primitive_binary)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/TestBinary\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/TestBinary\", \
 		\"value\":\"UUJBQkFDWDEyKjEyMzQ1Njc4OTBhYmNkZQ==\"}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::Binary);
@@ -463,11 +463,11 @@ TEST(json_primitive_sbyte)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/TestSByte\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/TestSByte\", \
 		\"value\":45}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::SByte);
@@ -480,11 +480,11 @@ TEST(json_primitive_byte)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/TestByte\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/TestByte\", \
 		\"value\":-23}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::Byte);
@@ -497,11 +497,11 @@ TEST(json_primitive_double)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyGiftCard/Amount\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyGiftCard/Amount\", \
 		\"value\":123.3434}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::Double);
@@ -514,11 +514,11 @@ TEST(json_primitive_float)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/TestFloat\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/TestFloat\", \
 		\"value\":-123.4}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::Single);
@@ -531,11 +531,11 @@ TEST(json_primitive_duration)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Customers(2)/TimeBetweenLastTwoOrders\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Customers(2)/TimeBetweenLastTwoOrders\", \
 		\"value\":\"PT1H38M23S\"}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::Duration);
@@ -548,16 +548,16 @@ TEST(json_primitive_datetime)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#People(3)/Microsoft.Test.OData.Services.ODataWCFService.Employee/DateHired\", \
+	::odata::string_t _payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#People(3)/Microsoft.Test.OData.Services.ODataWCFService.Employee/DateHired\", \
 		\"value\":\"2010-12-13T00:00:00Z\"}");
 
  	web::json::value json_payload = web::json::value::parse(_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(return_payload->get_values()[0]);
 	auto primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(primitive_value->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::DateTimeOffset);
 	VERIFY_ARE_EQUAL(primitive_type->get_type_kind(), edm_type_kind_t::Primitive);
-	VERIFY_ARE_EQUAL(primitive_value->as<::utility::datetime>().to_string(::utility::datetime::ISO_8601), U("2010-12-13T00:00:00Z"));
+	VERIFY_ARE_EQUAL(primitive_value->as<::utility::datetime>().to_string(::utility::datetime::ISO_8601), _XPLATSTR("2010-12-13T00:00:00Z"));
 }
 
 TEST(collection_of_primitive_with_single_return_test)
@@ -565,20 +565,20 @@ TEST(collection_of_primitive_with_single_return_test)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload = U(
+	::odata::string_t _entity_payload = _XPLATSTR(
 	    "{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#People(4)/Numbers\", \
 		\"value\":[\"111-11-1111\"]}"
 		);
 
  	web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
-	VERIFY_IS_NOT_NULL(return_payload);	
+	auto return_payload = json_reader->deserialize(json_payload);
+	VERIFY_IS_NOT_NULL(return_payload);
 	auto entity_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(entity_values[0]);
 	VERIFY_IS_NOT_NULL(primitive_value);
 	VERIFY_ARE_EQUAL(primitive_value->get_value_type()->get_type_kind(), edm_type_kind_t::Primitive);
-	VERIFY_ARE_EQUAL(primitive_value->as<::utility::string_t>(), U("111-11-1111"));
+	VERIFY_ARE_EQUAL(primitive_value->as<::odata::string_t>(), _XPLATSTR("111-11-1111"));
 }
 
 TEST(collection_of_primitive_with_empty_return_test)
@@ -586,14 +586,14 @@ TEST(collection_of_primitive_with_empty_return_test)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload = U(
+	::odata::string_t _entity_payload = _XPLATSTR(
 	    "{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#People(4)/Numbers\", \
 		\"value\":[]}"
 		);
 
  	web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
-	VERIFY_IS_NOT_NULL(return_payload);	
+	auto return_payload = json_reader->deserialize(json_payload);
+	VERIFY_IS_NOT_NULL(return_payload);
 	auto entity_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(entity_values.size(), 0);
 }
@@ -603,19 +603,19 @@ TEST(single_enum_test)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload = U(
+	::odata::string_t _entity_payload = _XPLATSTR(
 		"{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/SkinColor\",\"value\":\"Red\"}"
 		);
 
  	web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
-	VERIFY_IS_NOT_NULL(return_payload);	
+	auto return_payload = json_reader->deserialize(json_payload);
+	VERIFY_IS_NOT_NULL(return_payload);
 	auto return_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(return_values.size(), 1);
 	auto enum_value = std::dynamic_pointer_cast<odata_enum_value>(return_values[0]);
 	VERIFY_IS_NOT_NULL(enum_value);
 	VERIFY_ARE_EQUAL(enum_value->get_value_type()->get_type_kind(), edm_type_kind_t::Enum);
-	VERIFY_ARE_EQUAL(enum_value->to_string(), U("Red"));
+	VERIFY_ARE_EQUAL(enum_value->to_string(), _XPLATSTR("Red"));
 }
 
 TEST(collection_of_enum_test)
@@ -623,28 +623,28 @@ TEST(collection_of_enum_test)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload = U(
+	::odata::string_t _entity_payload = _XPLATSTR(
 	    "{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/CoverColors\", \
 		\"value\":[\"Green\",\"Blue\",\"Blue\"]}"
 		);
 
  	web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
-	VERIFY_IS_NOT_NULL(return_payload);	
+	auto return_payload = json_reader->deserialize(json_payload);
+	VERIFY_IS_NOT_NULL(return_payload);
 	auto return_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(return_values.size(), 3);
 	auto enum_value = std::dynamic_pointer_cast<odata_enum_value>(return_values[0]);
 	VERIFY_IS_NOT_NULL(enum_value);
 	VERIFY_ARE_EQUAL(enum_value->get_value_type()->get_type_kind(), edm_type_kind_t::Enum);
-	VERIFY_ARE_EQUAL(enum_value->to_string(), U("Green"));
+	VERIFY_ARE_EQUAL(enum_value->to_string(), _XPLATSTR("Green"));
 	enum_value = std::dynamic_pointer_cast<odata_enum_value>(return_values[1]);
 	VERIFY_IS_NOT_NULL(enum_value);
 	VERIFY_ARE_EQUAL(enum_value->get_value_type()->get_type_kind(), edm_type_kind_t::Enum);
-	VERIFY_ARE_EQUAL(enum_value->to_string(), U("Blue"));
+	VERIFY_ARE_EQUAL(enum_value->to_string(), _XPLATSTR("Blue"));
 	enum_value = std::dynamic_pointer_cast<odata_enum_value>(return_values[2]);
 	VERIFY_IS_NOT_NULL(enum_value);
 	VERIFY_ARE_EQUAL(enum_value->get_value_type()->get_type_kind(), edm_type_kind_t::Enum);
-	VERIFY_ARE_EQUAL(enum_value->to_string(), U("Blue"));
+	VERIFY_ARE_EQUAL(enum_value->to_string(), _XPLATSTR("Blue"));
 }
 
 TEST(collection_of_enum_with_single_return_test)
@@ -652,20 +652,20 @@ TEST(collection_of_enum_with_single_return_test)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload = U(
+	::odata::string_t _entity_payload = _XPLATSTR(
 	    "{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/CoverColors\", \
 		\"value\":[\"Green\"]}"
 		);
 
  	web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
-	VERIFY_IS_NOT_NULL(return_payload);	
+	auto return_payload = json_reader->deserialize(json_payload);
+	VERIFY_IS_NOT_NULL(return_payload);
 	auto return_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(return_values.size(), 1);
 	auto enum_value = std::dynamic_pointer_cast<odata_enum_value>(return_values[0]);
 	VERIFY_IS_NOT_NULL(enum_value);
 	VERIFY_ARE_EQUAL(enum_value->get_value_type()->get_type_kind(), edm_type_kind_t::Enum);
-	VERIFY_ARE_EQUAL(enum_value->to_string(), U("Green"));
+	VERIFY_ARE_EQUAL(enum_value->to_string(), _XPLATSTR("Green"));
 
 }
 
@@ -674,14 +674,14 @@ TEST(collection_of_enum_with_empty_return_test)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload = U(
+	::odata::string_t _entity_payload = _XPLATSTR(
 	    "{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(5)/CoverColors\", \
 		\"value\":[]}"
 		);
 
  	web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
-	VERIFY_IS_NOT_NULL(return_payload);	
+	auto return_payload = json_reader->deserialize(json_payload);
+	VERIFY_IS_NOT_NULL(return_payload);
 	auto return_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(return_values.size(), 0);
 }
@@ -691,7 +691,7 @@ TEST(singleton_test)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload = U(
+	::odata::string_t _entity_payload = _XPLATSTR(
 		"{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#DefaultStoredPI\", \
 		\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/DefaultStoredPI\", \
 		\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/DefaultStoredPI\", \
@@ -699,24 +699,24 @@ TEST(singleton_test)
 		);
 
 	::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	VERIFY_IS_NOT_NULL(return_payload);
 	auto entity_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
 	VERIFY_IS_NOT_NULL(entity_value);
 	int storedpid = 0;
-	VERIFY_ARE_EQUAL(entity_value->try_get(U("StoredPIID"), storedpid), true);
+	VERIFY_ARE_EQUAL(entity_value->try_get(_XPLATSTR("StoredPIID"), storedpid), true);
 	VERIFY_ARE_EQUAL(storedpid, 800);
-    ::utility::string_t pinname;
-	VERIFY_ARE_EQUAL(entity_value->try_get(U("PIName"), pinname), true);
-	VERIFY_ARE_EQUAL(pinname, U("The Default Stored PI"));
-    ::utility::string_t pitype;
-	VERIFY_ARE_EQUAL(entity_value->try_get(U("PIType"), pitype), true);
-	VERIFY_ARE_EQUAL(pitype, U("CreditCard"));
+    ::odata::string_t pinname;
+	VERIFY_ARE_EQUAL(entity_value->try_get(_XPLATSTR("PIName"), pinname), true);
+	VERIFY_ARE_EQUAL(pinname, _XPLATSTR("The Default Stored PI"));
+    ::odata::string_t pitype;
+	VERIFY_ARE_EQUAL(entity_value->try_get(_XPLATSTR("PIType"), pitype), true);
+	VERIFY_ARE_EQUAL(pitype, _XPLATSTR("CreditCard"));
 	::utility::datetime createdate;
-	VERIFY_ARE_EQUAL(entity_value->try_get(U("CreatedDate"), createdate), true);
-	VERIFY_ARE_EQUAL(createdate.to_string(::utility::datetime::date_format::ISO_8601), U("2013-12-31T00:00:00Z"));
+	VERIFY_ARE_EQUAL(entity_value->try_get(_XPLATSTR("CreatedDate"), createdate), true);
+	VERIFY_ARE_EQUAL(createdate.to_string(::utility::datetime::date_format::ISO_8601), _XPLATSTR("2013-12-31T00:00:00Z"));
 }
 
 TEST(single_entity_with_single_navigation_test)
@@ -724,30 +724,30 @@ TEST(single_entity_with_single_navigation_test)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload = U(
+	::odata::string_t _entity_payload = _XPLATSTR(
 		"{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyGiftCard/$entity\", \
 		\"GiftCardID\":301,\"GiftCardNO\":\"AAA123A\",\"Amount\":19.9,\"ExperationDate\":\"2013-12-30T00:00:00Z\"}"
 		);
 
 	::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	VERIFY_IS_NOT_NULL(return_payload);
 	auto entity_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
 	VERIFY_IS_NOT_NULL(entity_value);
 	int cardid = 0;
-	VERIFY_ARE_EQUAL(entity_value->try_get(U("GiftCardID"), cardid), true);
+	VERIFY_ARE_EQUAL(entity_value->try_get(_XPLATSTR("GiftCardID"), cardid), true);
 	VERIFY_ARE_EQUAL(cardid, 301);
-    ::utility::string_t cardno;
-	VERIFY_ARE_EQUAL(entity_value->try_get(U("GiftCardNO"), cardno), true);
-	VERIFY_ARE_EQUAL(cardno, U("AAA123A"));
+    ::odata::string_t cardno;
+	VERIFY_ARE_EQUAL(entity_value->try_get(_XPLATSTR("GiftCardNO"), cardno), true);
+	VERIFY_ARE_EQUAL(cardno, _XPLATSTR("AAA123A"));
     double amount;
-	VERIFY_ARE_EQUAL(entity_value->try_get(U("Amount"), amount), true);
+	VERIFY_ARE_EQUAL(entity_value->try_get(_XPLATSTR("Amount"), amount), true);
 	VERIFY_ARE_EQUAL(amount, 19.9);
 	::utility::datetime experationdate;
-	VERIFY_ARE_EQUAL(entity_value->try_get(U("ExperationDate"), experationdate), true);
-	VERIFY_ARE_EQUAL(experationdate.to_string(::utility::datetime::date_format::ISO_8601), U("2013-12-30T00:00:00Z"));
+	VERIFY_ARE_EQUAL(entity_value->try_get(_XPLATSTR("ExperationDate"), experationdate), true);
+	VERIFY_ARE_EQUAL(experationdate.to_string(::utility::datetime::date_format::ISO_8601), _XPLATSTR("2013-12-30T00:00:00Z"));
 }
 
 TEST(single_entity_with_collection_of_navigation_test)
@@ -755,7 +755,7 @@ TEST(single_entity_with_collection_of_navigation_test)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload = U(
+	::odata::string_t _entity_payload = _XPLATSTR(
 		"{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyPaymentInstruments\", \
 		\"value\":[{\"PaymentInstrumentID\":101901,\"FriendlyName\":\"101 first PI\",\"CreatedDate\":\"2012-11-01T00:00:00Z\"}, \
 		{\"@odata.type\":\"#Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI\",\"PaymentInstrumentID\":101902,\"FriendlyName\": \
@@ -767,22 +767,22 @@ TEST(single_entity_with_collection_of_navigation_test)
 		);
 
     ::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	VERIFY_IS_NOT_NULL(return_payload);
 	auto entity_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(entity_values.size(), 3);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
 	VERIFY_IS_NOT_NULL(entity_value);
 	int payid = 0;
-	VERIFY_ARE_EQUAL(entity_value->try_get(U("PaymentInstrumentID"), payid), true);
+	VERIFY_ARE_EQUAL(entity_value->try_get(_XPLATSTR("PaymentInstrumentID"), payid), true);
 	VERIFY_ARE_EQUAL(payid, 101901);
     entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[1]);
 	VERIFY_IS_NOT_NULL(entity_value);
-	VERIFY_ARE_EQUAL(entity_value->try_get(U("PaymentInstrumentID"), payid), true);
+	VERIFY_ARE_EQUAL(entity_value->try_get(_XPLATSTR("PaymentInstrumentID"), payid), true);
 	VERIFY_ARE_EQUAL(payid, 101902);
     entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[2]);
 	VERIFY_IS_NOT_NULL(entity_value);
-	VERIFY_ARE_EQUAL(entity_value->try_get(U("PaymentInstrumentID"), payid), true);
+	VERIFY_ARE_EQUAL(entity_value->try_get(_XPLATSTR("PaymentInstrumentID"), payid), true);
 	VERIFY_ARE_EQUAL(payid, 101903);
 }
 
@@ -790,7 +790,7 @@ TEST(collection_of_entity_with_single_navigation_test)
 {
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
-	::utility::string_t _entity_payload = U(
+	::odata::string_t _entity_payload = _XPLATSTR(
 		"{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Employees\",  \
 		\"value\":[{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Employees(PersonID=3)\", \
 		\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Employees(PersonID=3)\", \
@@ -814,14 +814,14 @@ TEST(collection_of_entity_with_single_navigation_test)
 	    );
 
     ::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	VERIFY_IS_NOT_NULL(return_payload);
 	auto entity_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(entity_values.size(), 2);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
 	VERIFY_IS_NOT_NULL(entity_value);
 	std::shared_ptr<odata_value> property_value;
-	auto ok = entity_value->get_property_value(U("Company"), property_value);
+	auto ok = entity_value->get_property_value(_XPLATSTR("Company"), property_value);
 	auto contained_value = std::dynamic_pointer_cast<odata_entity_value>(property_value);
 	VERIFY_IS_NOT_NULL(contained_value);
 	VERIFY_ARE_EQUAL(contained_value->properties().size(), 7);
@@ -832,17 +832,17 @@ TEST(collection_of_entity_with_collection_of_navigation_test)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts\",\"value\":[{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)\",\"AccountID\":101,\"CountryRegion\":\"US\",\"AccountInfo\":{\"FirstName\":\"Alex\",\"LastName\":\"Green\"},\"MyPaymentInstruments@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyPaymentInstruments\",\"MyPaymentInstruments\":[{\"PaymentInstrumentID\":101901,\"FriendlyName\":\"101 first PI\",\"CreatedDate\":\"2012-11-01T00:00:00Z\"},{\"@odata.type\":\"#Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI\",\"PaymentInstrumentID\":101902,\"FriendlyName\":\"101 frist credit PI\",\"CreatedDate\":\"2012-11-01T00:00:00Z\",\"CardNumber\":\"6000000000000000\",\"CVV\":\"234\",\"HolderName\":\"Alex\",\"Balance\":100.0,\"ExperationDate\":\"2022-11-01T00:00:00Z\"},{\"@odata.type\":\"#Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI\",\"PaymentInstrumentID\":101903,\"FriendlyName\":\"101 second credit PI\",\"CreatedDate\":\"2012-11-01T00:00:00Z\",\"CardNumber\":\"8000000000000000\",\"CVV\":\"012\",\"HolderName\":\"James\",\"Balance\":300.0,\"ExperationDate\":\"2022-10-02T00:00:00Z\"}]},{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(102)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(102)\",\"AccountID\":102,\"CountryRegion\":\"GB\",\"AccountInfo\":{\"FirstName\":\"James\",\"LastName\":\"Bunder\"},\"MyPaymentInstruments@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(102)/MyPaymentInstruments\",\"MyPaymentInstruments\":[]},{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)\",\"AccountID\":103,\"CountryRegion\":\"CN\",\"AccountInfo\":{\"FirstName\":\"Adam\",\"LastName\":\"Homes\"},\"MyPaymentInstruments@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(103)/MyPaymentInstruments\",\"MyPaymentInstruments\":[{\"PaymentInstrumentID\":103901,\"FriendlyName\":\"103 frist PI\",\"CreatedDate\":\"2013-10-01T00:00:00Z\"},{\"PaymentInstrumentID\":103902,\"FriendlyName\":\"103 second PI\",\"CreatedDate\":\"2013-01-01T00:00:00Z\"},{\"PaymentInstrumentID\":103905,\"FriendlyName\":\"103 new PI\",\"CreatedDate\":\"2013-10-29T00:00:00Z\"},{\"PaymentInstrumentID\":101910,\"FriendlyName\":\"103 backup PI\",\"CreatedDate\":\"2013-06-15T00:00:00Z\"}]},{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(104)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(104)\",\"AccountID\":104,\"CountryRegion\":\"CN\",\"AccountInfo\":{\"FirstName\":\"Adrian\",\"LastName\":\"Green\"},\"MyPaymentInstruments@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(104)/MyPaymentInstruments\",\"MyPaymentInstruments\":[]},{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(105)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(105)\",\"AccountID\":105,\"CountryRegion\":\"US\",\"AccountInfo\":{\"FirstName\":\"Lily\",\"LastName\":\"Green\"},\"MyPaymentInstruments@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(105)/MyPaymentInstruments\",\"MyPaymentInstruments\":[]},{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(106)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(106)\",\"AccountID\":106,\"CountryRegion\":\"CN\",\"AccountInfo\":{\"FirstName\":\"Allen\",\"LastName\":\"Ivorson\"},\"MyPaymentInstruments@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(106)/MyPaymentInstruments\",\"MyPaymentInstruments\":[]},{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(107)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(107)\",\"AccountID\":107,\"CountryRegion\":\"FR\",\"AccountInfo\":{\"FirstName\":\"Albert\",\"LastName\":\"Ivorson\"},\"MyPaymentInstruments@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(107)/MyPaymentInstruments\",\"MyPaymentInstruments\":[]}]}");
+	::odata::string_t _entity_payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts\",\"value\":[{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)\",\"AccountID\":101,\"CountryRegion\":\"US\",\"AccountInfo\":{\"FirstName\":\"Alex\",\"LastName\":\"Green\"},\"MyPaymentInstruments@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyPaymentInstruments\",\"MyPaymentInstruments\":[{\"PaymentInstrumentID\":101901,\"FriendlyName\":\"101 first PI\",\"CreatedDate\":\"2012-11-01T00:00:00Z\"},{\"@odata.type\":\"#Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI\",\"PaymentInstrumentID\":101902,\"FriendlyName\":\"101 frist credit PI\",\"CreatedDate\":\"2012-11-01T00:00:00Z\",\"CardNumber\":\"6000000000000000\",\"CVV\":\"234\",\"HolderName\":\"Alex\",\"Balance\":100.0,\"ExperationDate\":\"2022-11-01T00:00:00Z\"},{\"@odata.type\":\"#Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI\",\"PaymentInstrumentID\":101903,\"FriendlyName\":\"101 second credit PI\",\"CreatedDate\":\"2012-11-01T00:00:00Z\",\"CardNumber\":\"8000000000000000\",\"CVV\":\"012\",\"HolderName\":\"James\",\"Balance\":300.0,\"ExperationDate\":\"2022-10-02T00:00:00Z\"}]},{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(102)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(102)\",\"AccountID\":102,\"CountryRegion\":\"GB\",\"AccountInfo\":{\"FirstName\":\"James\",\"LastName\":\"Bunder\"},\"MyPaymentInstruments@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(102)/MyPaymentInstruments\",\"MyPaymentInstruments\":[]},{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)\",\"AccountID\":103,\"CountryRegion\":\"CN\",\"AccountInfo\":{\"FirstName\":\"Adam\",\"LastName\":\"Homes\"},\"MyPaymentInstruments@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(103)/MyPaymentInstruments\",\"MyPaymentInstruments\":[{\"PaymentInstrumentID\":103901,\"FriendlyName\":\"103 frist PI\",\"CreatedDate\":\"2013-10-01T00:00:00Z\"},{\"PaymentInstrumentID\":103902,\"FriendlyName\":\"103 second PI\",\"CreatedDate\":\"2013-01-01T00:00:00Z\"},{\"PaymentInstrumentID\":103905,\"FriendlyName\":\"103 new PI\",\"CreatedDate\":\"2013-10-29T00:00:00Z\"},{\"PaymentInstrumentID\":101910,\"FriendlyName\":\"103 backup PI\",\"CreatedDate\":\"2013-06-15T00:00:00Z\"}]},{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(104)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(104)\",\"AccountID\":104,\"CountryRegion\":\"CN\",\"AccountInfo\":{\"FirstName\":\"Adrian\",\"LastName\":\"Green\"},\"MyPaymentInstruments@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(104)/MyPaymentInstruments\",\"MyPaymentInstruments\":[]},{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(105)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(105)\",\"AccountID\":105,\"CountryRegion\":\"US\",\"AccountInfo\":{\"FirstName\":\"Lily\",\"LastName\":\"Green\"},\"MyPaymentInstruments@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(105)/MyPaymentInstruments\",\"MyPaymentInstruments\":[]},{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(106)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(106)\",\"AccountID\":106,\"CountryRegion\":\"CN\",\"AccountInfo\":{\"FirstName\":\"Allen\",\"LastName\":\"Ivorson\"},\"MyPaymentInstruments@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(106)/MyPaymentInstruments\",\"MyPaymentInstruments\":[]},{\"@odata.id\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(107)\",\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(107)\",\"AccountID\":107,\"CountryRegion\":\"FR\",\"AccountInfo\":{\"FirstName\":\"Albert\",\"LastName\":\"Ivorson\"},\"MyPaymentInstruments@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(107)/MyPaymentInstruments\",\"MyPaymentInstruments\":[]}]}");
 
     ::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	VERIFY_IS_NOT_NULL(return_payload);
 	auto entity_values = return_payload->get_values();
 	VERIFY_ARE_EQUAL(entity_values.size(), 7);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
 	VERIFY_IS_NOT_NULL(entity_value);
 	std::shared_ptr<odata_value> property_value;
-	auto ok = entity_value->get_property_value(U("MyPaymentInstruments"), property_value);
+	auto ok = entity_value->get_property_value(_XPLATSTR("MyPaymentInstruments"), property_value);
 	auto contained_values = std::dynamic_pointer_cast<odata_collection_value>(property_value);
 	VERIFY_IS_NOT_NULL(contained_values);
 	VERIFY_ARE_EQUAL(contained_values->get_collection_values().size(), 3);
@@ -859,27 +859,27 @@ TEST(edit_link_entity_set)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(ProductID)\", \
+	::odata::string_t _entity_payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(ProductID)\", \
 		\"value\":[{\"ProductID\":1},{\"ProductID\":2}]}");
 
     ::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto entity_values = return_payload->get_values();
 
 	VERIFY_ARE_EQUAL(entity_values.size(), 2);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
-	::utility::string_t edit_link;
-	auto ok = entity_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Products(1)"));
+	::odata::string_t edit_link;
+	auto ok = entity_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Products(1)"));
 
 	entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[1]);
-	ok = entity_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Products(2)"));
+	ok = entity_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Products(2)"));
 }
 
 TEST(edit_link_entity_relative_path)
 {
-	::utility::string_t _entity_payload = U(
+	::odata::string_t _entity_payload = _XPLATSTR(
 		"{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts/$entity\", \
 		\"@odata.editLink\":\"Accounts(101)\", \
 		\"AccountID\":101,\"CountryRegion\":\"%0A%E4%B8%AD%E5%8D%8E%E4%BA%BA%E6%B0%91%E5%85%B1%E5%92%8C%E5%9B%BD\",\"AccountInfo\":{\"FirstName\":\"Alex\",\"LastName\":\"Green\"}}"
@@ -889,14 +889,14 @@ TEST(edit_link_entity_relative_path)
 	VERIFY_IS_NOT_NULL(json_reader);
 
 	::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto entity_values = return_payload->get_values();
 
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
-	::utility::string_t edit_link;
-	auto ok = entity_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)"));
+	::odata::string_t edit_link;
+	auto ok = entity_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)"));
 }
 
 //http://services.odata.org/V4/Northwind/Northwind.svc/Products(1)
@@ -905,18 +905,18 @@ TEST(edit_link_entity_set_with_key)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload 
-		= U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(ProductID)/$entity\", \"ProductID\":1}");
+	::odata::string_t _entity_payload
+		= _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products(ProductID)/$entity\", \"ProductID\":1}");
 
     ::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto entity_values = return_payload->get_values();
 
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
-	::utility::string_t edit_link;
-	auto ok = entity_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Products(1)"));
+	::odata::string_t edit_link;
+	auto ok = entity_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Products(1)"));
 }
 
 //http://odatae2etest.azurewebsites.net/cpptest/DefaultService/LabourUnion
@@ -925,18 +925,18 @@ TEST(edit_link_singleton)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload 
-		= U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#LabourUnion\",\"LabourUnionID\":0,\"Name\":\"MS Labour Union\"}");
+	::odata::string_t _entity_payload
+		= _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#LabourUnion\",\"LabourUnionID\":0,\"Name\":\"MS Labour Union\"}");
 
     ::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto entity_values = return_payload->get_values();
 
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
-	::utility::string_t edit_link;
-	auto ok = entity_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/LabourUnion"));
+	::odata::string_t edit_link;
+	auto ok = entity_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/LabourUnion"));
 }
 
 //http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts?$expand=MyPaymentInstruments
@@ -945,27 +945,27 @@ TEST(edit_link_contained_navigation)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload 
-		= U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(AccountID,MyPaymentInstruments,MyPaymentInstruments(PaymentInstrumentID))\", \
+	::odata::string_t _entity_payload
+		= _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(AccountID,MyPaymentInstruments,MyPaymentInstruments(PaymentInstrumentID))\", \
 		\"value\":[{\"AccountID\":101,\"MyPaymentInstruments@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyPaymentInstruments(PaymentInstrumentID)\",\"MyPaymentInstruments\":[{\"PaymentInstrumentID\":101901}]}]}");
 
     ::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto entity_values = return_payload->get_values();
 
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
-	::utility::string_t edit_link;
-	auto ok = entity_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)"));
+	::odata::string_t edit_link;
+	auto ok = entity_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)"));
 
 	std::shared_ptr<odata_value> property_value;
-	ok = entity_value->get_property_value(U("MyPaymentInstruments"), property_value);
+	ok = entity_value->get_property_value(_XPLATSTR("MyPaymentInstruments"), property_value);
 	auto contained_values = std::dynamic_pointer_cast<odata_collection_value>(property_value);
 	auto contained_value = std::dynamic_pointer_cast<odata_entity_value>(contained_values->get_collection_values()[0]);
 	edit_link;
-	ok = contained_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101901)"));
+	ok = contained_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101901)"));
 }
 
 TEST(edit_link_contained_navigation_derived_type)
@@ -973,27 +973,27 @@ TEST(edit_link_contained_navigation_derived_type)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload 
-		= U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(AccountID,MyPaymentInstruments,MyPaymentInstruments(PaymentInstrumentID))\", \
+	::odata::string_t _entity_payload
+		= _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(AccountID,MyPaymentInstruments,MyPaymentInstruments(PaymentInstrumentID))\", \
 		\"value\":[{\"AccountID\":101,\"MyPaymentInstruments@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyPaymentInstruments(PaymentInstrumentID)\",\"MyPaymentInstruments\":[{\"@odata.type\": \"#Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI\",\"PaymentInstrumentID\":101901}]}]}");
 
     ::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto entity_values = return_payload->get_values();
 
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
-	::utility::string_t edit_link;
-	auto ok = entity_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)"));
+	::odata::string_t edit_link;
+	auto ok = entity_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)"));
 
 	std::shared_ptr<odata_value> property_value;
-	ok = entity_value->get_property_value(U("MyPaymentInstruments"), property_value);
+	ok = entity_value->get_property_value(_XPLATSTR("MyPaymentInstruments"), property_value);
 	auto contained_values = std::dynamic_pointer_cast<odata_collection_value>(property_value);
 	auto contained_value = std::dynamic_pointer_cast<odata_entity_value>(contained_values->get_collection_values()[0]);
 	edit_link;
-	ok = contained_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101901)/Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI"));
+	ok = contained_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101901)/Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI"));
 }
 
 //http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments
@@ -1002,19 +1002,19 @@ TEST(edit_link_contained_navigation_property_derived_type)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload 
-		= U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyPaymentInstruments(PaymentInstrumentID)\", \
+	::odata::string_t _entity_payload
+		= _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyPaymentInstruments(PaymentInstrumentID)\", \
 		\"value\":[{\"@odata.type\":\"#Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI\",\"PaymentInstrumentID\":101902}]}");
 
     ::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto entity_values = return_payload->get_values();
 
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
-	::utility::string_t edit_link;
-	auto ok = entity_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101902)/Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI"));
+	::odata::string_t edit_link;
+	auto ok = entity_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101902)/Microsoft.Test.OData.Services.ODataWCFService.CreditCardPI"));
 }
 
 //http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts?$expand=MyGiftCard
@@ -1023,26 +1023,26 @@ TEST(edit_link_singleton_contained_navigation)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload 
-		= U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(AccountID,MyGiftCard,MyGiftCard(GiftCardID))\", \
+	::odata::string_t _entity_payload
+		= _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(AccountID,MyGiftCard,MyGiftCard(GiftCardID))\", \
 		\"value\":[{\"AccountID\":101,\"MyGiftCard@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyGiftCard(GiftCardID)/$entity\",\"MyGiftCard\":{\"GiftCardID\":301}}]}");
 
     ::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto entity_values = return_payload->get_values();
 
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
-	::utility::string_t edit_link;
-	auto ok = entity_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)"));
+	::odata::string_t edit_link;
+	auto ok = entity_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)"));
 
 	std::shared_ptr<odata_value> property_value;
-	ok = entity_value->get_property_value(U("MyGiftCard"), property_value);
+	ok = entity_value->get_property_value(_XPLATSTR("MyGiftCard"), property_value);
 	auto contained_value = std::dynamic_pointer_cast<odata_entity_value>(property_value);
 	edit_link;
-	ok = contained_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyGiftCard"));
+	ok = contained_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyGiftCard"));
 }
 
 //http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyGiftCard
@@ -1051,18 +1051,18 @@ TEST(edit_link_singleton_contained_navigation_property)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload 
-		= U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyGiftCard(GiftCardID)/$entity\",\"GiftCardID\":301}");
+	::odata::string_t _entity_payload
+		= _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyGiftCard(GiftCardID)/$entity\",\"GiftCardID\":301}");
 
     ::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto entity_values = return_payload->get_values();
 
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
-	::utility::string_t edit_link;
-	auto ok = entity_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyGiftCard"));
+	::odata::string_t edit_link;
+	auto ok = entity_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyGiftCard"));
 }
 
 //http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments?$expand=BillingStatements
@@ -1071,27 +1071,27 @@ TEST(edit_link_contained_in_contained_expand)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload 
-		= U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(103)/MyPaymentInstruments(PaymentInstrumentID,BillingStatements,BillingStatements(StatementID))/$entity\",\"PaymentInstrumentID\":103901,\"BillingStatements@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(StatementID)\", \
+	::odata::string_t _entity_payload
+		= _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(103)/MyPaymentInstruments(PaymentInstrumentID,BillingStatements,BillingStatements(StatementID))/$entity\",\"PaymentInstrumentID\":103901,\"BillingStatements@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(StatementID)\", \
 		\"BillingStatements\":[{\"StatementID\":103901001},{\"StatementID\":103901002}]}");
 
     ::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto entity_values = return_payload->get_values();
 
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
-	::utility::string_t edit_link;
-	auto ok = entity_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)/MyPaymentInstruments(103901)"));
+	::odata::string_t edit_link;
+	auto ok = entity_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)/MyPaymentInstruments(103901)"));
 
 	std::shared_ptr<odata_value> property_value;
-	ok = entity_value->get_property_value(U("BillingStatements"), property_value);
+	ok = entity_value->get_property_value(_XPLATSTR("BillingStatements"), property_value);
 	auto contained_values = std::dynamic_pointer_cast<odata_collection_value>(property_value);
 	auto contained_value = std::dynamic_pointer_cast<odata_entity_value>(contained_values->get_collection_values()[0]);
 	edit_link;
-	ok = contained_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901001)"));
+	ok = contained_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901001)"));
 }
 
 //http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)/MyPaymentInstruments(103901)/BillingStatements
@@ -1100,19 +1100,19 @@ TEST(edit_link_contained_in_contained_property)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload 
-		= U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(103)/MyPaymentInstruments(103901)/BillingStatements/$entity\", \
+	::odata::string_t _entity_payload
+		= _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(103)/MyPaymentInstruments(103901)/BillingStatements/$entity\", \
 		\"StatementID\":103901001,\"TransactionType\":\"OnlinePurchase\",\"TransactionDescription\":\"Digital goods: App\",\"Amount\":100.0}");
 
     ::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto entity_values = return_payload->get_values();
 
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
-	::utility::string_t edit_link;
-	auto ok = entity_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901001)"));
+	::odata::string_t edit_link;
+	auto ok = entity_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901001)"));
 }
 
 //http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101901)/TheStoredPI
@@ -1121,18 +1121,18 @@ TEST(edit_link_none_contained_in_contained_property)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload 
-		= U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#StoredPIs(StoredPIID)/$entity\",\"StoredPIID\":802}");
+	::odata::string_t _entity_payload
+		= _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#StoredPIs(StoredPIID)/$entity\",\"StoredPIID\":802}");
 
     ::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto entity_values = return_payload->get_values();
 
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
-	::utility::string_t edit_link;
-	auto ok = entity_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/StoredPIs(802)"));
+	::odata::string_t edit_link;
+	auto ok = entity_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/StoredPIs(802)"));
 }
 
 //http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments?$expand=TheStoredPI
@@ -1141,26 +1141,26 @@ TEST(edit_link_none_contained_in_contained)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload 
-		= U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyPaymentInstruments(PaymentInstrumentID,TheStoredPI,TheStoredPI(StoredPIID))\", \
+	::odata::string_t _entity_payload
+		= _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts(101)/MyPaymentInstruments(PaymentInstrumentID,TheStoredPI,TheStoredPI(StoredPIID))\", \
 		\"value\":[{\"PaymentInstrumentID\":101901,\"TheStoredPI\":{\"StoredPIID\":802}}]}");
 
     ::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto entity_values = return_payload->get_values();
 
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
-	::utility::string_t edit_link;
-	auto ok = entity_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101901)"));
+	::odata::string_t edit_link;
+	auto ok = entity_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)/MyPaymentInstruments(101901)"));
 
 	std::shared_ptr<odata_value> property_value;
-	ok = entity_value->get_property_value(U("TheStoredPI"), property_value);
+	ok = entity_value->get_property_value(_XPLATSTR("TheStoredPI"), property_value);
 	auto contained_value = std::dynamic_pointer_cast<odata_entity_value>(property_value);
 	edit_link;
-	ok = contained_value->try_get(U("@odata.editLink"), edit_link);
-	VERIFY_ARE_EQUAL(edit_link, U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/StoredPIs(802)"));
+	ok = contained_value->try_get(_XPLATSTR("@odata.editLink"), edit_link);
+	VERIFY_ARE_EQUAL(edit_link, _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService/StoredPIs(802)"));
 }
 
 
@@ -1169,36 +1169,36 @@ TEST(read_unicode_data_in_entity)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload_escaped = U(
+	::odata::string_t _entity_payload_escaped = _XPLATSTR(
 		"{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts/$entity\", \
 		\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)\", \
 		\"AccountID\":101,\"CountryRegion\":\"\u4e0a\u6d77\",\"AccountInfo\":{\"FirstName\":\"Alex\",\"LastName\":\"Green\"}}"
 		);
-	
+
     ::web::json::value json_payload_escaped = web::json::value::parse(_entity_payload_escaped);
-	auto return_payload_escaped = json_reader->deserilize(json_payload_escaped);
+	auto return_payload_escaped = json_reader->deserialize(json_payload_escaped);
 	auto entity_values = return_payload_escaped->get_values();
 
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
-	::utility::string_t countryregion;
-	auto ok = entity_value->try_get(U("CountryRegion"), countryregion);
-	VERIFY_ARE_EQUAL(countryregion, U("上海"));
+	::odata::string_t countryregion;
+	auto ok = entity_value->try_get(_XPLATSTR("CountryRegion"), countryregion);
+	VERIFY_ARE_EQUAL(countryregion, _XPLATSTR("上海"));
 
-	::utility::string_t _entity_payload_unescaped = U(
+	::odata::string_t _entity_payload_unescaped = _XPLATSTR(
 		"{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Accounts/$entity\", \
 		\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Accounts(101)\", \
 		\"AccountID\":101,\"CountryRegion\":\"上海\",\"AccountInfo\":{\"FirstName\":\"Alex\",\"LastName\":\"Green\"}}"
 		);
 
 	::web::json::value json_payload_unescaped = web::json::value::parse(_entity_payload_unescaped);
-	auto return_payload_unescaped = json_reader->deserilize(json_payload_unescaped);
+	auto return_payload_unescaped = json_reader->deserialize(json_payload_unescaped);
 	entity_values = return_payload_unescaped->get_values();
 
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
-	ok = entity_value->try_get(U("CountryRegion"), countryregion);
-	VERIFY_ARE_EQUAL(countryregion, U("上海"));
+	ok = entity_value->try_get(_XPLATSTR("CountryRegion"), countryregion);
+	VERIFY_ARE_EQUAL(countryregion, _XPLATSTR("上海"));
 }
 
 
@@ -1210,20 +1210,20 @@ TEST(read_binary_data)
 	auto json_reader = get_json_reader();
 	VERIFY_IS_NOT_NULL(json_reader);
 
-	::utility::string_t _entity_payload = U("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products/$entity\", \
+	::odata::string_t _entity_payload = _XPLATSTR("{\"@odata.context\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/$metadata#Products/$entity\", \
 		\"@odata.editLink\":\"http://odatae2etest.azurewebsites.net/cpptest/DefaultService/Products(5)\", \
 		\"ProductID\":5,\"Picture\":\"UUJBQkFDWDEyKjEyMzQ1Njc4OTBhYmNkZQ==\"}");
 
 	::web::json::value json_payload = web::json::value::parse(_entity_payload);
-	auto return_payload = json_reader->deserilize(json_payload);
+	auto return_payload = json_reader->deserialize(json_payload);
 	auto entity_values = return_payload->get_values();
 
 	VERIFY_ARE_EQUAL(entity_values.size(), 1);
 	auto entity_value = std::dynamic_pointer_cast<odata_entity_value>(entity_values[0]);
 
     std::shared_ptr<odata_value> property_value;
-	entity_value->get_property_value(U("Picture"), property_value);
-	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value); 
+	entity_value->get_property_value(_XPLATSTR("Picture"), property_value);
+	auto primitive_value = std::dynamic_pointer_cast<odata_primitive_value>(property_value);
 	auto binary_output = primitive_value->as<std::vector<unsigned char>>();
 	VERIFY_ARE_EQUAL(binary_output[7], '1');
 	VERIFY_ARE_EQUAL(binary_output[9], '*');

--- a/tests/functional/core_test/odata_json_writer_test.cpp
+++ b/tests/functional/core_test/odata_json_writer_test.cpp
@@ -19,48 +19,48 @@ static std::shared_ptr<odata_json_writer> get_json_writer()
 	auto model = get_test_model();
 	if (model)
 	{
-		return std::make_shared<odata_json_writer>(model);
+		return ::odata::make_shared<odata_json_writer>(model);
 	}
 
 	return nullptr;
 }
 
-typedef std::unordered_map<::utility::string_t, ::utility::string_t> map_type;
-const map_type::value_type init_test_values[] = 
+typedef std::unordered_map<::odata::string_t, ::odata::string_t> map_type;
+const map_type::value_type init_test_values[] =
 {
-	map_type::value_type(U("single_entity"), U("{\"AccountID\":100,\"AccountInfo\":{\"FirstName\":\"Leo\",\"LastName\":\"Hu\"},\"CountryRegion\":\"China\"}")),
+	map_type::value_type(_XPLATSTR("single_entity"), _XPLATSTR("{\"AccountID\":100,\"AccountInfo\":{\"FirstName\":\"Leo\",\"LastName\":\"Hu\"},\"CountryRegion\":\"China\"}")),
 
-	map_type::value_type(U("collection_of_entity"), U("[{\"AccountID\":100,\"CountryRegion\":\"China\"},{\"AccountID\":200,\"CountryRegion\":\"USA\"},{\"AccountID\":300,\"CountryRegion\":\"JP\"}]")),
-    
+	map_type::value_type(_XPLATSTR("collection_of_entity"), _XPLATSTR("[{\"AccountID\":100,\"CountryRegion\":\"China\"},{\"AccountID\":200,\"CountryRegion\":\"USA\"},{\"AccountID\":300,\"CountryRegion\":\"JP\"}]")),
+
 #ifdef __APPLE__
-	map_type::value_type(U("unicode_data_in_entity"), U("\"CountryRegion\":\"上海\",\"AccountID\":100}")),
+	map_type::value_type(_XPLATSTR("unicode_data_in_entity"), _XPLATSTR("\"CountryRegion\":\"上海\",\"AccountID\":100}")),
 #else
-	map_type::value_type(U("unicode_data_in_entity"), U("{\"AccountID\":100,\"CountryRegion\":\"上海\"}")),
+	map_type::value_type(_XPLATSTR("unicode_data_in_entity"), _XPLATSTR("{\"AccountID\":100,\"CountryRegion\":\"上海\"}")),
 #endif
-	map_type::value_type(U("single_complex"), U("{\"FirstName\":\"Leo\",\"LastName\":\"Hu\"}")),
-	map_type::value_type(U("collection_of_complex"), U("[{\"FirstName\":\"Leo\",\"LastName\":\"Hu\"},{\"FirstName\":\"Tian\",\"LastName\":\"Ouyang\"}]")),
-	map_type::value_type(U("single_primitive"), U("100")),
-	map_type::value_type(U("max_i16"), U("32767")),
-	map_type::value_type(U("min_i16"), U("-32768")),
-	map_type::value_type(U("max_i32"), U("2147483647")),
-	map_type::value_type(U("min_i32"), U("-2147483648")),
-	map_type::value_type(U("max_i64"), U("9223372036854775807")),
-	map_type::value_type(U("min_i64"), U("-9223372036854775808")),
-	map_type::value_type(U("primitive_bool_true"), U("true")),
-	map_type::value_type(U("primitive_bool_false"), U("false")),
-	map_type::value_type(U("primitive_sbyte"), U("234")),
-	map_type::value_type(U("primitive_byte"), U("123")),
-	map_type::value_type(U("primitive_datetime"), U("\"2013-12-31T00:00:00Z\"")),
-	map_type::value_type(U("primitive_duration"), U("\"PT38M38S\"")),
-	map_type::value_type(U("primitive_binary"), U("\"UUJBQkFDWDEyKlhjdmpr\"")),
-	map_type::value_type(U("collection_of_primitive"), U("[100,500,400,300,200]")),
-	map_type::value_type(U("single_enum"), U("\"Read\"")),
-	map_type::value_type(U("collection_of_enum"), U("[\"Read\",\"Write\",\"ReadWrite\"]")),
+	map_type::value_type(_XPLATSTR("single_complex"), _XPLATSTR("{\"FirstName\":\"Leo\",\"LastName\":\"Hu\"}")),
+	map_type::value_type(_XPLATSTR("collection_of_complex"), _XPLATSTR("[{\"FirstName\":\"Leo\",\"LastName\":\"Hu\"},{\"FirstName\":\"Tian\",\"LastName\":\"Ouyang\"}]")),
+	map_type::value_type(_XPLATSTR("single_primitive"), _XPLATSTR("100")),
+	map_type::value_type(_XPLATSTR("max_i16"), _XPLATSTR("32767")),
+	map_type::value_type(_XPLATSTR("min_i16"), _XPLATSTR("-32768")),
+	map_type::value_type(_XPLATSTR("max_i32"), _XPLATSTR("2147483647")),
+	map_type::value_type(_XPLATSTR("min_i32"), _XPLATSTR("-2147483648")),
+	map_type::value_type(_XPLATSTR("max_i64"), _XPLATSTR("9223372036854775807")),
+	map_type::value_type(_XPLATSTR("min_i64"), _XPLATSTR("-9223372036854775808")),
+	map_type::value_type(_XPLATSTR("primitive_bool_true"), _XPLATSTR("true")),
+	map_type::value_type(_XPLATSTR("primitive_bool_false"), _XPLATSTR("false")),
+	map_type::value_type(_XPLATSTR("primitive_sbyte"), _XPLATSTR("234")),
+	map_type::value_type(_XPLATSTR("primitive_byte"), _XPLATSTR("123")),
+	map_type::value_type(_XPLATSTR("primitive_datetime"), _XPLATSTR("\"2013-12-31T00:00:00Z\"")),
+	map_type::value_type(_XPLATSTR("primitive_duration"), _XPLATSTR("\"PT38M38S\"")),
+	map_type::value_type(_XPLATSTR("primitive_binary"), _XPLATSTR("\"UUJBQkFDWDEyKlhjdmpr\"")),
+	map_type::value_type(_XPLATSTR("collection_of_primitive"), _XPLATSTR("[100,500,400,300,200]")),
+	map_type::value_type(_XPLATSTR("single_enum"), _XPLATSTR("\"Read\"")),
+	map_type::value_type(_XPLATSTR("collection_of_enum"), _XPLATSTR("[\"Read\",\"Write\",\"ReadWrite\"]")),
 };
 
 const static map_type test_data_map(init_test_values, init_test_values + 22);
 
-static bool check_writer_result(const ::utility::string_t& check_key, const ::utility::string_t& check_value)
+static bool check_writer_result(const ::odata::string_t& check_key, const ::odata::string_t& check_value)
 {
 	auto find_iter = test_data_map.find(check_key);
 	if (find_iter != test_data_map.end())
@@ -80,17 +80,17 @@ TEST(single_entity)
 	VERIFY_IS_NOT_NULL(json_writer);
 	auto model = get_test_model();
 
-	auto complex_value = std::make_shared<odata_complex_value>(model->find_complex_type(U("AccountInfo")));
-	complex_value->set_value(U("FirstName"), U("Leo"));
-	complex_value->set_value(U("LastName"), U("Hu"));
+	auto complex_value = ::odata::make_shared<odata_complex_value>(model->find_complex_type(_XPLATSTR("AccountInfo")));
+	complex_value->set_value(_XPLATSTR("FirstName"), _XPLATSTR("Leo"));
+	complex_value->set_value(_XPLATSTR("LastName"), _XPLATSTR("Hu"));
 
-	auto entity_value = std::make_shared<odata_entity_value>(model->find_entity_type(U("Account")));
-	entity_value->set_value(U("AccountID"), (int32_t)100);
-	entity_value->set_value(U("CountryRegion"), U("China"));
-	entity_value->set_value(U("AccountInfo"), complex_value);
+	auto entity_value = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("Account")));
+	entity_value->set_value(_XPLATSTR("AccountID"), (int32_t)100);
+	entity_value->set_value(_XPLATSTR("CountryRegion"), _XPLATSTR("China"));
+	entity_value->set_value(_XPLATSTR("AccountInfo"), complex_value);
 
 	auto json_string = json_writer->serialize(entity_value).to_string();
-	bool pass = check_writer_result(U("single_entity"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("single_entity"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -100,27 +100,27 @@ TEST(collection_of_entity)
 	VERIFY_IS_NOT_NULL(json_writer);
 	auto model = get_test_model();
 
-	auto entity_value_1 = std::make_shared<odata_entity_value>(model->find_entity_type(U("Account")));
-	entity_value_1->set_value(U("AccountID"), (int32_t)100);
-	entity_value_1->set_value(U("CountryRegion"), U("China"));
+	auto entity_value_1 = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("Account")));
+	entity_value_1->set_value(_XPLATSTR("AccountID"), (int32_t)100);
+	entity_value_1->set_value(_XPLATSTR("CountryRegion"), _XPLATSTR("China"));
 
-	auto entity_value_2 = std::make_shared<odata_entity_value>(model->find_entity_type(U("Account")));
-	entity_value_2->set_value(U("AccountID"), (int32_t)200);
-	entity_value_2->set_value(U("CountryRegion"), U("USA"));
+	auto entity_value_2 = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("Account")));
+	entity_value_2->set_value(_XPLATSTR("AccountID"), (int32_t)200);
+	entity_value_2->set_value(_XPLATSTR("CountryRegion"), _XPLATSTR("USA"));
 
-	auto entity_value_3 = std::make_shared<odata_entity_value>(model->find_entity_type(U("Account")));
-	entity_value_3->set_value(U("AccountID"), (int32_t)300);
-	entity_value_3->set_value(U("CountryRegion"), U("JP"));
+	auto entity_value_3 = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("Account")));
+	entity_value_3->set_value(_XPLATSTR("AccountID"), (int32_t)300);
+	entity_value_3->set_value(_XPLATSTR("CountryRegion"), _XPLATSTR("JP"));
 
-	auto collection_type = std::make_shared<edm_collection_type>(U("entity values"), model->find_entity_type(U("Account")));
-	auto collection_value = std::make_shared<odata_collection_value>(collection_type);
+	auto collection_type = ::odata::make_shared<edm_collection_type>(_XPLATSTR("entity values"), model->find_entity_type(_XPLATSTR("Account")));
+	auto collection_value = ::odata::make_shared<odata_collection_value>(collection_type);
 
 	collection_value->add_collection_value(entity_value_1);
 	collection_value->add_collection_value(entity_value_2);
 	collection_value->add_collection_value(entity_value_3);
 
 	auto json_string = json_writer->serialize(collection_value).to_string();
-	bool pass = check_writer_result(U("collection_of_entity"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("collection_of_entity"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -130,12 +130,12 @@ TEST(single_complex)
 	VERIFY_IS_NOT_NULL(json_writer);
 	auto model = get_test_model();
 
-	auto complex_value = std::make_shared<odata_complex_value>(model->find_complex_type(U("AccountInfo")));
-	complex_value->set_value(U("FirstName"), U("Leo"));
-	complex_value->set_value(U("LastName"), U("Hu"));
+	auto complex_value = ::odata::make_shared<odata_complex_value>(model->find_complex_type(_XPLATSTR("AccountInfo")));
+	complex_value->set_value(_XPLATSTR("FirstName"), _XPLATSTR("Leo"));
+	complex_value->set_value(_XPLATSTR("LastName"), _XPLATSTR("Hu"));
 
 	auto json_string = json_writer->serialize(complex_value).to_string();
-	bool pass = check_writer_result(U("single_complex"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("single_complex"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -145,21 +145,21 @@ TEST(collection_of_complex)
 	VERIFY_IS_NOT_NULL(json_writer);
 	auto model = get_test_model();
 
-	auto complex_value_1 = std::make_shared<odata_complex_value>(model->find_complex_type(U("AccountInfo")));
-	complex_value_1->set_value(U("FirstName"), U("Leo"));
-	complex_value_1->set_value(U("LastName"), U("Hu"));
+	auto complex_value_1 = ::odata::make_shared<odata_complex_value>(model->find_complex_type(_XPLATSTR("AccountInfo")));
+	complex_value_1->set_value(_XPLATSTR("FirstName"), _XPLATSTR("Leo"));
+	complex_value_1->set_value(_XPLATSTR("LastName"), _XPLATSTR("Hu"));
 
-	auto complex_value_2 = std::make_shared<odata_complex_value>(model->find_complex_type(U("AccountInfo")));
-	complex_value_2->set_value(U("FirstName"), U("Tian"));
-	complex_value_2->set_value(U("LastName"), U("Ouyang"));
+	auto complex_value_2 = ::odata::make_shared<odata_complex_value>(model->find_complex_type(_XPLATSTR("AccountInfo")));
+	complex_value_2->set_value(_XPLATSTR("FirstName"), _XPLATSTR("Tian"));
+	complex_value_2->set_value(_XPLATSTR("LastName"), _XPLATSTR("Ouyang"));
 
-	auto collection_type = std::make_shared<edm_collection_type>(U("complex values"), model->find_complex_type(U("AccountInfo")));
-	auto collection_value = std::make_shared<odata_collection_value>(collection_type);
+	auto collection_type = ::odata::make_shared<edm_collection_type>(_XPLATSTR("complex values"), model->find_complex_type(_XPLATSTR("AccountInfo")));
+	auto collection_value = ::odata::make_shared<odata_collection_value>(collection_type);
 	collection_value->add_collection_value(complex_value_1);
 	collection_value->add_collection_value(complex_value_2);
 
 	auto json_string = json_writer->serialize(collection_value).to_string();
-	bool pass = check_writer_result(U("collection_of_complex"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("collection_of_complex"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -169,10 +169,10 @@ TEST(single_primitive)
 	VERIFY_IS_NOT_NULL(json_writer);
 	auto model = get_test_model();
 
-	auto int32_value = std::make_shared<odata_primitive_value>(edm_primitive_type::INT32(), ::utility::conversions::print_string(100));
+	auto int32_value = ::odata::make_shared<odata_primitive_value>(edm_primitive_type::INT32(), ::utility::conversions::print_string(100));
 
 	auto json_string = json_writer->serialize(int32_value).to_string();
-	bool pass = check_writer_result(U("single_primitive"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("single_primitive"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -183,9 +183,9 @@ TEST(single_primitive_int16_min)
 	auto model = get_test_model();
 
 	int16_t value = -32768;
-	auto odata_value = std::make_shared<odata_primitive_value>(edm_primitive_type::INT16(), ::utility::conversions::print_string(value));
+	auto odata_value = ::odata::make_shared<odata_primitive_value>(edm_primitive_type::INT16(), ::utility::conversions::print_string(value));
 	auto json_string = json_writer->serialize(odata_value).to_string();
-	bool pass = check_writer_result(U("min_i16"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("min_i16"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -196,9 +196,9 @@ TEST(single_primitive_int16_max)
 	auto model = get_test_model();
 
 	int16_t value = 32767;
-	auto odata_value = std::make_shared<odata_primitive_value>(edm_primitive_type::INT16(), ::utility::conversions::print_string(value));
+	auto odata_value = ::odata::make_shared<odata_primitive_value>(edm_primitive_type::INT16(), ::utility::conversions::print_string(value));
 	auto json_string = json_writer->serialize(odata_value).to_string();
-	bool pass = check_writer_result(U("max_i16"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("max_i16"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -209,9 +209,9 @@ TEST(single_primitive_int32_max)
 	auto model = get_test_model();
 
 	int32_t value = 2147483647;
-	auto odata_value = std::make_shared<odata_primitive_value>(edm_primitive_type::INT32(), ::utility::conversions::print_string(value));
+	auto odata_value = ::odata::make_shared<odata_primitive_value>(edm_primitive_type::INT32(), ::utility::conversions::print_string(value));
 	auto json_string = json_writer->serialize(odata_value).to_string();
-	bool pass = check_writer_result(U("max_i32"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("max_i32"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -222,9 +222,9 @@ TEST(single_primitive_int32_min)
 	auto model = get_test_model();
 
 	int32_t value = -2147483648;
-	auto odata_value = std::make_shared<odata_primitive_value>(edm_primitive_type::INT32(), ::utility::conversions::print_string(value));
+	auto odata_value = ::odata::make_shared<odata_primitive_value>(edm_primitive_type::INT32(), ::utility::conversions::print_string(value));
 	auto json_string = json_writer->serialize(odata_value).to_string();
-	bool pass = check_writer_result(U("min_i32"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("min_i32"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -235,9 +235,9 @@ TEST(single_primitive_int64_max)
 	auto model = get_test_model();
 
 	int64_t value = 9223372036854775807;
-	auto odata_value = std::make_shared<odata_primitive_value>(edm_primitive_type::INT64(), ::utility::conversions::print_string(value));
+	auto odata_value = ::odata::make_shared<odata_primitive_value>(edm_primitive_type::INT64(), ::utility::conversions::print_string(value));
 	auto json_string = json_writer->serialize(odata_value).to_string();
-	bool pass = check_writer_result(U("max_i64"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("max_i64"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -248,9 +248,9 @@ TEST(single_primitive_int64_min)
 	auto model = get_test_model();
 
 	int64_t value = -9223372036854775808;
-	auto odata_value = std::make_shared<odata_primitive_value>(edm_primitive_type::INT64(), ::utility::conversions::print_string(value));
+	auto odata_value = ::odata::make_shared<odata_primitive_value>(edm_primitive_type::INT64(), ::utility::conversions::print_string(value));
 	auto json_string = json_writer->serialize(odata_value).to_string();
-	bool pass = check_writer_result(U("min_i64"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("min_i64"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -263,7 +263,7 @@ TEST(single_primitive_int64_min)
 //	float value = 123213.43;
 //	auto odata_value = odata_primitive_value::make_primitive_value(value);
 //	auto json_string = json_writer->serialize(odata_value).to_string();
-//	bool pass = check_writer_result(U("primitive_float"), json_string);
+//	bool pass = check_writer_result(_XPLATSTR("primitive_float"), json_string);
 //	VERIFY_ARE_EQUAL(pass, true);
 //}
 //
@@ -284,7 +284,7 @@ TEST(single_primitive_bool_true)
 	bool value = true;
 	auto odata_value = odata_primitive_value::make_primitive_value(value);
 	auto json_string = json_writer->serialize(odata_value).to_string();
-	bool pass = check_writer_result(U("primitive_bool_true"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("primitive_bool_true"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -297,7 +297,7 @@ TEST(single_primitive_bool_false)
 	bool value = false;
 	auto odata_value = odata_primitive_value::make_primitive_value(value);
 	auto json_string = json_writer->serialize(odata_value).to_string();
-	bool pass = check_writer_result(U("primitive_bool_false"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("primitive_bool_false"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -310,8 +310,8 @@ TEST(single_primitive_binary)
 	unsigned char ini_binary[] = {'Q', 'B', 'A', 'B', 'A', 'C', 'X', '1', '2', '*', 'X', 'c', 'v', 'j', 'k'};
 	std::vector<unsigned char> value(ini_binary, ini_binary + 15);
 	auto odata_value = odata_primitive_value::make_primitive_value(value);
-    auto json_string = json_writer->serialize(odata_value).to_string();
-	bool pass = check_writer_result(U("primitive_binary"), json_string);
+	auto json_string = json_writer->serialize(odata_value).to_string();
+	bool pass = check_writer_result(_XPLATSTR("primitive_binary"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -324,7 +324,7 @@ TEST(single_primitive_sbyte)
 	unsigned char value = 234;
 	auto odata_value = odata_primitive_value::make_primitive_value(value);
 	auto json_string = json_writer->serialize(odata_value).to_string();
-	bool pass = check_writer_result(U("primitive_sbyte"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("primitive_sbyte"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -337,7 +337,7 @@ TEST(single_primitive_byte)
 	char value = 123;
 	auto odata_value = odata_primitive_value::make_primitive_value(value);
 	auto json_string = json_writer->serialize(odata_value).to_string();
-	bool pass = check_writer_result(U("primitive_byte"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("primitive_byte"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -347,10 +347,10 @@ TEST(single_primitive_duration)
 	VERIFY_IS_NOT_NULL(json_writer);
 	auto model = get_test_model();
 
-	auto value = ::utility::datetime::from_string(U("2013-12-31T00:00:00Z"), ::utility::datetime::date_format::ISO_8601);
+	auto value = ::utility::datetime::from_string(_XPLATSTR("2013-12-31T00:00:00Z"), ::utility::datetime::date_format::ISO_8601);
 	auto odata_value = odata_primitive_value::make_primitive_value(value);
 	auto json_string = json_writer->serialize(odata_value).to_string();
-	bool pass = check_writer_result(U("primitive_datetime"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("primitive_datetime"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -363,7 +363,7 @@ TEST(single_primitive_datetime)
 	::utility::seconds value(2318);
 	auto odata_value = odata_primitive_value::make_primitive_value(value);
 	auto json_string = json_writer->serialize(odata_value).to_string();
-	bool pass = check_writer_result(U("primitive_duration"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("primitive_duration"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -373,14 +373,14 @@ TEST(collection_of_primitive)
 	VERIFY_IS_NOT_NULL(json_writer);
 	auto model = get_test_model();
 
-	auto int32_value_1 = std::make_shared<odata_primitive_value>(edm_primitive_type::INT32(), ::utility::conversions::print_string(100));
-	auto int32_value_2 = std::make_shared<odata_primitive_value>(edm_primitive_type::INT32(), ::utility::conversions::print_string(500));
-	auto int32_value_3 = std::make_shared<odata_primitive_value>(edm_primitive_type::INT32(), ::utility::conversions::print_string(400));
-	auto int32_value_4 = std::make_shared<odata_primitive_value>(edm_primitive_type::INT32(), ::utility::conversions::print_string(300));
-	auto int32_value_5 = std::make_shared<odata_primitive_value>(edm_primitive_type::INT32(), ::utility::conversions::print_string(200));
+	auto int32_value_1 = ::odata::make_shared<odata_primitive_value>(edm_primitive_type::INT32(), ::utility::conversions::print_string(100));
+	auto int32_value_2 = ::odata::make_shared<odata_primitive_value>(edm_primitive_type::INT32(), ::utility::conversions::print_string(500));
+	auto int32_value_3 = ::odata::make_shared<odata_primitive_value>(edm_primitive_type::INT32(), ::utility::conversions::print_string(400));
+	auto int32_value_4 = ::odata::make_shared<odata_primitive_value>(edm_primitive_type::INT32(), ::utility::conversions::print_string(300));
+	auto int32_value_5 = ::odata::make_shared<odata_primitive_value>(edm_primitive_type::INT32(), ::utility::conversions::print_string(200));
 
-	auto collection_type = std::make_shared<edm_collection_type>(U("primitive values"), edm_primitive_type::INT32());
-	auto collection_value = std::make_shared<odata_collection_value>(collection_type);
+	auto collection_type = ::odata::make_shared<edm_collection_type>(_XPLATSTR("primitive values"), edm_primitive_type::INT32());
+	auto collection_value = ::odata::make_shared<odata_collection_value>(collection_type);
 	collection_value->add_collection_value(int32_value_1);
 	collection_value->add_collection_value(int32_value_2);
 	collection_value->add_collection_value(int32_value_3);
@@ -388,7 +388,7 @@ TEST(collection_of_primitive)
 	collection_value->add_collection_value(int32_value_5);
 
 	auto json_string = json_writer->serialize(collection_value).to_string();
-	bool pass = check_writer_result(U("collection_of_primitive"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("collection_of_primitive"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -398,10 +398,10 @@ TEST(single_enum)
 	VERIFY_IS_NOT_NULL(json_writer);
 	auto model = get_test_model();
 
-	auto enum_value = std::make_shared<odata_enum_value>(model->find_enum_type(U("AccessLevel")), U("Read"));
+	auto enum_value = ::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("AccessLevel")), _XPLATSTR("Read"));
 
 	auto json_string = json_writer->serialize(enum_value).to_string();
-	bool pass = check_writer_result(U("single_enum"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("single_enum"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -411,18 +411,18 @@ TEST(collection_of_enum)
 	VERIFY_IS_NOT_NULL(json_writer);
 	auto model = get_test_model();
 
-	auto enum_value_1 = std::make_shared<odata_enum_value>(model->find_enum_type(U("AccessLevel")), U("Read"));
-	auto enum_value_2 = std::make_shared<odata_enum_value>(model->find_enum_type(U("AccessLevel")), U("Write"));
-	auto enum_value_3 = std::make_shared<odata_enum_value>(model->find_enum_type(U("AccessLevel")), U("ReadWrite"));
+	auto enum_value_1 = ::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("AccessLevel")), _XPLATSTR("Read"));
+	auto enum_value_2 = ::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("AccessLevel")), _XPLATSTR("Write"));
+	auto enum_value_3 = ::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("AccessLevel")), _XPLATSTR("ReadWrite"));
 
-	auto collection_type = std::make_shared<edm_collection_type>(U("enum values"), model->find_enum_type(U("AccessLevel")));
-	auto collection_value = std::make_shared<odata_collection_value>(collection_type);
+	auto collection_type = ::odata::make_shared<edm_collection_type>(_XPLATSTR("enum values"), model->find_enum_type(_XPLATSTR("AccessLevel")));
+	auto collection_value = ::odata::make_shared<odata_collection_value>(collection_type);
 	collection_value->add_collection_value(enum_value_1);
 	collection_value->add_collection_value(enum_value_2);
 	collection_value->add_collection_value(enum_value_3);
 
 	auto json_string = json_writer->serialize(collection_value).to_string();
-	bool pass = check_writer_result(U("collection_of_enum"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("collection_of_enum"), json_string);
 	VERIFY_ARE_EQUAL(pass, true);
 }
 
@@ -432,12 +432,12 @@ TEST(unicode_data_in_entity)
 	VERIFY_IS_NOT_NULL(json_writer);
 	auto model = get_test_model();
 
-	auto entity_value = std::make_shared<odata_entity_value>(model->find_entity_type(U("Account")));
-	entity_value->set_value(U("AccountID"), (int32_t)100);
-	entity_value->set_value(U("CountryRegion"), U("上海"));
+	auto entity_value = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("Account")));
+	entity_value->set_value(_XPLATSTR("AccountID"), (int32_t)100);
+	entity_value->set_value(_XPLATSTR("CountryRegion"), _XPLATSTR("上海"));
 
 	auto json_string = json_writer->serialize(entity_value).serialize();
-	bool pass = check_writer_result(U("unicode_data_in_entity"), json_string);
+	bool pass = check_writer_result(_XPLATSTR("unicode_data_in_entity"), json_string);
 
 	VERIFY_ARE_EQUAL(pass, true);
 }

--- a/tests/functional/core_test/odata_value_test.cpp
+++ b/tests/functional/core_test/odata_value_test.cpp
@@ -31,7 +31,7 @@ TEST(primitive_value)
 	unsigned char ini_binary[] = {'Q', 'B', 'A', 'B', 'A', 'C', 'X', '1', '2', '*', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'p'};
 	std::vector<unsigned char> binary(ini_binary, ini_binary + 25);
 	auto binary_input = odata_primitive_value::make_primitive_value(binary);
-	VERIFY_ARE_EQUAL(binary_input->to_string(), U("UUJBQkFDWDEyKjEyMzQ1Njc4OTBhYmNkZQ=="));
+	VERIFY_ARE_EQUAL(binary_input->to_string(), _XPLATSTR("UUJBQkFDWDEyKjEyMzQ1Njc4OTBhYmNkZQ=="));
 	auto binary_output = binary_input->as<std::vector<unsigned char>>();
 	VERIFY_ARE_EQUAL(binary_output[7], '1');
 
@@ -65,7 +65,7 @@ TEST(primitive_value)
 	VERIFY_ARE_EQUAL(bool_v->as<bool>(), false);
 
 	//date time
-	::utility::datetime dt = ::utility::datetime::from_string(U("2014-5-13T11:40:00Z"), ::utility::datetime::date_format::ISO_8601);
+	::utility::datetime dt = ::utility::datetime::from_string(_XPLATSTR("2014-5-13T11:40:00Z"), ::utility::datetime::date_format::ISO_8601);
 	auto date_v = odata_primitive_value::make_primitive_value(dt);
 	VERIFY_ARE_EQUAL(date_v->get_value_type()->get_type_kind(), edm_type_kind_t::Primitive);
 	primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(date_v->get_value_type());
@@ -75,7 +75,7 @@ TEST(primitive_value)
 
 	//duration
 	::utility::seconds sd(3600);
-	auto second_v = odata_primitive_value::make_primitive_value(sd); 
+	auto second_v = odata_primitive_value::make_primitive_value(sd);
 	VERIFY_ARE_EQUAL(second_v->get_value_type()->get_type_kind(), edm_type_kind_t::Primitive);
 	primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(second_v->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::Duration);
@@ -90,17 +90,17 @@ TEST(primitive_value)
 	VERIFY_IS_TRUE(abs(float_v->as<float>() - -121.2312) < 0.00001);
 
 	//string
-	auto str_v = odata_primitive_value::make_primitive_value(U("test string"));
+	auto str_v = odata_primitive_value::make_primitive_value(_XPLATSTR("test string"));
 	VERIFY_ARE_EQUAL(str_v->get_value_type()->get_type_kind(), edm_type_kind_t::Primitive);
 	primitive_type = std::dynamic_pointer_cast<edm_primitive_type>(str_v->get_value_type());
 	VERIFY_ARE_EQUAL(primitive_type->get_primitive_kind(), edm_primitive_type_kind_t::String);
-	VERIFY_ARE_EQUAL(str_v->as<::utility::string_t>(), U("test string"));
+	VERIFY_ARE_EQUAL(str_v->as<::odata::string_t>(), _XPLATSTR("test string"));
 }
 
 TEST(primitive_value_boundary_i64)
 {
 
-	// min i64 
+	// min i64
 	{
 	    auto i64 = odata_primitive_value::make_primitive_value((int64_t)-9223372036854775808);
 	    VERIFY_ARE_EQUAL(i64->get_value_type()->get_type_kind(), edm_type_kind_t::Primitive);
@@ -110,7 +110,7 @@ TEST(primitive_value_boundary_i64)
 	    VERIFY_ARE_EQUAL(i64->as<int64_t>(), -9223372036854775808);
 	}
 
-	// max i64 
+	// max i64
 	{
 	    auto i64 = odata_primitive_value::make_primitive_value((int64_t)9223372036854775807);
 	    VERIFY_ARE_EQUAL(i64->get_value_type()->get_type_kind(), edm_type_kind_t::Primitive);
@@ -192,56 +192,56 @@ TEST(primitive_value_boundary_i16)
 TEST(structured_value)
 {
     std::shared_ptr<::odata::edm::edm_named_type> type = nullptr;
-	auto structurd_value = std::make_shared<odata_structured_value>(type);
+	auto structurd_value = ::odata::make_shared<odata_structured_value>(type);
 	VERIFY_IS_NOT_NULL(structurd_value);
 
 	int16_t i16 = -8;
-	structurd_value->set_value(U("int16"), i16);
+	structurd_value->set_value(_XPLATSTR("int16"), i16);
 	int32_t i32 = -123;
-	structurd_value->set_value(U("int32"), i32);
+	structurd_value->set_value(_XPLATSTR("int32"), i32);
 	int64_t i64 = -121321321321321;
-	structurd_value->set_value(U("int64"), i64);
+	structurd_value->set_value(_XPLATSTR("int64"), i64);
 	unsigned char ini_binary[] = {'Q', 'B', 'A', 'B', 'A', 'C', 'X', '1', '2', '*'};
 	std::vector<unsigned char> binary(ini_binary, ini_binary + 10);
-	structurd_value->set_value(U("binary"), binary);
+	structurd_value->set_value(_XPLATSTR("binary"), binary);
 	bool bl = true;
-	structurd_value->set_value(U("boolean"), bl);
-	::utility::datetime dt = ::utility::datetime::from_string(U("2013-12-31T00:00:00Z"), ::utility::datetime::date_format::ISO_8601);
-	structurd_value->set_value(U("datetime"), dt);
-	::utility::char_t* ch_str = U("char_t pointer input");
-	structurd_value->set_value(U("char_t pointer"), ch_str);
-	::utility::string_t str = U("string_t input");
-	structurd_value->set_value(U("string_t"), str);
+	structurd_value->set_value(_XPLATSTR("boolean"), bl);
+	::utility::datetime dt = ::utility::datetime::from_string(_XPLATSTR("2013-12-31T00:00:00Z"), ::utility::datetime::date_format::ISO_8601);
+	structurd_value->set_value(_XPLATSTR("datetime"), dt);
+	::utility::char_t* ch_str = _XPLATSTR("char_t pointer input");
+	structurd_value->set_value(_XPLATSTR("char_t pointer"), ch_str);
+	::odata::string_t str = _XPLATSTR("string_t input");
+	structurd_value->set_value(_XPLATSTR("string_t"), str);
 	double db = -32342212.23424;
-	structurd_value->set_value(U("double"), db);
+	structurd_value->set_value(_XPLATSTR("double"), db);
 
 	bool b_get = false;
-	b_get = structurd_value->try_get(U("int16"), i16);
+	b_get = structurd_value->try_get(_XPLATSTR("int16"), i16);
 	VERIFY_ARE_EQUAL(b_get, true);
 	VERIFY_ARE_EQUAL(i16, -8);
-	b_get = structurd_value->try_get(U("int32"), i32);
+	b_get = structurd_value->try_get(_XPLATSTR("int32"), i32);
 	VERIFY_ARE_EQUAL(b_get, true);
 	VERIFY_ARE_EQUAL(i32, -123);
-	b_get = structurd_value->try_get(U("int64"), i64);
+	b_get = structurd_value->try_get(_XPLATSTR("int64"), i64);
 	VERIFY_ARE_EQUAL(b_get, true);
 	VERIFY_ARE_EQUAL(i64, -121321321321321);
-	b_get = structurd_value->try_get(U("binary"), binary);
+	b_get = structurd_value->try_get(_XPLATSTR("binary"), binary);
 	VERIFY_ARE_EQUAL(b_get, true);
 	VERIFY_ARE_EQUAL(binary.size(), 10);
 	VERIFY_ARE_EQUAL(binary[5], 'C');
-	b_get = structurd_value->try_get(U("boolean"), bl);
+	b_get = structurd_value->try_get(_XPLATSTR("boolean"), bl);
 	VERIFY_ARE_EQUAL(b_get, true);
 	VERIFY_ARE_EQUAL(bl, true);
-	b_get = structurd_value->try_get(U("datetime"), dt);
+	b_get = structurd_value->try_get(_XPLATSTR("datetime"), dt);
 	VERIFY_ARE_EQUAL(b_get, true);
-	VERIFY_ARE_EQUAL(dt.to_string(::utility::datetime::date_format::ISO_8601), U("2013-12-31T00:00:00Z"));
-	b_get = structurd_value->try_get(U("char_t pointer"), str);
+	VERIFY_ARE_EQUAL(dt.to_string(::utility::datetime::date_format::ISO_8601), _XPLATSTR("2013-12-31T00:00:00Z"));
+	b_get = structurd_value->try_get(_XPLATSTR("char_t pointer"), str);
 	VERIFY_ARE_EQUAL(b_get, true);
-	VERIFY_ARE_EQUAL(str, U("char_t pointer input"));
-	b_get = structurd_value->try_get(U("string_t"), str);
+	VERIFY_ARE_EQUAL(str, _XPLATSTR("char_t pointer input"));
+	b_get = structurd_value->try_get(_XPLATSTR("string_t"), str);
 	VERIFY_ARE_EQUAL(b_get, true);
-	VERIFY_ARE_EQUAL(str, U("string_t input"));
-	b_get = structurd_value->try_get(U("double"), db);
+	VERIFY_ARE_EQUAL(str, _XPLATSTR("string_t input"));
+	b_get = structurd_value->try_get(_XPLATSTR("double"), db);
 	VERIFY_ARE_EQUAL(b_get, true);
 	double as = abs(db - -32342212.23424);
 	VERIFY_ARE_EQUAL(as < 0.000001, true);
@@ -252,26 +252,26 @@ TEST(complex_value)
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
 
-	auto complex_value = std::make_shared<odata_complex_value>(model->find_complex_type(U("AccountInfo")));
-	complex_value->set_value(U("FirstName"), U("Leo"));
-	complex_value->set_value(U("LastName"), U("Hu"));
-    
+	auto complex_value = ::odata::make_shared<odata_complex_value>(model->find_complex_type(_XPLATSTR("AccountInfo")));
+	complex_value->set_value(_XPLATSTR("FirstName"), _XPLATSTR("Leo"));
+	complex_value->set_value(_XPLATSTR("LastName"), _XPLATSTR("Hu"));
+
     std::shared_ptr<::odata::edm::edm_named_type> type = nullptr;
-	auto structurd_value = std::make_shared<odata_structured_value>(type);
+	auto structurd_value = ::odata::make_shared<odata_structured_value>(type);
 	VERIFY_IS_NOT_NULL(structurd_value);
-	structurd_value->set_value(U("complex value"), complex_value);
+	structurd_value->set_value(_XPLATSTR("complex value"), complex_value);
 
 	bool b_get = false;
 	std::shared_ptr<odata_complex_value> verify = nullptr;
-	b_get = structurd_value->try_get(U("complex value"), verify);
+	b_get = structurd_value->try_get(_XPLATSTR("complex value"), verify);
 	VERIFY_ARE_EQUAL(b_get, true);
 	VERIFY_IS_NOT_NULL(verify);
 	VERIFY_ARE_EQUAL(verify->properties().size(), 2);
-	::utility::string_t str;
-	verify->try_get(U("FirstName"), str);
-	VERIFY_ARE_EQUAL(str, U("Leo"));
-	verify->try_get(U("LastName"), str);
-	VERIFY_ARE_EQUAL(str, U("Hu"));
+	::odata::string_t str;
+	verify->try_get(_XPLATSTR("FirstName"), str);
+	VERIFY_ARE_EQUAL(str, _XPLATSTR("Leo"));
+	verify->try_get(_XPLATSTR("LastName"), str);
+	VERIFY_ARE_EQUAL(str, _XPLATSTR("Hu"));
 }
 
 TEST(entity_value)
@@ -279,27 +279,27 @@ TEST(entity_value)
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
 
-	auto entity_value = std::make_shared<odata_entity_value>(model->find_entity_type(U("Account")));
-	entity_value->set_value(U("AccountID"), (int32_t)100);
-	entity_value->set_value(U("CountryRegion"), U("China"));
-    
+	auto entity_value = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("Account")));
+	entity_value->set_value(_XPLATSTR("AccountID"), (int32_t)100);
+	entity_value->set_value(_XPLATSTR("CountryRegion"), _XPLATSTR("China"));
+
     std::shared_ptr<::odata::edm::edm_named_type> type = nullptr;
-	auto structurd_value = std::make_shared<odata_structured_value>(type);
+	auto structurd_value = ::odata::make_shared<odata_structured_value>(type);
 	VERIFY_IS_NOT_NULL(structurd_value);
-	structurd_value->set_value(U("entity value"), entity_value);
+	structurd_value->set_value(_XPLATSTR("entity value"), entity_value);
 
 	bool b_get = false;
 	std::shared_ptr<odata_entity_value> verify = nullptr;
-	b_get = structurd_value->try_get(U("entity value"), verify);
+	b_get = structurd_value->try_get(_XPLATSTR("entity value"), verify);
 	VERIFY_ARE_EQUAL(b_get, true);
 	VERIFY_IS_NOT_NULL(verify);
 	VERIFY_ARE_EQUAL(verify->properties().size(), 2);
 	int32_t id;
-	verify->try_get(U("AccountID"), id);
+	verify->try_get(_XPLATSTR("AccountID"), id);
 	VERIFY_ARE_EQUAL(id, 100);
-	::utility::string_t str;
-	verify->try_get(U("CountryRegion"), str);
-	VERIFY_ARE_EQUAL(str, U("China"));
+	::odata::string_t str;
+	verify->try_get(_XPLATSTR("CountryRegion"), str);
+	VERIFY_ARE_EQUAL(str, _XPLATSTR("China"));
 }
 
 TEST(enum_value)
@@ -307,53 +307,53 @@ TEST(enum_value)
 	auto model = get_test_model();
 	VERIFY_IS_NOT_NULL(model);
 
-	auto enum_value = std::make_shared<odata_enum_value>(model->find_enum_type(U("AccessLevel")), U("Read"));
+	auto enum_value = ::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("AccessLevel")), _XPLATSTR("Read"));
 	VERIFY_IS_NOT_NULL(enum_value);
 
     std::shared_ptr<::odata::edm::edm_named_type> type = nullptr;
-	auto structurd_value = std::make_shared<odata_structured_value>(type);
+	auto structurd_value = ::odata::make_shared<odata_structured_value>(type);
 	VERIFY_IS_NOT_NULL(structurd_value);
-	structurd_value->set_value(U("enum value"), enum_value);
+	structurd_value->set_value(_XPLATSTR("enum value"), enum_value);
 
 	bool b_get = false;
 	std::shared_ptr<odata_enum_value> verify = nullptr;
-	b_get = structurd_value->try_get(U("enum value"), verify);
+	b_get = structurd_value->try_get(_XPLATSTR("enum value"), verify);
 	VERIFY_ARE_EQUAL(b_get, true);
 	VERIFY_IS_NOT_NULL(verify);
-	VERIFY_ARE_EQUAL(verify->to_string(), U("Read"));
+	VERIFY_ARE_EQUAL(verify->to_string(), _XPLATSTR("Read"));
 }
 
 TEST(collection_value)
 {
 	auto model = get_test_model();
 
-	auto enum_value_1 = std::make_shared<odata_enum_value>(model->find_enum_type(U("AccessLevel")), U("Read"));
-	auto enum_value_2 = std::make_shared<odata_enum_value>(model->find_enum_type(U("AccessLevel")), U("Write"));
-	auto enum_value_3 = std::make_shared<odata_enum_value>(model->find_enum_type(U("AccessLevel")), U("ReadWrite"));
+	auto enum_value_1 = ::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("AccessLevel")), _XPLATSTR("Read"));
+	auto enum_value_2 = ::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("AccessLevel")), _XPLATSTR("Write"));
+	auto enum_value_3 = ::odata::make_shared<odata_enum_value>(model->find_enum_type(_XPLATSTR("AccessLevel")), _XPLATSTR("ReadWrite"));
 
-	auto collection_type = std::make_shared<edm_collection_type>(U("collection value"), model->find_enum_type(U("AccessLevel")));
-	auto collection_value = std::make_shared<odata_collection_value>(collection_type);
+	auto collection_type = ::odata::make_shared<edm_collection_type>(_XPLATSTR("collection value"), model->find_enum_type(_XPLATSTR("AccessLevel")));
+	auto collection_value = ::odata::make_shared<odata_collection_value>(collection_type);
 	collection_value->add_collection_value(enum_value_1);
 	collection_value->add_collection_value(enum_value_2);
 	collection_value->add_collection_value(enum_value_3);
 
-    
+
     std::shared_ptr<::odata::edm::edm_named_type> type = nullptr;
-	auto structurd_value = std::make_shared<odata_structured_value>(type);
+	auto structurd_value = ::odata::make_shared<odata_structured_value>(type);
 	VERIFY_IS_NOT_NULL(structurd_value);
-	structurd_value->set_value(U("collection value"), collection_value);
+	structurd_value->set_value(_XPLATSTR("collection value"), collection_value);
 
 	bool b_get = false;
 	std::shared_ptr<odata_collection_value> verify = nullptr;
-	b_get = structurd_value->try_get(U("collection value"), verify);
+	b_get = structurd_value->try_get(_XPLATSTR("collection value"), verify);
 	VERIFY_ARE_EQUAL(b_get, true);
 	VERIFY_ARE_EQUAL(verify->get_collection_values().size(), 3);
 	enum_value_1 = std::dynamic_pointer_cast<odata_enum_value>(verify->get_collection_values()[0]);
-	VERIFY_ARE_EQUAL(enum_value_1->to_string(), U("Read"));
+	VERIFY_ARE_EQUAL(enum_value_1->to_string(), _XPLATSTR("Read"));
 	enum_value_2 = std::dynamic_pointer_cast<odata_enum_value>(verify->get_collection_values()[1]);
-	VERIFY_ARE_EQUAL(enum_value_2->to_string(), U("Write"));
+	VERIFY_ARE_EQUAL(enum_value_2->to_string(), _XPLATSTR("Write"));
 	enum_value_3 = std::dynamic_pointer_cast<odata_enum_value>(verify->get_collection_values()[2]);
-	VERIFY_ARE_EQUAL(enum_value_3->to_string(), U("ReadWrite"));
+	VERIFY_ARE_EQUAL(enum_value_3->to_string(), _XPLATSTR("ReadWrite"));
 }
 
 TEST(primitive_collection_value)
@@ -364,8 +364,8 @@ TEST(primitive_collection_value)
 	auto p_value_2 = odata_primitive_value::make_primitive_value((double)-123123213);
 	auto p_value_3 = odata_primitive_value::make_primitive_value((double)-121.2312);
 
-	auto collection_type = std::make_shared<edm_collection_type>(U("collection value"), ::odata::edm::edm_primitive_type::DOUBLE());
-	auto collection_value = std::make_shared<odata_collection_value>(collection_type);
+	auto collection_type = ::odata::make_shared<edm_collection_type>(_XPLATSTR("collection value"), ::odata::edm::edm_primitive_type::DOUBLE());
+	auto collection_value = ::odata::make_shared<odata_collection_value>(collection_type);
 	collection_value->add_collection_value(p_value_1);
 	collection_value->add_collection_value(p_value_2);
 	collection_value->add_collection_value(p_value_3);
@@ -382,40 +382,40 @@ TEST(complex_collection_value)
 {
 	auto model = get_test_model();
 
-	auto complex_value_1 = std::make_shared<odata_complex_value>(model->find_complex_type(U("AccountInfo")));
-	complex_value_1->set_value(U("FirstName"), U("F_1"));
-	complex_value_1->set_value(U("LastName"), U("L_1"));
+	auto complex_value_1 = ::odata::make_shared<odata_complex_value>(model->find_complex_type(_XPLATSTR("AccountInfo")));
+	complex_value_1->set_value(_XPLATSTR("FirstName"), _XPLATSTR("F_1"));
+	complex_value_1->set_value(_XPLATSTR("LastName"), _XPLATSTR("L_1"));
 
-	auto collection_type = std::make_shared<edm_collection_type>(U("collection value"), model->find_complex_type(U("AccountInfo")));
-	auto collection_value = std::make_shared<odata_collection_value>(collection_type);
+	auto collection_type = ::odata::make_shared<edm_collection_type>(_XPLATSTR("collection value"), model->find_complex_type(_XPLATSTR("AccountInfo")));
+	auto collection_value = ::odata::make_shared<odata_collection_value>(collection_type);
 	collection_value->add_collection_value(complex_value_1);
 
 	complex_value_1 = std::dynamic_pointer_cast<odata_complex_value>(collection_value->get_collection_values()[0]);
-	::utility::string_t str;
-	complex_value_1->try_get(U("FirstName"), str);
-	VERIFY_ARE_EQUAL(str, U("F_1"));
-	complex_value_1->try_get(U("LastName"), str);
-	VERIFY_ARE_EQUAL(str, U("L_1"));
+	::odata::string_t str;
+	complex_value_1->try_get(_XPLATSTR("FirstName"), str);
+	VERIFY_ARE_EQUAL(str, _XPLATSTR("F_1"));
+	complex_value_1->try_get(_XPLATSTR("LastName"), str);
+	VERIFY_ARE_EQUAL(str, _XPLATSTR("L_1"));
 }
 
 TEST(entity_collection_value)
 {
 	auto model = get_test_model();
 
-	auto entity_value_1 = std::make_shared<odata_entity_value>(model->find_entity_type(U("Account")));
-	entity_value_1->set_value(U("AccountID"), (int32_t)100);
-	entity_value_1->set_value(U("CountryRegion"), U("China"));
+	auto entity_value_1 = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("Account")));
+	entity_value_1->set_value(_XPLATSTR("AccountID"), (int32_t)100);
+	entity_value_1->set_value(_XPLATSTR("CountryRegion"), _XPLATSTR("China"));
 
-	auto entity_value_2 = std::make_shared<odata_entity_value>(model->find_entity_type(U("Account")));
-	entity_value_2->set_value(U("AccountID"), (int32_t)200);
-	entity_value_2->set_value(U("CountryRegion"), U("JP"));
+	auto entity_value_2 = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("Account")));
+	entity_value_2->set_value(_XPLATSTR("AccountID"), (int32_t)200);
+	entity_value_2->set_value(_XPLATSTR("CountryRegion"), _XPLATSTR("JP"));
 
-	auto entity_value_3 = std::make_shared<odata_entity_value>(model->find_entity_type(U("Account")));
-	entity_value_3->set_value(U("AccountID"), (int32_t)300);
-	entity_value_3->set_value(U("CountryRegion"), U("GB"));
+	auto entity_value_3 = ::odata::make_shared<odata_entity_value>(model->find_entity_type(_XPLATSTR("Account")));
+	entity_value_3->set_value(_XPLATSTR("AccountID"), (int32_t)300);
+	entity_value_3->set_value(_XPLATSTR("CountryRegion"), _XPLATSTR("GB"));
 
-	auto collection_type = std::make_shared<edm_collection_type>(U("collection value"), model->find_entity_type(U("Account")));
-	auto collection_value = std::make_shared<odata_collection_value>(collection_type);
+	auto collection_type = ::odata::make_shared<edm_collection_type>(_XPLATSTR("collection value"), model->find_entity_type(_XPLATSTR("Account")));
+	auto collection_value = ::odata::make_shared<odata_collection_value>(collection_type);
 	collection_value->add_collection_value(entity_value_1);
 	collection_value->add_collection_value(entity_value_2);
 	collection_value->add_collection_value(entity_value_3);
@@ -425,21 +425,21 @@ TEST(entity_collection_value)
 	entity_value_3 = std::dynamic_pointer_cast<odata_entity_value>(collection_value->get_collection_values()[2]);
 
 	int32_t id;
-	::utility::string_t str;
-	entity_value_1->try_get(U("AccountID"), id);
+	::odata::string_t str;
+	entity_value_1->try_get(_XPLATSTR("AccountID"), id);
 	VERIFY_ARE_EQUAL(id, 100);
-	entity_value_1->try_get(U("CountryRegion"), str);
-	VERIFY_ARE_EQUAL(str, U("China"));
+	entity_value_1->try_get(_XPLATSTR("CountryRegion"), str);
+	VERIFY_ARE_EQUAL(str, _XPLATSTR("China"));
 
-	entity_value_2->try_get(U("AccountID"), id);
+	entity_value_2->try_get(_XPLATSTR("AccountID"), id);
 	VERIFY_ARE_EQUAL(id, 200);
-	entity_value_2->try_get(U("CountryRegion"), str);
-	VERIFY_ARE_EQUAL(str, U("JP"));
+	entity_value_2->try_get(_XPLATSTR("CountryRegion"), str);
+	VERIFY_ARE_EQUAL(str, _XPLATSTR("JP"));
 
-	entity_value_3->try_get(U("AccountID"), id);
+	entity_value_3->try_get(_XPLATSTR("AccountID"), id);
 	VERIFY_ARE_EQUAL(id, 300);
-	entity_value_3->try_get(U("CountryRegion"), str);
-	VERIFY_ARE_EQUAL(str, U("GB"));
+	entity_value_3->try_get(_XPLATSTR("CountryRegion"), str);
+	VERIFY_ARE_EQUAL(str, _XPLATSTR("GB"));
 }
 
 }

--- a/tests/functional/edm_test/edm_model_reader_test.cpp
+++ b/tests/functional/edm_test/edm_model_reader_test.cpp
@@ -148,67 +148,67 @@ SUITE(odata_edm_model_reader_tests)
 
 TEST(collection_of_navigation_type)
 {
-	//auto model_reader = std::make_shared<edm_model_reader>(edm_model_collection_of_navigation_type_test_string, strlen(edm_model_collection_of_navigation_type_test_string));
+	//auto model_reader = ::odata::make_shared<edm_model_reader>(edm_model_collection_of_navigation_type_test_string, strlen(edm_model_collection_of_navigation_type_test_string));
 	//model_reader->parse();
 	//auto model = model_reader->get_model();
 
-	auto model_reader = std::make_shared<edm_model_reader>(concurrency::streams::bytestream::open_istream(std::move(std::string(test_model_string))));
+	auto model_reader = ::odata::make_shared<edm_model_reader>(concurrency::streams::bytestream::open_istream(std::move(std::string(test_model_string))));
 	model_reader->parse();
 	auto model = model_reader->get_model();
 }
 
 TEST(collection_of_complex_type)
 {
-	auto model_reader = std::make_shared<edm_model_reader>(concurrency::streams::bytestream::open_istream(std::move(std::string(edm_model_collection_of_complex_type_test_string))));
+	auto model_reader = ::odata::make_shared<edm_model_reader>(concurrency::streams::bytestream::open_istream(std::move(std::string(edm_model_collection_of_complex_type_test_string))));
 	model_reader->parse();
 	auto model = model_reader->get_model();
 
 	VERIFY_IS_NOT_NULL(model);
-	auto enity_type = model->find_entity_type(U("Person"));
+	auto enity_type = model->find_entity_type(_XPLATSTR("Person"));
 	VERIFY_IS_NOT_NULL(enity_type);
-	auto addresses = enity_type->find_property(U("Addresses"));
+	auto addresses = enity_type->find_property(_XPLATSTR("Addresses"));
 	VERIFY_ARE_EQUAL(addresses->get_property_type()->get_type_kind(), edm_type_kind_t::Collection);
 	auto collection_type = std::dynamic_pointer_cast<edm_collection_type>(addresses->get_property_type());
 	auto collection_element_type = collection_type->get_element_type();
 	VERIFY_ARE_EQUAL(collection_element_type->get_type_kind(), edm_type_kind_t::Complex);
-	VERIFY_ARE_EQUAL(collection_element_type->get_full_name(), U("Microsoft.Test.OData.Services.ODataWCFService.Address"));
+	VERIFY_ARE_EQUAL(collection_element_type->get_full_name(), _XPLATSTR("Microsoft.Test.OData.Services.ODataWCFService.Address"));
 }
 
 
 TEST(edm_model_reader_entity_type_test)
 {
-	auto model_reader = std::make_shared<edm_model_reader>(concurrency::streams::bytestream::open_istream(std::move(std::string(edm_model_entity_type_test_string))));
+	auto model_reader = ::odata::make_shared<edm_model_reader>(concurrency::streams::bytestream::open_istream(std::move(std::string(edm_model_entity_type_test_string))));
 	model_reader->parse();
 	auto model = model_reader->get_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto enity_type = model->find_entity_type(U("Person"));
+	auto enity_type = model->find_entity_type(_XPLATSTR("Person"));
 	VERIFY_IS_NOT_NULL(enity_type);
 	VERIFY_ARE_EQUAL(enity_type->get_type_kind(), edm_type_kind_t::Entity);
 	VERIFY_ARE_EQUAL(enity_type->key().size(), 1);
-	VERIFY_ARE_EQUAL(enity_type->key()[0], U("PersonID"));
-	auto property_home_address = enity_type->find_property(U("HomeAddress"));
+	VERIFY_ARE_EQUAL(enity_type->key()[0], _XPLATSTR("PersonID"));
+	auto property_home_address = enity_type->find_property(_XPLATSTR("HomeAddress"));
 	VERIFY_IS_NOT_NULL(property_home_address);
 	VERIFY_ARE_EQUAL(property_home_address->get_property_type()->get_type_kind(), edm_type_kind_t::Complex);
-	auto navigation_property = enity_type->find_property(U("Parent"));
+	auto navigation_property = enity_type->find_property(_XPLATSTR("Parent"));
 	VERIFY_IS_NOT_NULL(navigation_property);
 	VERIFY_ARE_EQUAL(navigation_property->get_property_type()->get_type_kind(), edm_type_kind_t::Navigation);
 	auto navigation_type = std::dynamic_pointer_cast<edm_navigation_type>(navigation_property->get_property_type());
 	VERIFY_IS_NOT_NULL(navigation_type);
 	VERIFY_ARE_EQUAL(navigation_type->get_navigation_type()->get_type_kind(), edm_type_kind_t::Entity);
-	VERIFY_ARE_EQUAL(navigation_type->get_navigation_type()->get_name(), U("Person"));
+	VERIFY_ARE_EQUAL(navigation_type->get_navigation_type()->get_name(), _XPLATSTR("Person"));
 }
 
 
 TEST(edm_model_reader_complex_type_test)
 {
-	auto model_reader = std::make_shared<edm_model_reader>(concurrency::streams::bytestream::open_istream(std::move(std::string(edm_model_complex_type_test_string))));
+	auto model_reader = ::odata::make_shared<edm_model_reader>(concurrency::streams::bytestream::open_istream(std::move(std::string(edm_model_complex_type_test_string))));
 	model_reader->parse();
 	auto model = model_reader->get_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto complex_type = model->find_complex_type(U("AccountInfo"));
+	auto complex_type = model->find_complex_type(_XPLATSTR("AccountInfo"));
 	VERIFY_IS_NOT_NULL(complex_type);
 	VERIFY_ARE_EQUAL(complex_type->get_type_kind(), edm_type_kind_t::Complex);
-	auto property_last_name = complex_type->find_property(U("LastName"));
+	auto property_last_name = complex_type->find_property(_XPLATSTR("LastName"));
 	VERIFY_IS_NOT_NULL(property_last_name);
 	VERIFY_ARE_EQUAL(property_last_name->is_nullable(), false);
 	auto property_type = property_last_name->get_property_type();
@@ -221,11 +221,11 @@ TEST(edm_model_reader_complex_type_test)
 
 TEST(edm_model_reader_enum_type_test)
 {
-	auto model_reader = std::make_shared<edm_model_reader>(concurrency::streams::bytestream::open_istream(std::move(std::string(edm_model_enum_type_test_string))));
+	auto model_reader = ::odata::make_shared<edm_model_reader>(concurrency::streams::bytestream::open_istream(std::move(std::string(edm_model_enum_type_test_string))));
 	model_reader->parse();
 	auto model = model_reader->get_model();
 	VERIFY_IS_NOT_NULL(model);
-	auto enum_type = model->find_enum_type(U("AccessLevel"));
+	auto enum_type = model->find_enum_type(_XPLATSTR("AccessLevel"));
 	VERIFY_IS_NOT_NULL(enum_type);
 	VERIFY_ARE_EQUAL(enum_type->get_type_kind(), edm_type_kind_t::Enum);
 	VERIFY_ARE_EQUAL(enum_type->get_enum_members().size(), 5);
@@ -234,12 +234,12 @@ TEST(edm_model_reader_enum_type_test)
 	
 TEST(edm_model_reader_version_test)
 {
-	auto model_reader = std::make_shared<edm_model_reader>(concurrency::streams::bytestream::open_istream(std::move(std::string(edm_model_version_test_string))));
+	auto model_reader = ::odata::make_shared<edm_model_reader>(concurrency::streams::bytestream::open_istream(std::move(std::string(edm_model_version_test_string))));
 	model_reader->parse();
 	auto model = model_reader->get_model();
 	VERIFY_IS_NOT_NULL(model);
 	auto version = model->get_version();
-	VERIFY_ARE_EQUAL(version, U("4.0"));
+	VERIFY_ARE_EQUAL(version, _XPLATSTR("4.0"));
 }
 
 }

--- a/tests/functional/edm_test/edm_model_utility_test.cpp
+++ b/tests/functional/edm_test/edm_model_utility_test.cpp
@@ -16,28 +16,28 @@ namespace tests { namespace functional { namespace _odata {
 
 struct edm_type_comparision_object
 {
-	::utility::string_t primitive_name;
+	::odata::string_t primitive_name;
 	edm_primitive_type_kind_t expected_primitive_type;
 };
 
 #define edm_primitive_type_test_contents_size 15
-static edm_type_comparision_object edm_primitive_type_test_contents[edm_primitive_type_test_contents_size] = 
+static edm_type_comparision_object edm_primitive_type_test_contents[edm_primitive_type_test_contents_size] =
 {
-	{U("Edm.Binary"), edm_primitive_type_kind_t::Binary},
-	{U("Edm.Boolean"), edm_primitive_type_kind_t::Boolean},
-	{U("Edm.Byte"), edm_primitive_type_kind_t::Byte},
-	{U("Edm.Duration"), edm_primitive_type_kind_t::Duration},
-	{U("Edm.DateTimeOffset"), edm_primitive_type_kind_t::DateTimeOffset},
-	{U("Edm.Double"), edm_primitive_type_kind_t::Double},
-	{U("Edm.Decimal"), edm_primitive_type_kind_t::Decimal},
-	{U("Edm.Guid"), edm_primitive_type_kind_t::Guid},
-	{U("Edm.Int16"), edm_primitive_type_kind_t::Int16},
-	{U("Edm.Int32"), edm_primitive_type_kind_t::Int32},
-	{U("Edm.Int64"), edm_primitive_type_kind_t::Int64},
-	{U("Edm.SByte"), edm_primitive_type_kind_t::SByte},
-	{U("Edm.Single"), edm_primitive_type_kind_t::Single},
-	{U("Edm.Stream"), edm_primitive_type_kind_t::Stream},
-	{U("Edm.String"), edm_primitive_type_kind_t::String},
+	{_XPLATSTR("Edm.Binary"), edm_primitive_type_kind_t::Binary},
+	{_XPLATSTR("Edm.Boolean"), edm_primitive_type_kind_t::Boolean},
+	{_XPLATSTR("Edm.Byte"), edm_primitive_type_kind_t::Byte},
+	{_XPLATSTR("Edm.Duration"), edm_primitive_type_kind_t::Duration},
+	{_XPLATSTR("Edm.DateTimeOffset"), edm_primitive_type_kind_t::DateTimeOffset},
+	{_XPLATSTR("Edm.Double"), edm_primitive_type_kind_t::Double},
+	{_XPLATSTR("Edm.Decimal"), edm_primitive_type_kind_t::Decimal},
+	{_XPLATSTR("Edm.Guid"), edm_primitive_type_kind_t::Guid},
+	{_XPLATSTR("Edm.Int16"), edm_primitive_type_kind_t::Int16},
+	{_XPLATSTR("Edm.Int32"), edm_primitive_type_kind_t::Int32},
+	{_XPLATSTR("Edm.Int64"), edm_primitive_type_kind_t::Int64},
+	{_XPLATSTR("Edm.SByte"), edm_primitive_type_kind_t::SByte},
+	{_XPLATSTR("Edm.Single"), edm_primitive_type_kind_t::Single},
+	{_XPLATSTR("Edm.Stream"), edm_primitive_type_kind_t::Stream},
+	{_XPLATSTR("Edm.String"), edm_primitive_type_kind_t::String},
 };
 
 SUITE(odata_edm_model_utility_tests)
@@ -58,39 +58,39 @@ TEST(get_edm_primitive_type_from_name)
 
 TEST(get_edm_primitive_type_from_name_nagative_case)
 {
-	auto return_type = edm_model_utility::get_edm_primitive_type_from_name(U(""));
+	auto return_type = edm_model_utility::get_edm_primitive_type_from_name(_XPLATSTR(""));
 	VERIFY_IS_NULL(return_type);
-    return_type = edm_model_utility::get_edm_primitive_type_from_name(U("Edm."));
+    return_type = edm_model_utility::get_edm_primitive_type_from_name(_XPLATSTR("Edm."));
 	VERIFY_IS_NULL(return_type);
-    return_type = edm_model_utility::get_edm_primitive_type_from_name(U("Edm.Nothing"));
+    return_type = edm_model_utility::get_edm_primitive_type_from_name(_XPLATSTR("Edm.Nothing"));
 	VERIFY_IS_NULL(return_type);
 }
 
 struct get_edm_type_from_name_test_object
 {
-	::utility::string_t input_name;
+	::odata::string_t input_name;
 	edm_type_kind_t expected_edm_type;
 	edm_primitive_type_kind_t expected_primitive_type;
 };
 
 #define get_edm_type_from_name_test_size 15
-static get_edm_type_from_name_test_object get_edm_type_from_name_test_content[get_edm_type_from_name_test_size] = 
+static get_edm_type_from_name_test_object get_edm_type_from_name_test_content[get_edm_type_from_name_test_size] =
 {
-	{U("Collection(Edm.Binary)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Binary},
-	{U("Collection(Edm.Boolean)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Boolean},
-	{U("Collection(Edm.Byte)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Byte},
-	{U("Collection(Edm.Duration)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Duration},
-	{U("Collection(Edm.DateTimeOffset)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::DateTimeOffset},
-	{U("Collection(Edm.Double)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Double},
-	{U("Collection(Edm.Decimal)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Decimal},
-	{U("Collection(Edm.Guid)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Guid},
-	{U("Collection(Edm.Int16)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Int16},
-	{U("Collection(Edm.Int32)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Int32},
-	{U("Collection(Edm.Int64)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Int64},
-	{U("Collection(Edm.SByte)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::SByte},
-	{U("Collection(Edm.Single)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Single},
-	{U("Collection(Edm.Stream)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Stream},
-	{U("Collection(Edm.String)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::String},
+	{_XPLATSTR("Collection(Edm.Binary)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Binary},
+	{_XPLATSTR("Collection(Edm.Boolean)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Boolean},
+	{_XPLATSTR("Collection(Edm.Byte)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Byte},
+	{_XPLATSTR("Collection(Edm.Duration)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Duration},
+	{_XPLATSTR("Collection(Edm.DateTimeOffset)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::DateTimeOffset},
+	{_XPLATSTR("Collection(Edm.Double)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Double},
+	{_XPLATSTR("Collection(Edm.Decimal)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Decimal},
+	{_XPLATSTR("Collection(Edm.Guid)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Guid},
+	{_XPLATSTR("Collection(Edm.Int16)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Int16},
+	{_XPLATSTR("Collection(Edm.Int32)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Int32},
+	{_XPLATSTR("Collection(Edm.Int64)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Int64},
+	{_XPLATSTR("Collection(Edm.SByte)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::SByte},
+	{_XPLATSTR("Collection(Edm.Single)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Single},
+	{_XPLATSTR("Collection(Edm.Stream)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::Stream},
+	{_XPLATSTR("Collection(Edm.String)"), edm_type_kind_t::Collection, edm_primitive_type_kind_t::String},
 };
 
 TEST(get_edm_type_from_name_collection_primitive_case)
@@ -111,7 +111,7 @@ TEST(get_edm_type_from_name_collection_primitive_case)
 
 TEST(get_edm_type_from_name_collection_undetermined_case)
 {
-    auto return_type = edm_model_utility::get_edm_type_from_name(U("Collection(OData.Test)"));
+    auto return_type = edm_model_utility::get_edm_type_from_name(_XPLATSTR("Collection(OData.Test)"));
 	VERIFY_IS_NOT_NULL(return_type);
 	VERIFY_ARE_EQUAL(return_type->get_type_kind(), edm_type_kind_t::Collection);
 	auto collection_type = std::dynamic_pointer_cast<edm_collection_type>(return_type);
@@ -122,15 +122,15 @@ TEST(get_edm_type_from_name_collection_undetermined_case)
 
 TEST(get_edm_type_from_name_nagative_case)
 {
-    auto return_type = edm_model_utility::get_edm_type_from_name(U("OData.Test"));
+    auto return_type = edm_model_utility::get_edm_type_from_name(_XPLATSTR("OData.Test"));
 	VERIFY_IS_NULL(return_type);
 }
 
 TEST(get_primitive_kind_from_edm_type)
 {
 	auto primitive_type = edm_primitive_type::BINARY();
-	auto complex_type = std::make_shared<edm_complex_type>(U(""), U(""));
-	auto entity_type = std::make_shared<edm_entity_type>(U(""), U(""));
+	auto complex_type = ::odata::make_shared<edm_complex_type>(_XPLATSTR(""), _XPLATSTR(""));
+	auto entity_type = ::odata::make_shared<edm_entity_type>(_XPLATSTR(""), _XPLATSTR(""));
 
 	edm_primitive_type_kind_t out_put;
 	bool ok = edm_model_utility::get_primitive_kind_from_edm_type(primitive_type, out_put);
@@ -139,26 +139,26 @@ TEST(get_primitive_kind_from_edm_type)
 
 	ok = edm_model_utility::get_primitive_kind_from_edm_type(complex_type, out_put);
 	VERIFY_ARE_EQUAL(ok, false);
-	
+
 	ok = edm_model_utility::get_primitive_kind_from_edm_type(entity_type, out_put);
 	VERIFY_ARE_EQUAL(ok, false);
 }
 
 TEST(resolve_edm_types_after_parsing_type_in_entity)
 {
-	::utility::string_t name_space = U("odata.functional.test");
-	auto model = std::make_shared<edm_model>();
-	auto schema = model->add_schema(U("schema"), name_space);
-	auto complex_address = std::make_shared<edm_complex_type>(U("complex_address"), name_space);
-	auto entity_account = std::make_shared<edm_entity_type>(U("entity_account"), name_space);
-	auto property_address = std::make_shared<edm_property_type>(U("Address"));
-	property_address->set_property_type(std::make_shared<edm_named_type>(U("complex_address"), U(""), edm_type_kind_t::Unknown));
+	::odata::string_t name_space = _XPLATSTR("odata.functional.test");
+	auto model = ::odata::make_shared<edm_model>();
+	auto schema = model->add_schema(_XPLATSTR("schema"), name_space);
+	auto complex_address = ::odata::make_shared<edm_complex_type>(_XPLATSTR("complex_address"), name_space);
+	auto entity_account = ::odata::make_shared<edm_entity_type>(_XPLATSTR("entity_account"), name_space);
+	auto property_address = ::odata::make_shared<edm_property_type>(_XPLATSTR("Address"));
+	property_address->set_property_type(::odata::make_shared<edm_named_type>(_XPLATSTR("complex_address"), _XPLATSTR(""), edm_type_kind_t::Unknown));
 	entity_account->add_property(property_address);
 	schema->add_complex_type(complex_address);
 	schema->add_entity_type(entity_account);
 	edm_model_utility::resolve_edm_types_after_parsing(model);
 
-	auto prop = entity_account->find_property(U("Address"));
+	auto prop = entity_account->find_property(_XPLATSTR("Address"));
 	VERIFY_IS_NOT_NULL(prop);
 	auto prop_type = prop->get_property_type();
 	VERIFY_IS_NOT_NULL(prop_type);
@@ -167,19 +167,19 @@ TEST(resolve_edm_types_after_parsing_type_in_entity)
 
 TEST(resolve_edm_types_after_parsing_type_in_complex)
 {
-	::utility::string_t name_space = U("odata.functional.test");
-	auto model = std::make_shared<edm_model>();
-	auto schema = model->add_schema(U("schema"), name_space);
-	auto complex_address = std::make_shared<edm_complex_type>(U("complex_address"), name_space);
-	auto complex_account = std::make_shared<edm_complex_type>(U("complex_account"), name_space);
-	auto property_address = std::make_shared<edm_property_type>(U("Address"));
-	property_address->set_property_type(std::make_shared<edm_named_type>(U("complex_address"), U(""), edm_type_kind_t::Unknown));
+	::odata::string_t name_space = _XPLATSTR("odata.functional.test");
+	auto model = ::odata::make_shared<edm_model>();
+	auto schema = model->add_schema(_XPLATSTR("schema"), name_space);
+	auto complex_address = ::odata::make_shared<edm_complex_type>(_XPLATSTR("complex_address"), name_space);
+	auto complex_account = ::odata::make_shared<edm_complex_type>(_XPLATSTR("complex_account"), name_space);
+	auto property_address = ::odata::make_shared<edm_property_type>(_XPLATSTR("Address"));
+	property_address->set_property_type(::odata::make_shared<edm_named_type>(_XPLATSTR("complex_address"), _XPLATSTR(""), edm_type_kind_t::Unknown));
 	complex_account->add_property(property_address);
 	schema->add_complex_type(complex_address);
 	schema->add_complex_type(complex_account);
 	edm_model_utility::resolve_edm_types_after_parsing(model);
 
-	auto prop = complex_account->find_property(U("Address"));
+	auto prop = complex_account->find_property(_XPLATSTR("Address"));
 	VERIFY_IS_NOT_NULL(prop);
 	auto prop_type = prop->get_property_type();
 	VERIFY_IS_NOT_NULL(prop_type);
@@ -188,16 +188,16 @@ TEST(resolve_edm_types_after_parsing_type_in_complex)
 
 TEST(resolve_edm_types_after_parsing_type_in_operation)
 {
-	::utility::string_t name_space = U("odata.functional.test");
-	auto model = std::make_shared<edm_model>();
-	auto schema = model->add_schema(U("schema"), name_space);
+	::odata::string_t name_space = _XPLATSTR("odata.functional.test");
+	auto model = ::odata::make_shared<edm_model>();
+	auto schema = model->add_schema(_XPLATSTR("schema"), name_space);
 	std::shared_ptr<edm_operation_type>  operation;
-	operation.reset(new edm_operation_type(U("operation"), name_space, false, U(""), EdmOperationKind::Function, false));
-	auto complex_address = std::make_shared<edm_complex_type>(U("complex_address"), name_space);
-	auto complex_account = std::make_shared<edm_complex_type>(U("complex_account"), name_space);
-	operation->set_return_type(std::make_shared<edm_named_type>(U("complex_address"), U(""), edm_type_kind_t::Unknown));
-	auto param = std::make_shared<edm_operation_parameter>();
-	param->set_param_type(std::make_shared<edm_named_type>(U("complex_account"), U(""), edm_type_kind_t::Unknown));
+	operation.reset(new edm_operation_type(_XPLATSTR("operation"), name_space, false, _XPLATSTR(""), EdmOperationKind::Function, false));
+	auto complex_address = ::odata::make_shared<edm_complex_type>(_XPLATSTR("complex_address"), name_space);
+	auto complex_account = ::odata::make_shared<edm_complex_type>(_XPLATSTR("complex_account"), name_space);
+	operation->set_return_type(::odata::make_shared<edm_named_type>(_XPLATSTR("complex_address"), _XPLATSTR(""), edm_type_kind_t::Unknown));
+	auto param = ::odata::make_shared<edm_operation_parameter>();
+	param->set_param_type(::odata::make_shared<edm_named_type>(_XPLATSTR("complex_account"), _XPLATSTR(""), edm_type_kind_t::Unknown));
 	operation->add_operation_parameter(param);
 	schema->add_complex_type(complex_address);
 	schema->add_complex_type(complex_account);

--- a/tests/functional/odata_tests.cpp
+++ b/tests/functional/odata_tests.cpp
@@ -379,12 +379,12 @@ const char* test_model_string =
 ";
 
 std::shared_ptr<::odata::edm::edm_model> g_test_model;
-::utility::string_t g_service_root_url = U("http://odatae2etest.azurewebsites.net/cpptest/DefaultService");
+::odata::string_t g_service_root_url = _XPLATSTR("http://odatae2etest.azurewebsites.net/cpptest/DefaultService");
 std::shared_ptr<::odata::edm::edm_model> get_test_model()
 {
 	if (!g_test_model)
 	{
-		auto model_reader = std::make_shared<::odata::edm::edm_model_reader>(concurrency::streams::bytestream::open_istream(std::move(std::string(test_model_string))));
+		auto model_reader = ::odata::make_shared<::odata::edm::edm_model_reader>(concurrency::streams::bytestream::open_istream(std::move(std::string(test_model_string))));
 
 		model_reader->parse();
 		g_test_model = model_reader->get_model();

--- a/tests/functional/odata_tests.h
+++ b/tests/functional/odata_tests.h
@@ -14,6 +14,6 @@
 
 extern const char* test_model_string;
 extern std::shared_ptr<::odata::edm::edm_model> g_test_model;
-extern ::utility::string_t g_service_root_url;
+extern ::odata::string_t g_service_root_url;
 
 std::shared_ptr<::odata::edm::edm_model> get_test_model();

--- a/tools/codegentool/odata_codegen_initializer.cpp
+++ b/tools/codegentool/odata_codegen_initializer.cpp
@@ -15,28 +15,28 @@ using namespace ::concurrency::streams;
 
 namespace odata { namespace codegen { namespace tools {
 
-#define BASE_TYPE_NAME U("type_base")
-#define DATA_SERVICE_CONTEXT_NAME U("odata_service_context")
+#define BASE_TYPE_NAME _XPLATSTR("type_base")
+#define DATA_SERVICE_CONTEXT_NAME _XPLATSTR("odata_service_context")
 
 
-::pplx::task<int> odata_codegen_initializer::initialize_from_service_metadata(const ::utility::string_t metadata_url, const ::utility::string_t output_file_name, const ::utility::string_t user_name, const ::utility::string_t  password)
+::pplx::task<int> odata_codegen_initializer::initialize_from_service_metadata(const ::odata::string_t metadata_url, const ::odata::string_t output_file_name, const ::odata::string_t user_name, const ::odata::string_t password)
 {
-	m_config._file_name = output_file_name.empty() ? U("generated_code") : output_file_name;
+	m_config._file_name = output_file_name.empty() ? _XPLATSTR("generated_code") : output_file_name;
 
 	reset_class_info();
 
 	std::shared_ptr<::odata::client::odata_client> client = nullptr;
 	if (!user_name.empty() && !password.empty())
 	{
-	    ::odata::client::client_options options;
-	    options.enable_client_credential(user_name, password);
-		client = std::make_shared<::odata::client::odata_client>(metadata_url, options);
+		::odata::client::client_options options;
+		options.enable_client_credential(user_name, password);
+		client = ::odata::make_shared<::odata::client::odata_client>(metadata_url, options);
 	}
 	else
 	{
-		client = std::make_shared<::odata::client::odata_client>(metadata_url);
+		client = ::odata::make_shared<::odata::client::odata_client>(metadata_url);
 	}
-    
+
 	if (!client)
 	{
 		return ::pplx::task_from_result(-1);
@@ -45,7 +45,7 @@ namespace odata { namespace codegen { namespace tools {
 	::std::shared_ptr<edm_model> model;
 	try
 	{
-		model = client->get_model().get();
+		model = client->get_model().get().first;
 	}
 	catch (const std::exception &e)
 	{
@@ -57,9 +57,9 @@ namespace odata { namespace codegen { namespace tools {
 	return begin_initialize_code_gen_info(model);
 }
 
-::pplx::task<int> odata_codegen_initializer::initialize_from_metadata_file(const ::utility::string_t metadata_file, const ::utility::string_t output_file_name)
+::pplx::task<int> odata_codegen_initializer::initialize_from_metadata_file(const ::odata::string_t metadata_file, const ::odata::string_t output_file_name)
 {
-	m_config._file_name = output_file_name.empty() ? U("generated_code") : output_file_name;
+	m_config._file_name = output_file_name.empty() ? _XPLATSTR("generated_code") : output_file_name;
 
 	reset_class_info();
 
@@ -68,9 +68,9 @@ namespace odata { namespace codegen { namespace tools {
 	{
 		model = fstream::open_istream(metadata_file).then([] (istream file_opened) -> ::std::shared_ptr<edm_model>
 		{
-			auto model_reader = std::make_shared<edm_model_reader>(file_opened);
+			auto model_reader = ::odata::make_shared<edm_model_reader>(file_opened);
 			model_reader->parse();
-		
+
 			return model_reader->get_model();
 		}).get();
 	}
@@ -90,17 +90,17 @@ namespace odata { namespace codegen { namespace tools {
 	{
 		return ::pplx::task_from_result(-1);
 	}
-	
+
 	m_model = model;
 
-	auto entity_container = m_model->find_container();
+	auto &entity_container = m_model->find_container();
 	if (!entity_container)
 	{
 		throw std::runtime_error("must have an entity container in model!");
 	}
 
-	::utility::string_t ns_entity_container;
-	for (auto schema = m_model->get_schema().cbegin(); schema != m_model->get_schema().cend(); schema++)
+	::odata::string_t ns_entity_container;
+	for (auto schema = m_model->get_schema().cbegin(); schema != m_model->get_schema().cend(); ++schema)
 	{
 		if ((*schema)->find_container() != nullptr)
 		{
@@ -108,9 +108,9 @@ namespace odata { namespace codegen { namespace tools {
 		}
 	}
 
-	// merge namesapce to one that has entity container
-	// todo : support same class name in different namesapce
-	for (auto schema = m_model->get_schema().cbegin(); schema != m_model->get_schema().cend(); schema++)
+	// merge namespace to one that has entity container
+	// todo: support same class name in different namespace
+	for (auto schema = m_model->get_schema().cbegin(); schema != m_model->get_schema().cend(); ++schema)
 	{
 		schema_info _schema_info;
 		initialize_class_info(*schema, _schema_info);
@@ -120,7 +120,7 @@ namespace odata { namespace codegen { namespace tools {
 	}
 
 	schema_info total;
-	for (auto map_iter = m_code_gen_map.begin(); map_iter != m_code_gen_map.end(); map_iter++)
+	for (auto map_iter = m_code_gen_map.begin(); map_iter != m_code_gen_map.end(); ++map_iter)
 	{
 		schema_info _schema_info = map_iter->second;
 
@@ -141,11 +141,11 @@ void odata_codegen_initializer::reset_class_info()
 	m_code_gen_map.clear();
 }
 
-static ::utility::string_t normalize_namespace(const ::utility::string_t& _namespace)
+static ::odata::string_t normalize_namespace(const ::odata::string_t& _namespace)
 {
 	::utility::string_t ret = _namespace;
 
-	std::replace(ret.begin(), ret.end(), U('.'), U('_'));
+	std::replace(ret.begin(), ret.end(), _XPLATSTR('.'), _XPLATSTR('_'));
 
 	return ret;
 }
@@ -154,30 +154,30 @@ void odata_codegen_initializer::initialize_class_info(const std::shared_ptr<edm_
 {
 	if (!schema)
 	{
-		return ;
+		return;
 	}
 
-	auto enum_types = schema->get_enum_types();
-	for (auto enum_type_iter = enum_types.cbegin(); enum_type_iter != enum_types.cend(); enum_type_iter++)
+	auto &enum_types = schema->get_enum_types();
+	for (auto enum_type_iter = enum_types.cbegin(); enum_type_iter != enum_types.cend(); ++enum_type_iter)
 	{
 		class_info _info;
 
-		auto enum_type = enum_type_iter->second;
+		auto &enum_type = enum_type_iter->second;
 		_info._edm_name = enum_type->get_name();
 		_info._class_name = enum_type->get_name();
 		_info._edm_namespace = schema->get_name();
 		_info._type = CLASS_TYPE::E_CLASS_ENUM;
 
-		_schema_info.m_class_map[enum_type->get_name()] = _info;	
-		_schema_info.m_class_vec.push_back(_info);
+		_schema_info.m_class_map[enum_type->get_name()] = _info;
+		_schema_info.m_class_vec.emplace_back(_info);
 	}
 
-	auto complex_types = schema->get_complex_types();
-	for (auto complex_type_iter = complex_types.cbegin(); complex_type_iter != complex_types.cend(); complex_type_iter++)
+	auto &complex_types = schema->get_complex_types();
+	for (auto complex_type_iter = complex_types.cbegin(); complex_type_iter != complex_types.cend(); ++complex_type_iter)
 	{
 		class_info _info;
 
-		auto complex_type = complex_type_iter->second;
+		auto &complex_type = complex_type_iter->second;
 		_info._edm_name = complex_type->get_name();
 		_info._class_name = complex_type->get_name();
 		_info._edm_namespace = schema->get_name();
@@ -191,20 +191,19 @@ void odata_codegen_initializer::initialize_class_info(const std::shared_ptr<edm_
 		{
 			if (_info._base_class_name.find(complex_type->get_namespace()) == 0)
 			{
-				_info._base_class_name = 
-					_info._base_class_name.substr(complex_type->get_namespace().length() + 1, _info._base_class_name.length() - complex_type->get_namespace().length() - 1);
+				_info._base_class_name = _info._base_class_name.substr(complex_type->get_namespace().length() + 1, _info._base_class_name.length() - complex_type->get_namespace().length() - 1);
 			}
 		}
 
 		_schema_info.m_class_map[complex_type->get_name()] = _info;
 	}
 
-	auto entity_types = schema->get_entity_types();
-	for (auto entity_type_iter = entity_types.cbegin(); entity_type_iter != entity_types.cend(); entity_type_iter++)
+	auto &entity_types = schema->get_entity_types();
+	for (auto entity_type_iter = entity_types.cbegin(); entity_type_iter != entity_types.cend(); ++entity_type_iter)
 	{
 		class_info _info;
 
-		auto entity_type = entity_type_iter->second;
+		auto &entity_type = entity_type_iter->second;
 		_info._edm_name = entity_type->get_name();
 		_info._class_name = entity_type->get_name();
 		_info._edm_namespace = schema->get_name();
@@ -218,8 +217,7 @@ void odata_codegen_initializer::initialize_class_info(const std::shared_ptr<edm_
 		{
 			if (_info._base_class_name.find(entity_type->get_namespace()) == 0)
 			{
-				_info._base_class_name = 
-					_info._base_class_name.substr(entity_type->get_namespace().length() + 1, _info._base_class_name.length() - entity_type->get_namespace().length() - 1);
+				_info._base_class_name = _info._base_class_name.substr(entity_type->get_namespace().length() + 1, _info._base_class_name.length() - entity_type->get_namespace().length() - 1);
 			}
 		}
 
@@ -227,28 +225,28 @@ void odata_codegen_initializer::initialize_class_info(const std::shared_ptr<edm_
 	}
 
 
-	auto entity_containers = schema->get_containers();
+	auto &entity_containers = schema->get_containers();
 	if (entity_containers.size() > 1)
 	{
 		throw std::runtime_error("only support model with one entity container!");
 	}
 
-	for (auto entity_container_iter = entity_containers.cbegin(); entity_container_iter != entity_containers.cend(); entity_container_iter++)
+	for (auto entity_container_iter = entity_containers.cbegin(); entity_container_iter != entity_containers.cend(); ++entity_container_iter)
 	{
 		class_info _info;
 
-		auto container_type = entity_container_iter->second;
+		auto &container_type = entity_container_iter->second;
 		_info._edm_name = container_type->get_name();
 		_info._class_name = container_type->get_name();
 		_info._edm_namespace = schema->get_name();
 		_info._base_class_name = DATA_SERVICE_CONTEXT_NAME;
 		_info._type = CLASS_TYPE::E_CLASS_CONTAINER;
 
-		_schema_info.m_class_map[container_type->get_name()] = _info;	
+		_schema_info.m_class_map[container_type->get_name()] = _info;
 	}
 
 	// derived class dependency
-	std::unordered_map<::utility::string_t, ::utility::string_t> map_types_to_be_added;
+	std::unordered_map<::odata::string_t, ::odata::string_t> map_types_to_be_added;
 	map_types_to_be_added[BASE_TYPE_NAME] = BASE_TYPE_NAME;
 	map_types_to_be_added[DATA_SERVICE_CONTEXT_NAME] = DATA_SERVICE_CONTEXT_NAME;
 
@@ -257,35 +255,35 @@ void odata_codegen_initializer::initialize_class_info(const std::shared_ptr<edm_
 	{
 		b_continue = false;
 
-		for (auto class_iter = _schema_info.m_class_map.cbegin(); class_iter != _schema_info.m_class_map.cend(); class_iter++)
+		for (auto class_iter = _schema_info.m_class_map.cbegin(); class_iter != _schema_info.m_class_map.cend(); ++class_iter)
 		{
 			if (map_types_to_be_added.find(class_iter->second._base_class_name) != map_types_to_be_added.end()
 				&& map_types_to_be_added.find(class_iter->second._class_name) == map_types_to_be_added.end())
 			{
 				map_types_to_be_added[class_iter->second._class_name] = class_iter->second._class_name;
 
-				_schema_info.m_class_vec.push_back(class_iter->second);
+				_schema_info.m_class_vec.emplace_back(class_iter->second);
 
 				b_continue = true;
 			}
 		}
 	}
 
-	for (size_t i = 0; i < _schema_info.m_class_vec.size(); i++)
+	for (size_t i = 0; i < _schema_info.m_class_vec.size(); ++i)
 	{
 		auto _class_info = _schema_info.m_class_vec[i];
-		if ((_class_info._type == CLASS_TYPE::E_CLASS_COMPLEX || _class_info._type == CLASS_TYPE::E_CLASS_ENTITY) 
+		if ((_class_info._type == CLASS_TYPE::E_CLASS_COMPLEX || _class_info._type == CLASS_TYPE::E_CLASS_ENTITY)
 			&& (_class_info._base_class_name != BASE_TYPE_NAME))
 		{
-			std::vector<::utility::string_t> vec_derived_class;
+			std::vector<::odata::string_t> vec_derived_class;
 			if (_schema_info.m_derived_classes.find(_class_info._base_class_name) == _schema_info.m_derived_classes.end())
 			{
-				vec_derived_class.push_back(_class_info._class_name);
+				vec_derived_class.emplace_back(_class_info._class_name);
 				_schema_info.m_derived_classes[_class_info._base_class_name] = vec_derived_class;
 			}
 			else
 			{
-				_schema_info.m_derived_classes[_class_info._base_class_name].push_back(_class_info._class_name);
+				_schema_info.m_derived_classes[_class_info._base_class_name].emplace_back(_class_info._class_name);
 			}
 		}
 	}
@@ -295,24 +293,24 @@ void odata_codegen_initializer::initialize_property_info_of_class(const std::sha
 {
 	if (!schema)
 	{
-		return ;
+		return;
 	}
 
-	auto entity_types = schema->get_entity_types();
-	for (auto entity_type_iter = entity_types.cbegin(); entity_type_iter != entity_types.cend(); entity_type_iter++)
+	auto &entity_types = schema->get_entity_types();
+	for (auto entity_type_iter = entity_types.cbegin(); entity_type_iter != entity_types.cend(); ++entity_type_iter)
 	{
-		auto entity_type = entity_type_iter->second;
+		auto &entity_type = entity_type_iter->second;
 
 		class_property_info  class_property_map;
-		for (auto property_iter = entity_type->begin(); property_iter != entity_type->end(); property_iter++)
+		for (auto property_iter = entity_type->begin(); property_iter != entity_type->end(); ++property_iter)
 		{
-	    	auto property_type = property_iter->second;
+			auto &property_type = property_iter->second;
 
 			if (property_type->get_property_type()->get_type_kind() == edm_type_kind_t::Unknown)
 			{
 				continue;
 			}
-			
+
 			property_info property_info;
 
 			property_info._edm_name = property_type->get_name();
@@ -367,7 +365,7 @@ void odata_codegen_initializer::initialize_property_info_of_class(const std::sha
 			{
 				// collection of primitive complex enum
 				auto collection_type = std::dynamic_pointer_cast<edm_collection_type>(property_type->get_property_type());
-				auto element_type = collection_type->get_element_type();
+				auto &element_type = collection_type->get_element_type();
 				if (element_type->get_type_kind() == edm_type_kind_t::Complex)
 				{
 					property_info._strong_type_name = _schema_info.m_class_map[element_type->get_name()]._class_name;
@@ -375,8 +373,8 @@ void odata_codegen_initializer::initialize_property_info_of_class(const std::sha
 				}
 				else if (element_type->get_type_kind() == edm_type_kind_t::Primitive)
 				{
-				    property_info._strong_type_name = edm_model_utility::get_strong_type_name_from_edm_type_name(std::dynamic_pointer_cast<edm_primitive_type>(element_type));
-				    property_info._type = PROPERTY_TYPE::E_COLLECTION_PRIMITIVE;
+					property_info._strong_type_name = edm_model_utility::get_strong_type_name_from_edm_type_name(std::dynamic_pointer_cast<edm_primitive_type>(element_type));
+					property_info._type = PROPERTY_TYPE::E_COLLECTION_PRIMITIVE;
 				}
 				else if (element_type->get_type_kind() == edm_type_kind_t::Enum)
 				{
@@ -388,7 +386,7 @@ void odata_codegen_initializer::initialize_property_info_of_class(const std::sha
 					{
 						property_info._strong_type_name = _schema_info.m_class_map[element_type->get_name()]._class_name;
 					}
-				    property_info._type = PROPERTY_TYPE::E_COLLECTION_ENUM;
+					property_info._type = PROPERTY_TYPE::E_COLLECTION_ENUM;
 				}
 			}
 
@@ -401,15 +399,15 @@ void odata_codegen_initializer::initialize_property_info_of_class(const std::sha
 		_schema_info.m_class_property_map[entity_type->get_name()] = class_property_map;
 	}
 
-	auto complex_types = schema->get_complex_types();
-	for (auto complex_type_iter = complex_types.cbegin(); complex_type_iter != complex_types.cend(); complex_type_iter++)
+	auto &complex_types = schema->get_complex_types();
+	for (auto complex_type_iter = complex_types.cbegin(); complex_type_iter != complex_types.cend(); ++complex_type_iter)
 	{
-		auto complex_type = complex_type_iter->second;
+		auto &complex_type = complex_type_iter->second;
 
 		class_property_info  class_property_map;
-		for (auto property_iter = complex_type->begin(); property_iter != complex_type->end(); property_iter++)
+		for (auto property_iter = complex_type->begin(); property_iter != complex_type->end(); ++property_iter)
 		{
-			auto property_type = property_iter->second;
+			auto &property_type = property_iter->second;
 
 			if (property_type->get_property_type()->get_type_kind() == edm_type_kind_t::Unknown)
 			{
@@ -451,16 +449,16 @@ void odata_codegen_initializer::initialize_property_info_of_class(const std::sha
 			{
 				// collection of primitive complex enum
 				auto collection_type = std::dynamic_pointer_cast<edm_collection_type>(property_type->get_property_type());
-				auto element_type = collection_type->get_element_type();
+				auto &element_type = collection_type->get_element_type();
 				if (element_type->get_type_kind() == edm_type_kind_t::Complex)
 				{
 					property_info._strong_type_name = _schema_info.m_class_map[element_type->get_name()]._class_name;
-				    property_info._type = PROPERTY_TYPE::E_COLLECTION_COMPLEX;
+					property_info._type = PROPERTY_TYPE::E_COLLECTION_COMPLEX;
 				}
 				else if (element_type->get_type_kind() == edm_type_kind_t::Primitive)
 				{
-				    property_info._strong_type_name = edm_model_utility::get_strong_type_name_from_edm_type_name(std::dynamic_pointer_cast<edm_primitive_type>(element_type));
-				    property_info._type = PROPERTY_TYPE::E_COLLECTION_PRIMITIVE;
+					property_info._strong_type_name = edm_model_utility::get_strong_type_name_from_edm_type_name(std::dynamic_pointer_cast<edm_primitive_type>(element_type));
+					property_info._type = PROPERTY_TYPE::E_COLLECTION_PRIMITIVE;
 				}
 				else if (element_type->get_type_kind() == edm_type_kind_t::Enum)
 				{
@@ -471,8 +469,8 @@ void odata_codegen_initializer::initialize_property_info_of_class(const std::sha
 					else
 					{
 						property_info._strong_type_name = _schema_info.m_class_map[element_type->get_name()]._class_name;
-					}				    
-				    property_info._type = PROPERTY_TYPE::E_COLLECTION_ENUM;
+					}
+					property_info._type = PROPERTY_TYPE::E_COLLECTION_ENUM;
 				}
 			}
 
@@ -485,14 +483,14 @@ void odata_codegen_initializer::initialize_property_info_of_class(const std::sha
 		_schema_info.m_class_property_map[complex_type->get_name()] = class_property_map;
 	}
 
-	auto operation_types = schema->get_operation_types();
-	for (auto operation_type_iter = operation_types.cbegin(); operation_type_iter != operation_types.cend(); operation_type_iter++)
+	auto &operation_types = schema->get_operation_types();
+	for (auto operation_type_iter = operation_types.cbegin(); operation_type_iter != operation_types.cend(); ++operation_type_iter)
 	{
-		auto operation_type = operation_type_iter->second;
+		auto &operation_type = operation_type_iter->second;
 
-		if (operation_type->is_bound() && operation_type->get_operation_parameters().size() > 0)
+		if (operation_type->is_bound() && !operation_type->get_operation_parameters().empty())
 		{
-			auto bounded_type = operation_type->get_operation_parameters()[0]->get_param_type();
+			auto &bounded_type = operation_type->get_operation_parameters().front()->get_param_type();
 			if (!bounded_type)
 			{
 				continue;
@@ -524,30 +522,30 @@ void odata_codegen_initializer::initialize_property_info_of_class(const std::sha
 		}
 	}
 
-	std::map<::utility::string_t, ::utility::string_t> enum_member_name;
-	auto enum_types = schema->get_enum_types();
-	for (auto enum_type_iter = enum_types.cbegin(); enum_type_iter != enum_types.cend(); enum_type_iter++)
+	std::map<::odata::string_t, ::odata::string_t> enum_member_name;
+	auto &enum_types = schema->get_enum_types();
+	for (auto enum_type_iter = enum_types.cbegin(); enum_type_iter != enum_types.cend(); ++enum_type_iter)
 	{
 		class_property_info  class_property_map;
 
 		auto enum_type = std::dynamic_pointer_cast<edm_enum_type>(enum_type_iter->second);
-		auto enum_members = enum_type->get_enum_members();
-		for (auto enum_member_iter = enum_members.cbegin(); enum_member_iter != enum_members.cend(); enum_member_iter++)
+		auto &enum_members = enum_type->get_enum_members();
+		for (auto enum_member_iter = enum_members.cbegin(); enum_member_iter != enum_members.cend(); ++enum_member_iter)
 		{
-			auto enum_member = *enum_member_iter;
-		    property_info property_info;
+			auto &enum_member = *enum_member_iter;
+			property_info property_info;
 
 			property_info._edm_name = enum_member->get_enum_member_name();
 
-			if (enum_member_name.find(enum_member->get_enum_member_name()) == enum_member_name.end())
-			{
-				property_info._class_member_name = enum_member->get_enum_member_name();
-			}
-			else
-			{
-				property_info._class_member_name = enum_type->get_name() + U("_") + enum_member->get_enum_member_name();
-			}
-			
+			//if (enum_member_name.find(enum_member->get_enum_member_name()) == enum_member_name.end())
+			//{
+			//	property_info._class_member_name = enum_member->get_enum_member_name();
+			//}
+			//else
+			//{
+				property_info._class_member_name = enum_type->get_name() + _XPLATSTR("_") + enum_member->get_enum_member_name(); // Always build a complex enum value name for the sake of uniformity plus we might also encounter classes named like an enum value, thus the find call above is insufficient!
+			//}
+
 			enum_member_name[property_info._class_member_name] = property_info._class_member_name;
 			property_info._default_value = ::utility::conversions::print_string(enum_member->get_enum_member_value());
 
@@ -557,31 +555,31 @@ void odata_codegen_initializer::initialize_property_info_of_class(const std::sha
 		_schema_info.m_class_property_map[enum_type->get_name()] = class_property_map;
 	}
 
-	auto entity_containers = schema->get_containers();
+	auto &entity_containers = schema->get_containers();
 	if (entity_containers.size() == 1)
 	{
-		auto entity_container = schema->find_container();
+		auto &entity_container = schema->find_container();
 
 		class_property_info  class_property_map;
-		for (auto entity_set_iter = entity_container->begin(); entity_set_iter != entity_container->end(); entity_set_iter++)
+		for (auto entity_set_iter = entity_container->begin(); entity_set_iter != entity_container->end(); ++entity_set_iter)
 		{
-			auto entity_set = entity_set_iter->second;
-			
+			auto &entity_set = entity_set_iter->second;
+
 			property_info property_info;
 
 			property_info._edm_name = entity_set->get_name();
 			property_info._strong_type_name = entity_set->get_entity_type()->get_name();
 			property_info._class_member_name = entity_set->get_name();
 			std::transform(property_info._class_member_name.begin(), property_info._class_member_name.end(), property_info._class_member_name.begin(), ::tolower);
-			property_info._class_member_name = U("create_") + property_info._class_member_name + U("_query()");
+			property_info._class_member_name = _XPLATSTR("create_") + property_info._class_member_name + _XPLATSTR("_query()");
 			property_info._type = PROPERTY_TYPE::E_CONTAINER_ENTITY_SET;
 
 			class_property_map[property_info._class_member_name] = property_info;
 		}
 
-		for (auto singleton_iter = entity_container->get_singletons().cbegin(); singleton_iter != entity_container->get_singletons().cend(); singleton_iter++)
+		for (auto singleton_iter = entity_container->get_singletons().cbegin(); singleton_iter != entity_container->get_singletons().cend(); ++singleton_iter)
 		{
-			auto singleton = singleton_iter->second;
+			auto &singleton = singleton_iter->second;
 
 			property_info property_info;
 
@@ -589,22 +587,22 @@ void odata_codegen_initializer::initialize_property_info_of_class(const std::sha
 			property_info._strong_type_name = singleton->get_entity_type()->get_name();
 			property_info._class_member_name = singleton->get_name();
 			std::transform(property_info._class_member_name.begin(), property_info._class_member_name.end(), property_info._class_member_name.begin(), ::tolower);
-			property_info._class_member_name = U("create_") + property_info._class_member_name + U("_query()");
+			property_info._class_member_name = _XPLATSTR("create_") + property_info._class_member_name + _XPLATSTR("_query()");
 			property_info._type = PROPERTY_TYPE::E_CONTAINER_SINGLETON;
 
 			class_property_map[property_info._class_member_name] = property_info;
 		}
 
-		for (auto operation_imports_iter = entity_container->get_operation_imports().cbegin(); operation_imports_iter != entity_container->get_operation_imports().cend(); operation_imports_iter++)
+		for (auto operation_imports_iter = entity_container->get_operation_imports().cbegin(); operation_imports_iter != entity_container->get_operation_imports().cend(); ++operation_imports_iter)
 		{
-			auto operation_import = operation_imports_iter->second;
+			auto &operation_import = operation_imports_iter->second;
 
 			if (!operation_import)
 			{
 				continue;
 			}
 
-			auto operation_type = operation_import->get_operation_type();
+			auto &operation_type = operation_import->get_operation_type();
 
 			if (!operation_type)
 			{
@@ -613,7 +611,7 @@ void odata_codegen_initializer::initialize_property_info_of_class(const std::sha
 
 			property_info function_property_info;
 
-			function_property_info._edm_name = operation_type->get_name(); 
+			function_property_info._edm_name = operation_type->get_name();
 			function_property_info._class_member_name = operation_type->get_name();
 			set_operation_info(function_property_info, operation_type, _schema_info);
 
@@ -622,25 +620,24 @@ void odata_codegen_initializer::initialize_property_info_of_class(const std::sha
 
 		_schema_info.m_class_property_map[entity_container->get_name()] = class_property_map;
 	}
-
 }
 
-void odata_codegen_initializer::set_operation_info(property_info& _info, const std::shared_ptr<::odata::edm::edm_operation_type>& operation_type, schema_info& _schema_info)
+void odata_codegen_initializer::set_operation_info(property_info& _info, const std::shared_ptr<edm_operation_type>& operation_type, schema_info& _schema_info)
 {
 	if (!operation_type)
 	{
-		return ;
+		return;
 	}
 
 	_info._type = operation_type->is_function() ? PROPERTY_TYPE::E_FUNCTION : PROPERTY_TYPE::E_ACTION;
 
-	auto _operation_info = std::make_shared<operation_info>();
+	auto _operation_info = ::odata::make_shared<operation_info>();
 
-	auto ret_type = operation_type->get_operation_return_type();
+	auto &ret_type = operation_type->get_operation_return_type();
 	if (!ret_type)
 	{
-		_operation_info->_return_type = U("void");
-		_operation_info->_executor_name = U("odata_void_query_executor");
+		_operation_info->_return_type = _XPLATSTR("void");
+		_operation_info->_executor_name = _XPLATSTR("odata_void_query_executor");
 	}
 	else
 	{
@@ -649,7 +646,7 @@ void odata_codegen_initializer::set_operation_info(property_info& _info, const s
 			auto element_type = std::dynamic_pointer_cast<edm_collection_type>(ret_type)->get_element_type();
 			if (!element_type)
 			{
-				return ;
+				return;
 			}
 
 			_operation_info->_return_type = element_type->get_name();
@@ -697,7 +694,7 @@ void odata_codegen_initializer::set_operation_info(property_info& _info, const s
 	}
 
 	bool first = true;
-	for (auto param_iter = operation_type->get_operation_parameters().cbegin(); param_iter != operation_type->get_operation_parameters().cend(); param_iter++)
+	for (auto param_iter = operation_type->get_operation_parameters().cbegin(); param_iter != operation_type->get_operation_parameters().cend(); ++param_iter)
 	{
 		if (first && operation_type->is_bound())
 		{
@@ -707,7 +704,7 @@ void odata_codegen_initializer::set_operation_info(property_info& _info, const s
 
 		operation_param param;
 
-		auto param_type = (*param_iter)->get_param_type();
+		auto &param_type = (*param_iter)->get_param_type();
 
 		if (!param_type)
 		{
@@ -732,9 +729,9 @@ void odata_codegen_initializer::set_operation_info(property_info& _info, const s
 			param._member_strong_type_name = _schema_info.m_class_map[param_type->get_name()]._class_name;
 		}
 		else if (param_type->get_type_kind() == edm_type_kind_t::Collection)
-		{		
-            auto collection_type = std::dynamic_pointer_cast<edm_collection_type>(param_type);
-			auto element_type = collection_type->get_element_type();
+		{
+			auto collection_type = std::dynamic_pointer_cast<edm_collection_type>(param_type);
+			auto &element_type = collection_type->get_element_type();
 
 			if (element_type->get_type_kind() == edm_type_kind_t::Complex)
 			{
@@ -749,75 +746,74 @@ void odata_codegen_initializer::set_operation_info(property_info& _info, const s
 				param._member_strong_type_name = _schema_info.m_class_map[element_type->get_name()]._class_name;
 			}
 
-			param._member_strong_type_name = U("std::vector<") + param._member_strong_type_name;
-			param._member_strong_type_name += U(">");
+			param._member_strong_type_name = _XPLATSTR("std::vector<") + param._member_strong_type_name;
+			param._member_strong_type_name += _XPLATSTR(">");
 		}
 
 		param._member_name = (*param_iter)->get_param_name();
 
-		_operation_info->vec_params.push_back(param);
+		_operation_info->vec_params.emplace_back(param);
 	}
-			
+
 	_info._operation_info = _operation_info;
 }
 
-::utility::string_t odata_codegen_initializer::get_executor_name_from_edm_type(const std::shared_ptr<::odata::edm::edm_named_type>& type)
+::odata::string_t odata_codegen_initializer::get_executor_name_from_edm_type(const std::shared_ptr<edm_named_type>& type)
 {
-	::utility::string_t ret;
+	::odata::string_t ret;
 
 	if (type)
 	{
 		if (type->get_type_kind() == edm_type_kind_t::Entity)
 		{
-			ret = U("odata_entityset_query_executor");
+			ret = _XPLATSTR("odata_entityset_query_executor");
 		}
 		else if (type->get_type_kind() == edm_type_kind_t::Complex)
 		{
-			ret = U("odata_complex_query_executor");
+			ret = _XPLATSTR("odata_complex_query_executor");
 		}
 		else if (type->get_type_kind() == edm_type_kind_t::Enum)
 		{
-			ret = U("odata_enum_query_executor");
+			ret = _XPLATSTR("odata_enum_query_executor");
 		}
 		else if (type->get_type_kind() == edm_type_kind_t::Primitive)
 		{
-			ret = U("odata_primitive_query_executor");
+			ret = _XPLATSTR("odata_primitive_query_executor");
 		}
 	}
 
 	return ret;
 }
 
-void odata_codegen_initializer::set_default_value(property_info& _property_info, const std::shared_ptr<::odata::edm::edm_property_type>& property_type)
+void odata_codegen_initializer::set_default_value(property_info& _property_info, const std::shared_ptr<edm_property_type>& property_type)
 {
 	if (!property_type)
 	{
-		return ;
+		return;
 	}
 
 	if (!_property_info._default_value.empty())
 	{
-		return ;
+		return;
 	}
 
 	if (property_type->get_property_type()->get_type_kind() == edm_type_kind_t::Primitive)
 	{
 		if (_property_info._is_nullable == true)
-	    {
-			_property_info._default_value = U("nullptr");
-	    }
+		{
+			_property_info._default_value = _XPLATSTR("nullptr");
+		}
 		else
 		{
-			_property_info._default_value 
-				= edm_model_utility::get_strong_type_default_value_from_edm_type_name(std::dynamic_pointer_cast<edm_primitive_type>(property_type->get_property_type()));
+			_property_info._default_value = edm_model_utility::get_strong_type_default_value_from_edm_type_name(std::dynamic_pointer_cast<edm_primitive_type>(property_type->get_property_type()));
 		}
 	}
 	else if (property_type->get_property_type()->get_type_kind() == edm_type_kind_t::Complex)
 	{
 		if (_property_info._is_nullable == true)
-	    {
-			_property_info._default_value = U("nullptr");
-	    }
+		{
+			_property_info._default_value = _XPLATSTR("nullptr");
+		}
 	}
 	else if (property_type->get_property_type()->get_type_kind() == edm_type_kind_t::Navigation)
 	{
@@ -825,16 +821,16 @@ void odata_codegen_initializer::set_default_value(property_info& _property_info,
 		{
 			if (_property_info._is_nullable == true)
 			{
-				_property_info._default_value = U("nullptr");
+				_property_info._default_value = _XPLATSTR("nullptr");
 			}
 		}
 	}
 	else if (property_type->get_property_type()->get_type_kind() == edm_type_kind_t::Enum)
 	{
 		if (_property_info._is_nullable == true)
-	    {
-			_property_info._default_value = U("nullptr");
-	    }
+		{
+			_property_info._default_value = _XPLATSTR("nullptr");
+		}
 	}
 }
 
@@ -842,18 +838,18 @@ void odata_codegen_initializer::set_strong_type_name(property_info& _property_in
 {
 	_property_info._class_member_type = _property_info._strong_type_name;
 
-	if (_property_info._type == PROPERTY_TYPE::E_COLLECTION_PRIMITIVE 
+	if (_property_info._type == PROPERTY_TYPE::E_COLLECTION_PRIMITIVE
 		|| _property_info._type == PROPERTY_TYPE::E_COLLECTION_COMPLEX
 		|| _property_info._type == PROPERTY_TYPE::E_COLLECTION_ENTITY
 		|| _property_info._type == PROPERTY_TYPE::E_COLLECTION_ENUM)
 	{
-		_property_info._class_member_type = U("std::vector<") + _property_info._strong_type_name + U(">");
+		_property_info._class_member_type = _XPLATSTR("std::vector<") + _property_info._strong_type_name + _XPLATSTR(">");
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_ENTITY || _property_info._type == PROPERTY_TYPE::E_COMPLEX)
 	{
 		if (_property_info._is_nullable == true)
 		{
-			_property_info._class_member_type = U("std::shared_ptr<") + _property_info._strong_type_name + U(">");
+			_property_info._class_member_type = _XPLATSTR("std::shared_ptr<") + _property_info._strong_type_name + _XPLATSTR(">");
 		}
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_PRIMITIVE || _property_info._type == PROPERTY_TYPE::E_ENUM)

--- a/tools/codegentool/odata_codegen_initializer.h
+++ b/tools/codegentool/odata_codegen_initializer.h
@@ -16,7 +16,7 @@ namespace odata { namespace codegen { namespace tools {
 enum PROPERTY_TYPE
 {
 	E_PRIMITIVE = 0,
-    E_COMPLEX,
+	E_COMPLEX,
 	E_ENTITY,
 	E_ENUM,
 	E_COLLECTION_PRIMITIVE,
@@ -43,11 +43,11 @@ enum CLASS_TYPE
 
 struct class_info
 {
-	::utility::string_t _edm_name;
-	::utility::string_t _edm_namespace;
-	::utility::string_t _class_name;
-	::utility::string_t _base_class_name;
-	CLASS_TYPE          _type;
+	::odata::string_t _edm_name;
+	::odata::string_t _edm_namespace;
+	::odata::string_t _class_name;
+	::odata::string_t _base_class_name;
+	CLASS_TYPE        _type;
 
 	class_info()
 	{
@@ -57,33 +57,33 @@ struct class_info
 
 struct operation_param
 {
-	::utility::string_t _edm_name;
-	::utility::string_t _member_name;
-	::utility::string_t _member_type;
-	::utility::string_t _member_strong_type_name;
+	::odata::string_t _edm_name;
+	::odata::string_t _member_name;
+	::odata::string_t _member_type;
+	::odata::string_t _member_strong_type_name;
 };
 
 struct operation_info
 {
 	std::vector<operation_param> vec_params;
-    ::utility::string_t _return_type;
-	::utility::string_t _executor_name;
+	::odata::string_t _return_type;
+	::odata::string_t _executor_name;
 };
 
 struct property_info
 {
-	::utility::string_t _edm_name;
+	::odata::string_t _edm_name;
 	::utility::string_t _class_member_name;
 	// int* or vector<int>
-	::utility::string_t _class_member_type;
+	::odata::string_t _class_member_type;
 	// int or single entity type name
-	::utility::string_t _strong_type_name;
-	PROPERTY_TYPE       _type;
-	::utility::string_t _default_value;
-	bool                _is_nullable;
-	bool                _is_key;
+	::odata::string_t _strong_type_name;
+	PROPERTY_TYPE     _type;
+	::odata::string_t _default_value;
+	bool              _is_nullable;
+	bool              _is_key;
 
-	std::shared_ptr<operation_info>  _operation_info;   // used for action / function
+	std::shared_ptr<operation_info> _operation_info; // used for action / function
 
 	property_info()
 	{
@@ -97,8 +97,8 @@ struct property_info
 
 struct code_gen_configuration
 {
-	::utility::string_t _namespace;
-	::utility::string_t _file_name;
+	::odata::string_t _namespace;
+	::odata::string_t _file_name;
 
 	code_gen_configuration()
 	{
@@ -106,12 +106,12 @@ struct code_gen_configuration
 };
 
 // key is property name
-typedef std::unordered_map<::utility::string_t, property_info>  class_property_info;
+typedef std::unordered_map<::odata::string_t, property_info>  class_property_info;
 // key is enity complex enum type name
-typedef std::unordered_map<::utility::string_t, class_property_info>  class_property_map;  // class member infomation
+typedef std::unordered_map<::odata::string_t, class_property_info>  class_property_map;  // class member infomation
 // key is enity complex enum type name
-typedef std::unordered_map<::utility::string_t, class_info>  class_map;   // class infomation
-typedef std::unordered_map<::utility::string_t, std::vector<::utility::string_t>> derived_class_map;
+typedef std::unordered_map<::odata::string_t, class_info>  class_map;   // class infomation
+typedef std::unordered_map<::odata::string_t, std::vector<::odata::string_t>> derived_class_map;
 
 struct schema_info  // one model may contain several schemas (namespaces)
 {
@@ -130,13 +130,13 @@ struct schema_info  // one model may contain several schemas (namespaces)
 };
 
 // key is namespace name
-typedef std::unordered_map<::utility::string_t, schema_info> code_gen_map;
+typedef std::unordered_map<::odata::string_t, schema_info> code_gen_map;
 
 class odata_codegen_initializer
 {
 public:
-	::pplx::task<int> initialize_from_metadata_file(const ::utility::string_t metadata_file, const ::utility::string_t output_file_name);
-	::pplx::task<int> initialize_from_service_metadata(const ::utility::string_t metadata_url, const ::utility::string_t output_file_name, const ::utility::string_t user_name = U(""), const ::utility::string_t  password = U(""));
+	::pplx::task<int> initialize_from_metadata_file(const ::odata::string_t metadata_file, const ::odata::string_t output_file_name);
+	::pplx::task<int> initialize_from_service_metadata(const ::odata::string_t metadata_url, const ::odata::string_t output_file_name, const ::odata::string_t user_name = _XPLATSTR(""), const ::odata::string_t  password = _XPLATSTR(""));
 	::pplx::task<int> begin_initialize_code_gen_info(::std::shared_ptr<::odata::edm::edm_model> model);
 
 	const code_gen_configuration& get_config() const
@@ -153,7 +153,7 @@ public:
 	{
 		return m_code_gen_map;
 	}
-	
+
 private:
 	void reset_class_info();
 	void initialize_class_info(const std::shared_ptr<::odata::edm::edm_schema>& schema, schema_info& _schema_info);
@@ -162,7 +162,7 @@ private:
 	void set_default_value(property_info& _property_info, const std::shared_ptr<::odata::edm::edm_property_type>& property_type);
 	void set_strong_type_name(property_info& _property_info);
 
-	::utility::string_t get_executor_name_from_edm_type(const std::shared_ptr<::odata::edm::edm_named_type>& type);
+	::odata::string_t get_executor_name_from_edm_type(const std::shared_ptr<::odata::edm::edm_named_type>& type);
 	void set_operation_info(property_info& operation_info, const std::shared_ptr<::odata::edm::edm_operation_type>& operation_type, schema_info& _schema_info);
 private:
 	friend class odata_codegen_writer;
@@ -171,6 +171,5 @@ private:
 	code_gen_configuration                   m_config;
 	code_gen_map                             m_code_gen_map;
 };
-
 
 }}}

--- a/tools/codegentool/odata_codegen_tools.cpp
+++ b/tools/codegentool/odata_codegen_tools.cpp
@@ -35,7 +35,6 @@ void print_help()
 		<< "[Example] - " << ::std::endl
 		<< "    " << "odata_codegen_tools.exe -f \"c:\\files\\test.xml\" -o \"test\""  << ::std::endl
 		<< "    " << "odata_codegen_tools.exe -m \"http://service/odata\" -o \"newfile\" [-u \"abc\" -p \"ppp\"]" << ::std::endl << ::std::endl;
-		
 };
 
 #ifdef WIN32
@@ -44,24 +43,24 @@ int _tmain(int argc, ::utility::char_t* argv[])
 int main(int argc, ::utility::char_t* argv[])
 #endif
 {
-	::utility::string_t metadata_url;
-	::utility::string_t metadata_file;
-	::utility::string_t output_file_name;
-	::utility::string_t user_name;
-	::utility::string_t password;
+	::odata::string_t metadata_url;
+	::odata::string_t metadata_file;
+	::odata::string_t output_file_name;
+	::odata::string_t user_name;
+	::odata::string_t password;
 
 	bool argument_error = false;
 	if (argc < 3)
 	{
 		argument_error = true;
 	}
-	else 
+	else
 	{
-		for (int i = 1; i < argc; i++)
+		for (int i = 1; i < argc; ++i)
 		{
-			::utility::string_t option = argv[i];
+			::odata::string_t option = argv[i];
 
-			if (option == U("-f") || option == U("-m") || option == U("-o") || option == U("-u") || option == U("-p"))
+			if (option == _XPLATSTR("-f") || option == _XPLATSTR("-m") || option == _XPLATSTR("-o") || option == _XPLATSTR("-u") || option == _XPLATSTR("-p"))
 			{
 				if (++i >= argc)
 				{
@@ -69,23 +68,23 @@ int main(int argc, ::utility::char_t* argv[])
 					break;
 				}
 
-				if (option == U("-f"))
+				if (option == _XPLATSTR("-f"))
 				{
 					metadata_file = argv[i];
 				}
-				else if (option == U("-m"))
+				else if (option == _XPLATSTR("-m"))
 				{
 					metadata_url = argv[i];
 				}
-				else if (option == U("-o"))
+				else if (option == _XPLATSTR("-o"))
 				{
 					output_file_name = argv[i];
 				}
-				else if (option == U("-u"))
+				else if (option == _XPLATSTR("-u"))
 				{
 					user_name = argv[i];
 				}
-				else if (option == U("-p"))
+				else if (option == _XPLATSTR("-p"))
 				{
 					password = argv[i];
 				}
@@ -112,26 +111,26 @@ int main(int argc, ::utility::char_t* argv[])
 
 	try
 	{
-		auto initializer = std::make_shared<odata_codegen_initializer>();
+		auto initializer = ::odata::make_shared<odata_codegen_initializer>();
 		if (!metadata_file.empty())
 		{
 			initializer->initialize_from_metadata_file(metadata_file, output_file_name).then(
-			   [initializer] (int) -> int
-			   {
-				   auto writer = std::make_shared<odata_codegen_writer>(initializer);
-				   return writer->begin_generate_file().wait();
-			   }).wait();;
+				[initializer] (int) -> int
+				{
+					auto writer = ::odata::make_shared<odata_codegen_writer>(initializer);
+					return writer->begin_generate_file().wait();
+				}).wait();
 		}
 		else if (!metadata_url.empty())
 		{
 			initializer->initialize_from_service_metadata(metadata_url, output_file_name, user_name, password).then(
-			   [initializer] (int) -> int
-			   {
-				   auto writer = std::make_shared<odata_codegen_writer>(initializer);
-				   return writer->begin_generate_file().wait();
-			   }).wait();
+				[initializer] (int) -> int
+				{
+					auto writer = ::odata::make_shared<odata_codegen_writer>(initializer);
+					return writer->begin_generate_file().wait();
+				}).wait();
 		}
-			
+
 	}
 	catch (const ::std::exception &e)
 	{
@@ -144,4 +143,3 @@ int main(int argc, ::utility::char_t* argv[])
 
 	return 0;
 }
-

--- a/tools/codegentool/odata_codegen_writer.cpp
+++ b/tools/codegentool/odata_codegen_writer.cpp
@@ -9,15 +9,18 @@
 #include "odata/edm/edm_model_utility.h"
 #include <regex>
 
-#define INDENT U("    ")
+#define INDENT _XPLATSTR("    ")
+#ifndef CLASS_NAME_PREFIX
+	#define CLASS_NAME_PREFIX _XPLATSTR("EDM_")
+#endif
 
 namespace odata { namespace codegen { namespace tools {
 
-static ::utility::string_t normalize_namespace(const ::utility::string_t& _namespace)
+static ::odata::string_t normalize_namespace(const ::odata::string_t& _namespace)
 {
 	::utility::string_t ret = _namespace;
 
-	std::replace(ret.begin(), ret.end(), U('.'), U('_'));
+	std::replace(ret.begin(), ret.end(), _XPLATSTR('.'), _XPLATSTR('_'));
 
 	return ret;
 }
@@ -29,32 +32,32 @@ static ::utility::string_t normalize_namespace(const ::utility::string_t& _names
 		return ::pplx::task_from_result(0);
 	}
 
-	::utility::ofstream_t ofs_header(m_initializer->get_config()._file_name + U(".h"));
-	::utility::ofstream_t ofs_cpp(m_initializer->get_config()._file_name + U(".cpp"));
+	::utility::ofstream_t ofs_header(m_initializer->get_config()._file_name + _XPLATSTR(".h"));
+	::utility::ofstream_t ofs_cpp(m_initializer->get_config()._file_name + _XPLATSTR(".cpp"));
 
 	generate_declare_include_files(ofs_header);
 	generate_implement_include_files(ofs_cpp);
 
-	for (auto schema_iter = m_initializer->m_code_gen_map.begin(); schema_iter != m_initializer->m_code_gen_map.end(); schema_iter++)
+	for (auto schema_iter = m_initializer->m_code_gen_map.begin(); schema_iter != m_initializer->m_code_gen_map.end(); ++schema_iter)
 	{
 		generate_declare_namespace_begin(ofs_header, normalize_namespace(schema_iter->first));
-	    generate_implement_namespace_begin(ofs_cpp, normalize_namespace(schema_iter->first));
+		generate_implement_namespace_begin(ofs_cpp, normalize_namespace(schema_iter->first));
 
 		generate_declare_class(ofs_header, schema_iter->second);
 
 		generate_enum_types(ofs_header, ofs_cpp, schema_iter->second);
-	    generate_complex_types(ofs_header, ofs_cpp, schema_iter->second);
-	    generate_entity_types(ofs_header, ofs_cpp, schema_iter->second);
+		generate_complex_types(ofs_header, ofs_cpp, schema_iter->second);
+		generate_entity_types(ofs_header, ofs_cpp, schema_iter->second);
 
 		// generate entity container in h file
 		generate_entity_container(ofs_header, ofs_cpp, schema_iter->second);
 
 		// generate derived creator in cpp
 		generate_derived_creator(ofs_cpp, schema_iter->second);
-        
-        generate_declare_include_files_end(ofs_header);
-	    generate_declare_namespace_end(ofs_header);
-	    generate_implement_namespace_end(ofs_cpp);
+
+		generate_declare_include_files_end(ofs_header);
+		generate_declare_namespace_end(ofs_header);
+		generate_implement_namespace_end(ofs_cpp);
 	}
 
 	ofs_header.close();
@@ -65,55 +68,55 @@ static ::utility::string_t normalize_namespace(const ::utility::string_t& _names
 
 void odata_codegen_writer::generate_declare_include_files(::utility::ofstream_t& out)
 {
-	output_line_content(out, U("#pragma once"));
-	output_line_content(out, U("#include \"odata/codegen/code_generation.h\""));
-	output_line_content(out, U("#include \"odata/codegen/odata_service_context.h\""));
-	output_line_content(out, U("#include \"odata/codegen/odata_service_query.h\""));
-	output_line_content(out, U("#include \"odata/codegen/odata_entityset_query_executor.h\""));
-	output_line_content(out, U("#include \"odata/codegen/odata_singleton_query_executor.h\""));
-	output_line_content(out, U("#include \"odata/codegen/odata_primitive_query_executor.h\""));
-	output_line_content(out, U("#include \"odata/codegen/odata_primitive_query_executor.h\""));
-	output_line_content(out, U("#include \"odata/codegen/odata_complex_query_executor.h\""));
-	output_line_content(out, U("#include \"odata/codegen/odata_enum_query_executor.h\""));
-	output_line_content(out, U("#include \"odata/codegen/odata_void_query_executor.h\""));
-	output_line_content(out, U("#include \"odata/codegen/odata_query_builder.h\""));
-	output_line_content(out, U("#include \"cpprest/json.h\""));
+	output_line_content(out, _XPLATSTR("#pragma once"));
+	output_line_content(out, _XPLATSTR("#include \"odata/codegen/code_generation.h\""));
+	output_line_content(out, _XPLATSTR("#include \"odata/codegen/odata_service_context.h\""));
+	output_line_content(out, _XPLATSTR("#include \"odata/codegen/odata_service_query.h\""));
+	output_line_content(out, _XPLATSTR("#include \"odata/codegen/odata_entityset_query_executor.h\""));
+	output_line_content(out, _XPLATSTR("#include \"odata/codegen/odata_singleton_query_executor.h\""));
+	output_line_content(out, _XPLATSTR("#include \"odata/codegen/odata_primitive_query_executor.h\""));
+	output_line_content(out, _XPLATSTR("#include \"odata/codegen/odata_primitive_query_executor.h\""));
+	output_line_content(out, _XPLATSTR("#include \"odata/codegen/odata_complex_query_executor.h\""));
+	output_line_content(out, _XPLATSTR("#include \"odata/codegen/odata_enum_query_executor.h\""));
+	output_line_content(out, _XPLATSTR("#include \"odata/codegen/odata_void_query_executor.h\""));
+	output_line_content(out, _XPLATSTR("#include \"odata/codegen/odata_query_builder.h\""));
+	output_line_content(out, _XPLATSTR("#include \"cpprest/json.h\""));
 	output_empty_line(out, 1);
-	output_line_content(out, U("using namespace std;"));
-	output_line_content(out, U("using namespace ::odata::client;"));
-	output_line_content(out, U("using namespace ::odata::core;"));
-	output_line_content(out, U("using namespace ::odata::edm;"));
-	output_line_content(out, U("using namespace ::odata::codegen;"));
+	output_line_content(out, _XPLATSTR("using namespace std;"));
+	output_line_content(out, _XPLATSTR("using namespace ::odata::client;"));
+	output_line_content(out, _XPLATSTR("using namespace ::odata::core;"));
+	output_line_content(out, _XPLATSTR("using namespace ::odata::edm;"));
+	output_line_content(out, _XPLATSTR("using namespace ::odata::codegen;"));
 	output_empty_line(out, 1);
 }
 
 void odata_codegen_writer::generate_implement_include_files(::utility::ofstream_t& out)
 {
-	out << U("#include \"") << m_initializer->get_config()._file_name  << U(".h\"") << std::endl;
+	out << _XPLATSTR("#include \"") << m_initializer->get_config()._file_name  << _XPLATSTR(".h\"") << std::endl;
 	output_empty_line(out, 1);
 }
 
-void odata_codegen_writer::generate_declare_namespace_begin(::utility::ofstream_t& out, const ::utility::string_t& _namespace)
+void odata_codegen_writer::generate_declare_namespace_begin(::utility::ofstream_t& out, const ::odata::string_t& _namespace)
 {
-	output_line_content(out, U("namespace ") + normalize_namespace(_namespace));
-	output_line_content(out, U("{"));
+	output_line_content(out, _XPLATSTR("namespace ") + normalize_namespace(_namespace));
+	output_line_content(out, _XPLATSTR("{"));
 	output_empty_line(out, 1);
 }
 
-void odata_codegen_writer::generate_implement_namespace_begin(::utility::ofstream_t& out, const ::utility::string_t& _namespace)
+void odata_codegen_writer::generate_implement_namespace_begin(::utility::ofstream_t& out, const ::odata::string_t& _namespace)
 {
 	generate_declare_namespace_begin(out, _namespace);
 }
-    
+
 void odata_codegen_writer::generate_declare_include_files_end(::utility::ofstream_t& out)
 {
-    output_line_content(out, U("#include \"odata/codegen/odata_function_param_formatter.h\""));
-    output_empty_line(out, 1);
+	output_line_content(out, _XPLATSTR("#include \"odata/codegen/odata_function_param_formatter.h\""));
+	output_empty_line(out, 1);
 }
 
 void odata_codegen_writer::generate_declare_namespace_end(::utility::ofstream_t& out)
 {
-	output_line_content(out, U("}"));
+	output_line_content(out, _XPLATSTR("}"));
 }
 
 void odata_codegen_writer::generate_implement_namespace_end(::utility::ofstream_t& out)
@@ -125,7 +128,7 @@ void odata_codegen_writer::generate_implement_namespace_end(::utility::ofstream_
 // class YYY;
 void odata_codegen_writer::generate_declare_class(::utility::ofstream_t& o_header, schema_info& _schema_info)
 {
-	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); class_iter++)
+	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); ++class_iter)
 	{
 		auto _class_info = *class_iter;
 
@@ -134,12 +137,12 @@ void odata_codegen_writer::generate_declare_class(::utility::ofstream_t& o_heade
 			continue;
 		}
 
-		o_header << U("class ") << _class_info._class_name << U(";") << std::endl;
+		o_header << _XPLATSTR("class ") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(";") << std::endl;
 	}
 
 	output_empty_line(o_header, 1);
 
-	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); class_iter++)
+	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); ++class_iter)
 	{
 		auto _class_info = *class_iter;
 
@@ -148,7 +151,7 @@ void odata_codegen_writer::generate_declare_class(::utility::ofstream_t& o_heade
 			continue;
 		}
 
-		o_header << U("class ") << _class_info._class_name << U(";") << std::endl;
+		o_header << _XPLATSTR("class ") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(";") << std::endl;
 	}
 
 	output_empty_line(o_header, 1);
@@ -156,7 +159,7 @@ void odata_codegen_writer::generate_declare_class(::utility::ofstream_t& o_heade
 
 void odata_codegen_writer::generate_enum_types(::utility::ofstream_t& o_header, ::utility::ofstream_t& o_cpp, schema_info& _schema_info)
 {
-	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); class_iter++)
+	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); ++class_iter)
 	{
 		auto _class_info = *class_iter;
 
@@ -170,7 +173,7 @@ void odata_codegen_writer::generate_enum_types(::utility::ofstream_t& o_header, 
 
 		auto class_property_map = (_schema_info.m_class_property_map)[_class_info._class_name];
 
-		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); property_iter++)
+		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); ++property_iter)
 		{
 			auto _property_info = property_iter->second;
 
@@ -180,8 +183,8 @@ void odata_codegen_writer::generate_enum_types(::utility::ofstream_t& o_header, 
 		generate_declare_enum_end(o_header);
 
 		// generate .cpp
-        generate_implement_enum_type_to_string_begin(o_cpp, _class_info);
-		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); property_iter++)
+		generate_implement_enum_type_to_string_begin(o_cpp, _class_info);
+		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); ++property_iter)
 		{
 			auto _property_info = property_iter->second;
 
@@ -190,7 +193,7 @@ void odata_codegen_writer::generate_enum_types(::utility::ofstream_t& o_header, 
 		generate_implement_enum_type_to_string_end(o_cpp, _class_info);
 
 		generate_implement_string_to_enum_type_begin(o_cpp, _class_info);
-		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); property_iter++)
+		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); ++property_iter)
 		{
 			auto _property_info = property_iter->second;
 
@@ -200,23 +203,23 @@ void odata_codegen_writer::generate_enum_types(::utility::ofstream_t& o_header, 
 	}
 
 	generate_declare_enum_resolver_begin(o_header);
-	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); class_iter++)
+	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); ++class_iter)
 	{
 		auto _class_info = *class_iter;
 
 		if (_class_info._type != CLASS_TYPE::E_CLASS_ENUM)
 		{
 			continue;
-		}   
+		}
 
-	    generate_declare_enum_resolver_on(o_header, _class_info);   
+		generate_declare_enum_resolver_on(o_header, _class_info);
 	}
 	generate_declare_enum_resolver_end(o_header);
 }
 
 void odata_codegen_writer::generate_complex_types(::utility::ofstream_t& o_header, ::utility::ofstream_t& o_cpp, schema_info& _schema_info)
 {
-	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); class_iter++)
+	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); ++class_iter)
 	{
 		auto class_info = *class_iter;
 
@@ -233,7 +236,7 @@ void odata_codegen_writer::generate_complex_types(::utility::ofstream_t& o_heade
 		auto class_property_map = _schema_info.m_class_property_map[class_info._class_name];
 
 		// generate class member
-		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); property_iter++)
+		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); ++property_iter)
 		{
 			generate_declare_class_member_in_complex(o_header, property_iter->second);
 		}
@@ -243,7 +246,7 @@ void odata_codegen_writer::generate_complex_types(::utility::ofstream_t& o_heade
 
 		// generate .cpp
 		generate_implement_begin_constructor_in_complex(o_cpp, class_info);
-		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); property_iter++)
+		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); ++property_iter)
 		{
 			auto _property_info = property_iter->second;
 			if (!_property_info._default_value.empty())
@@ -254,10 +257,10 @@ void odata_codegen_writer::generate_complex_types(::utility::ofstream_t& o_heade
 		generate_implement_end_constructor_in_complex(o_cpp, class_info);
 
 		generate_implement_begin_destructor_in_complex(o_cpp, class_info);
-	    for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); property_iter++)
+		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); ++property_iter)
 		{
 			auto _property_info = property_iter->second;
-			if (_property_info._is_nullable && (_property_info._type == PROPERTY_TYPE::E_PRIMITIVE 
+			if (_property_info._is_nullable && (_property_info._type == PROPERTY_TYPE::E_PRIMITIVE
 				|| _property_info._type == PROPERTY_TYPE::E_ENUM || _property_info._type == PROPERTY_TYPE::E_COMPLEX))
 			{
 				generate_implement_on_destructor_in_complex(o_cpp, _property_info);
@@ -265,7 +268,7 @@ void odata_codegen_writer::generate_complex_types(::utility::ofstream_t& o_heade
 		}
 		generate_implement_end_destructor_in_complex(o_cpp, class_info);
 
-		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); property_iter++)
+		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); ++property_iter)
 		{
 			generate_implement_class_member_in_complex(o_cpp, class_info, property_iter->second);
 		}
@@ -274,7 +277,7 @@ void odata_codegen_writer::generate_complex_types(::utility::ofstream_t& o_heade
 
 		generate_implement_begin_materialize_in_complex(o_cpp, class_info);
 
-		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); property_iter++)
+		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); ++property_iter)
 		{
 			generate_implement_on_materialize_in_complex(o_cpp, class_info, property_iter->second);
 		}
@@ -283,18 +286,18 @@ void odata_codegen_writer::generate_complex_types(::utility::ofstream_t& o_heade
 
 		generate_implement_begin_serialize_in_complex(o_cpp, class_info);
 
-		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); property_iter++)
+		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); ++property_iter)
 		{
 			generate_implement_on_serialize_in_complex(o_cpp, class_info, property_iter->second);
 		}
 
 		generate_implement_end_serialize_in_complex(o_cpp, class_info);
-	}	
+	}
 }
 
 void odata_codegen_writer::generate_entity_types(::utility::ofstream_t& o_header, ::utility::ofstream_t& o_cpp, schema_info& _schema_info)
 {
-	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); class_iter++)
+	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); ++class_iter)
 	{
 		auto class_info = *class_iter;
 
@@ -311,12 +314,13 @@ void odata_codegen_writer::generate_entity_types(::utility::ofstream_t& o_header
 		auto class_property_map = _schema_info.m_class_property_map[class_info._class_name];
 
 		std::vector<property_info> keys;
+		keys.reserve(std::count_if(class_property_map.cbegin(), class_property_map.cend(), [](auto property){ return property.second._is_key; }));
 		// generate class member
-		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); property_iter++)
+		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); ++property_iter)
 		{
 			if (property_iter->second._is_key)
 			{
-				keys.push_back(property_iter->second);
+				keys.emplace_back(property_iter->second);
 			}
 
 			generate_declare_class_member_in_entity(o_header, class_info, property_iter->second);
@@ -330,7 +334,7 @@ void odata_codegen_writer::generate_entity_types(::utility::ofstream_t& o_header
 
 		// generate .cpp
 		generate_implement_begin_constructor_in_entity(o_cpp, class_info);
-		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); property_iter++)
+		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); ++property_iter)
 		{
 			auto _property_info = property_iter->second;
 			if (!_property_info._default_value.empty())
@@ -341,10 +345,10 @@ void odata_codegen_writer::generate_entity_types(::utility::ofstream_t& o_header
 		generate_implement_end_constructor_in_entity(o_cpp, class_info);
 
 		generate_implement_begin_destructor_in_entity(o_cpp, class_info);
-	    for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); property_iter++)
+		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); ++property_iter)
 		{
 			auto _property_info = property_iter->second;
-			if (_property_info._is_nullable && (_property_info._type == PROPERTY_TYPE::E_PRIMITIVE 
+			if (_property_info._is_nullable && (_property_info._type == PROPERTY_TYPE::E_PRIMITIVE
 				|| _property_info._type == PROPERTY_TYPE::E_ENUM || _property_info._type == PROPERTY_TYPE::E_COMPLEX))
 			{
 				generate_implement_on_destructor_in_entity(o_cpp, _property_info);
@@ -352,7 +356,7 @@ void odata_codegen_writer::generate_entity_types(::utility::ofstream_t& o_header
 		}
 		generate_implement_end_destructor_in_entity(o_cpp, class_info);
 
-		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); property_iter++)
+		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); ++property_iter)
 		{
 			generate_implement_class_member_in_entity(o_cpp, class_info, property_iter->second);
 		}
@@ -361,7 +365,7 @@ void odata_codegen_writer::generate_entity_types(::utility::ofstream_t& o_header
 
 		generate_implement_begin_materialize_in_entity(o_cpp, class_info);
 
-		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); property_iter++)
+		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); ++property_iter)
 		{
 			generate_implement_on_materialize_in_entity(o_cpp, class_info, property_iter->second);
 		}
@@ -370,54 +374,54 @@ void odata_codegen_writer::generate_entity_types(::utility::ofstream_t& o_header
 
 		generate_implement_begin_serialize_in_entity(o_cpp, class_info);
 
-		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); property_iter++)
+		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); ++property_iter)
 		{
 			generate_implement_on_serialize_in_entity(o_cpp, class_info, property_iter->second);
 		}
 
 		generate_implement_end_serialize_in_entity(o_cpp, class_info);
-	}	
+	}
 }
 
 
 //class InMemoryEntities : public odata_service_context
 //{
 //public:
-//	InMemoryEntities(const ::utility::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)
+//	InMemoryEntities(const ::odata::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)
 //	{
 //	}
 void odata_codegen_writer::generate_entity_container_begin(::utility::ofstream_t& o_header, const class_info& _class_info)
 {
-	o_header << U("class ") << _class_info._class_name << U(" : public odata_service_context") << std::endl;
-	o_header << U("{") << std::endl;
-	o_header << U("public:") << std::endl;
-	o_header << INDENT <<  _class_info._class_name << U("(const ::utility::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)") << std::endl;
-	o_header << INDENT << U("{") << std::endl;
-	o_header << INDENT << U("}") << std::endl << std::endl;
+	o_header << _XPLATSTR("class ") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(" : public odata_service_context") << std::endl;
+	o_header << _XPLATSTR("{") << std::endl;
+	o_header << _XPLATSTR("public:") << std::endl;
+	o_header << INDENT << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR("(const ::odata::string_t& baseAddress, client_options options = client_options()) : odata_service_context(baseAddress, options)") << std::endl;
+	o_header << INDENT << _XPLATSTR("{") << std::endl;
+	o_header << INDENT << _XPLATSTR("}") << std::endl << std::endl;
 }
 
-	//std::shared_ptr<odata_service_query<odata_entityset_query_executor<Product>, odata_query_builder>> create_products_query() 
-	//{ 
-	//	return create_query<odata_entityset_query_executor<Product>, odata_query_builder>(U("Products"));
+	//std::shared_ptr<odata_service_query<odata_entityset_query_executor<Product>, odata_query_builder>> create_products_query()
+	//{
+	//	return create_query<odata_entityset_query_executor<Product>, odata_query_builder>(_XPLATSTR("Products"));
 	//}
-void odata_codegen_writer::generate_declare_entity_set_in_entity_container(::utility::ofstream_t& out, const class_info& _class_info, const property_info& _property_info)
+void odata_codegen_writer::generate_declare_entity_set_in_entity_container(::utility::ofstream_t& out, const class_info& /*_class_info*/, const property_info& _property_info)
 {
-	out << INDENT << U("std::shared_ptr<odata_service_query<odata_entityset_query_executor<") << _property_info._strong_type_name << U(">, odata_query_builder>> ") << _property_info._class_member_name << std::endl;
-	out << INDENT << U("{") << std::endl;
-	out << INDENT << INDENT << U("return create_query<odata_entityset_query_executor<") << _property_info._strong_type_name << U(">, odata_query_builder>(U(\"") << _property_info._edm_name << U("\"));") << std::endl; 
-	out << INDENT << U("}") << std::endl << std::endl;
+	out << INDENT << _XPLATSTR("std::shared_ptr<odata_service_query<odata_entityset_query_executor<") << _property_info._strong_type_name << _XPLATSTR(">, odata_query_builder>> ") << _property_info._class_member_name << std::endl;
+	out << INDENT << _XPLATSTR("{") << std::endl;
+	out << INDENT << INDENT << _XPLATSTR("return create_query<odata_entityset_query_executor<") << _property_info._strong_type_name << _XPLATSTR(">, odata_query_builder>(_XPLATSTR(\"") << _property_info._edm_name << _XPLATSTR("\"));") << std::endl;
+	out << INDENT << _XPLATSTR("}") << std::endl << std::endl;
 }
 
-	//std::shared_ptr<odata_service_query<odata_singleton_query_executor<Customer>, odata_query_builder>> create_vipcustomer_query() 
-	//{ 
-	//	return create_query<odata_singleton_query_executor<Customer>, odata_query_builder>(U("VipCustomer"));
+	//std::shared_ptr<odata_service_query<odata_singleton_query_executor<Customer>, odata_query_builder>> create_vipcustomer_query()
+	//{
+	//	return create_query<odata_singleton_query_executor<Customer>, odata_query_builder>(_XPLATSTR("VipCustomer"));
 	//}
-void odata_codegen_writer::generate_declare_singleton_in_entity_container(::utility::ofstream_t& out, const class_info& _class_info, const property_info& _property_info)
+void odata_codegen_writer::generate_declare_singleton_in_entity_container(::utility::ofstream_t& out, const class_info& /*_class_info*/, const property_info& _property_info)
 {
-	out << INDENT << U("std::shared_ptr<odata_service_query<odata_singleton_query_executor<") << _property_info._strong_type_name << U(">, odata_query_builder>> ") << _property_info._class_member_name << std::endl;
-	out << INDENT << U("{") << std::endl;
-	out << INDENT << INDENT << U("return create_query<odata_singleton_query_executor<") << _property_info._strong_type_name << U(">, odata_query_builder>(U(\"") << _property_info._edm_name << U("\"));") << std::endl; 
-	out << INDENT << U("}") << std::endl << std::endl;
+	out << INDENT << _XPLATSTR("std::shared_ptr<odata_service_query<odata_singleton_query_executor<") << _property_info._strong_type_name << _XPLATSTR(">, odata_query_builder>> ") << _property_info._class_member_name << std::endl;
+	out << INDENT << _XPLATSTR("{") << std::endl;
+	out << INDENT << INDENT << _XPLATSTR("return create_query<odata_singleton_query_executor<") << _property_info._strong_type_name << _XPLATSTR(">, odata_query_builder>(_XPLATSTR(\"") << _property_info._edm_name << _XPLATSTR("\"));") << std::endl;
+	out << INDENT << _XPLATSTR("}") << std::endl << std::endl;
 }
 
 	//typedef odata_enum_query_executor<Color, enum_type_resolver> enum_GetDefaultColor_excecutor;
@@ -428,46 +432,46 @@ void odata_codegen_writer::generate_declare_operation_imports_in_entity_containe
 
 	if (!_operation_info)
 	{
-		return ;
+		return;
 	}
 
-	::utility::string_t _declare_name;
+	::odata::string_t _declare_name;
 	if (_property_info._type == PROPERTY_TYPE::E_ACTION)
 	{
-		_declare_name = U("DECLARE_ACTION_IMPORT_P");
+		_declare_name = _XPLATSTR("DECLARE_ACTION_IMPORT_P");
 	}
 	else
 	{
-		_declare_name = U("DECLARE_FUNCTION_IMPORT_P");
+		_declare_name = _XPLATSTR("DECLARE_FUNCTION_IMPORT_P");
 	}
 
 	// typedef odata_enum_query_executor<Color, enum_type_resolver> enum_GetDefaultColor_excecutor;
-	if ( _operation_info->_executor_name == U("odata_enum_query_executor"))
+	if ( _operation_info->_executor_name == _XPLATSTR("odata_enum_query_executor"))
 	{
 		// DECLARE_FUNCTION_IMPORT_P0(InMemoryEntities, GetDefaultColor, enum_GetDefaultColor_excecutor);
-		out << INDENT << U("typedef odata_enum_query_executor<") << _operation_info->_return_type << U(", enum_type_resolver> ")
-			<< U("enum_") << _property_info._class_member_name << U("_excecutor;") << std::endl;
+		out << INDENT << _XPLATSTR("typedef odata_enum_query_executor<") << _operation_info->_return_type << _XPLATSTR(", enum_type_resolver> ")
+			<< _XPLATSTR("enum_") << _property_info._class_member_name << _XPLATSTR("_excecutor;") << std::endl;
 
-	    out << INDENT << _declare_name << _operation_info->vec_params.size() << U("(") << _class_info._class_name << U(", ") << _property_info._class_member_name 
-		    << U(", ") << U("enum_") << _property_info._class_member_name << U("_excecutor");
+		out << INDENT << _declare_name << _operation_info->vec_params.size() << _XPLATSTR("(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name
+			<< _XPLATSTR(", ") << _XPLATSTR("enum_") << _property_info._class_member_name << _XPLATSTR("_excecutor");
 	}
-	else if (_operation_info->_executor_name == U("odata_void_query_executor"))
+	else if (_operation_info->_executor_name == _XPLATSTR("odata_void_query_executor"))
 	{
-	    out << INDENT << _declare_name << _operation_info->vec_params.size() << U("(") << _class_info._class_name << U(", ") << _property_info._class_member_name 
-		    << U(", ") << _operation_info->_executor_name;
+		out << INDENT << _declare_name << _operation_info->vec_params.size() << _XPLATSTR("(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name
+			<< _XPLATSTR(", ") << _operation_info->_executor_name;
 	}
 	else
 	{
-	    out << INDENT << _declare_name << _operation_info->vec_params.size() << U("(") << _class_info._class_name << U(", ") << _property_info._class_member_name 
-		    << U(", ") << _operation_info->_executor_name << U("<") << _operation_info->_return_type << U(">");
+		out << INDENT << _declare_name << _operation_info->vec_params.size() << _XPLATSTR("(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name
+			<< _XPLATSTR(", ") << _operation_info->_executor_name << _XPLATSTR("<") << _operation_info->_return_type << _XPLATSTR(">");
 	}
 
-	for (auto param_iter = _operation_info->vec_params.cbegin(); param_iter != _operation_info->vec_params.cend(); param_iter++)
+	for (auto param_iter = _operation_info->vec_params.cbegin(); param_iter != _operation_info->vec_params.cend(); ++param_iter)
 	{
-		out << U(", ") << param_iter->_edm_name << U(", ") << param_iter->_member_strong_type_name << U(", ") <<  param_iter->_member_name;
+		out << _XPLATSTR(", ") << param_iter->_edm_name << _XPLATSTR(", ") << param_iter->_member_strong_type_name << _XPLATSTR(", ") <<  param_iter->_member_name;
 	}
 
-	out << U(");") << std::endl << std::endl;
+	out << _XPLATSTR(");") << std::endl << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_operation_imports_in_entity_container(::utility::ofstream_t& out, const class_info& _class_info, const property_info& _property_info)
@@ -476,51 +480,51 @@ void odata_codegen_writer::generate_implement_operation_imports_in_entity_contai
 
 	if (!_operation_info)
 	{
-		return ;
+		return;
 	}
 
-	::utility::string_t _declare_name;
+	::odata::string_t _declare_name;
 	if (_property_info._type == PROPERTY_TYPE::E_ACTION)
 	{
-		_declare_name = U("IMPLEMENT_ACTION_IMPORT_P");
+		_declare_name = _XPLATSTR("IMPLEMENT_ACTION_IMPORT_P");
 	}
 	else
 	{
-		_declare_name = U("IMPLEMENT_FUNCTION_IMPORT_P");
+		_declare_name = _XPLATSTR("IMPLEMENT_FUNCTION_IMPORT_P");
 	}
 
-	if ( _operation_info->_executor_name == U("odata_enum_query_executor"))
+	if ( _operation_info->_executor_name == _XPLATSTR("odata_enum_query_executor"))
 	{
-	    out << _declare_name << _operation_info->vec_params.size() << U("(") << _class_info._class_name << U(", ") << _property_info._class_member_name 
-		    << U(", ") << _class_info._class_name << U("::enum_") << _property_info._class_member_name << U("_excecutor");
+		out << _declare_name << _operation_info->vec_params.size() << _XPLATSTR("(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name
+			<< _XPLATSTR(", ") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR("::enum_") << _property_info._class_member_name << _XPLATSTR("_excecutor");
 	}
-	else if (_operation_info->_executor_name == U("odata_void_query_executor"))
+	else if (_operation_info->_executor_name == _XPLATSTR("odata_void_query_executor"))
 	{
-	    out << _declare_name << _operation_info->vec_params.size() << U("(") << _class_info._class_name << U(", ") << _property_info._class_member_name 
-		    << U(", ") << _operation_info->_executor_name;
+		out << _declare_name << _operation_info->vec_params.size() << _XPLATSTR("(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name
+			<< _XPLATSTR(", ") << _operation_info->_executor_name;
 	}
 	else
 	{
-	    out << _declare_name << _operation_info->vec_params.size() << U("(") << _class_info._class_name << U(", ") << _property_info._class_member_name 
-		    << U(", ") << _operation_info->_executor_name << U("<") << _operation_info->_return_type << U(">");
+		out << _declare_name << _operation_info->vec_params.size() << _XPLATSTR("(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name
+			<< _XPLATSTR(", ") << _operation_info->_executor_name << _XPLATSTR("<") << _operation_info->_return_type << _XPLATSTR(">");
 	}
 
-	for (auto param_iter = _operation_info->vec_params.cbegin(); param_iter != _operation_info->vec_params.cend(); param_iter++)
+	for (auto param_iter = _operation_info->vec_params.cbegin(); param_iter != _operation_info->vec_params.cend(); ++param_iter)
 	{
-		out << U(", ") << param_iter->_edm_name << U(", ") << param_iter->_member_strong_type_name << U(", ") <<  param_iter->_member_name;
+		out << _XPLATSTR(", ") << param_iter->_edm_name << _XPLATSTR(", ") << param_iter->_member_strong_type_name << _XPLATSTR(", ") <<  param_iter->_member_name;
 	}
 
-	out << U(");") << std::endl << std::endl;
+	out << _XPLATSTR(");") << std::endl << std::endl;
 }
 
-void odata_codegen_writer::generate_entity_container_end(::utility::ofstream_t& o_header, const class_info& _class_info)
+void odata_codegen_writer::generate_entity_container_end(::utility::ofstream_t& o_header, const class_info& /*_class_info*/)
 {
-	o_header << U("};") << std::endl << std::endl;
+	o_header << _XPLATSTR("};") << std::endl << std::endl;
 }
 
 void odata_codegen_writer::generate_entity_container(::utility::ofstream_t& o_header, ::utility::ofstream_t& o_cpp, schema_info& _schema_info)
 {
-	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); class_iter++)
+	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); ++class_iter)
 	{
 		auto _class_info = *class_iter;
 
@@ -533,7 +537,7 @@ void odata_codegen_writer::generate_entity_container(::utility::ofstream_t& o_he
 
 		auto class_property_map = (_schema_info.m_class_property_map)[_class_info._class_name];
 
-		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); property_iter++)
+		for (auto property_iter = class_property_map.cbegin(); property_iter != class_property_map.cend(); ++property_iter)
 		{
 			auto _property_info = property_iter->second;
 
@@ -577,12 +581,12 @@ void odata_codegen_writer::generate_entity_container(::utility::ofstream_t& o_he
 //IMPLEMENT_EMPTY_DERIVED_TYPE_CREATOR_MAP(Order)
 //
 //BEGIN_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(Person)
-//  ON_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(Customer, customer)
+//	ON_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(Customer, customer)
 //	ON_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(Employee, employee)
 //END_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(Person)
 //
 //BEGIN_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(PaymentInstrument)
-//  ON_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(CreditCardPI, creditcardpi)
+//	ON_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(CreditCardPI, creditcardpi)
 //END_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(PaymentInstrument)
 //
 //DECLARE_DERIVED_COMPLEX_CREATOR_FUNC(HomeAddress, homeaddress)
@@ -595,7 +599,7 @@ void odata_codegen_writer::generate_entity_container(::utility::ofstream_t& o_he
 //IMPLEMENT_COMPLEX_DERIVED_TYPE_CREATOR_MAP(AccountInfo)
 void odata_codegen_writer::generate_derived_creator(::utility::ofstream_t& o_cpp, schema_info& _schema_info)
 {
-	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); class_iter++)
+	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); ++class_iter)
 	{
 		auto _class_info = *class_iter;
 
@@ -607,17 +611,17 @@ void odata_codegen_writer::generate_derived_creator(::utility::ofstream_t& o_cpp
 		auto find_iter = _schema_info.m_derived_classes.find(_class_info._class_name);
 		if (find_iter != _schema_info.m_derived_classes.end())
 		{
-			for (auto derived_iter = find_iter->second.cbegin(); derived_iter != find_iter->second.cend(); derived_iter++)
+			for (auto derived_iter = find_iter->second.cbegin(); derived_iter != find_iter->second.cend(); ++derived_iter)
 			{
-				auto derived_class_name = *derived_iter; 
+				auto derived_class_name = *derived_iter;
 				::utility::string_t derived_class_creator_name = derived_class_name;
 				std::transform(derived_class_name.begin(), derived_class_name.end(), derived_class_creator_name.begin(), ::tolower);
-				o_cpp << U("DECLARE_DERIVED_COMPLEX_CREATOR_FUNC(") << derived_class_name << U(", ") <<  derived_class_creator_name << U(")") << std::endl;
+				o_cpp << _XPLATSTR("DECLARE_DERIVED_COMPLEX_CREATOR_FUNC(") << CLASS_NAME_PREFIX << derived_class_name << _XPLATSTR(", ") <<  derived_class_creator_name << _XPLATSTR(")") << std::endl;
 			}
 		}
 	}
 
-	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); class_iter++)
+	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); ++class_iter)
 	{
 		auto _class_info = *class_iter;
 
@@ -629,27 +633,27 @@ void odata_codegen_writer::generate_derived_creator(::utility::ofstream_t& o_cpp
 		auto find_iter = _schema_info.m_derived_classes.find(_class_info._class_name);
 		if (find_iter == _schema_info.m_derived_classes.end())
 		{
-			o_cpp << U("IMPLEMENT_COMPLEX_DERIVED_TYPE_CREATOR_MAP(") << _class_info._class_name << U(")") << std::endl;
+			o_cpp << _XPLATSTR("IMPLEMENT_COMPLEX_DERIVED_TYPE_CREATOR_MAP(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(")") << std::endl;
 		}
 		else
 		{
-			o_cpp << std::endl << U("BEGIN_IMPLEMENT_COMPLEX_DERIVED_TYPE_CREATOR_MAP(") << _class_info._class_name << U(")") << std::endl;
+			o_cpp << std::endl << _XPLATSTR("BEGIN_IMPLEMENT_COMPLEX_DERIVED_TYPE_CREATOR_MAP(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(")") << std::endl;
 
-			for (auto derived_iter = find_iter->second.cbegin(); derived_iter != find_iter->second.cend(); derived_iter++)
+			for (auto derived_iter = find_iter->second.cbegin(); derived_iter != find_iter->second.cend(); ++derived_iter)
 			{
-				auto derived_class_name = *derived_iter; 
+				auto derived_class_name = *derived_iter;
 				::utility::string_t derived_class_creator_name = derived_class_name;
 				std::transform(derived_class_name.begin(), derived_class_name.end(), derived_class_creator_name.begin(), ::tolower);
-				o_cpp << INDENT << U("ON_IMPLEMENT_COMPLEX_DERIVED_TYPE_CREATOR_MAP(") << derived_class_name << U(", ") <<  derived_class_creator_name << U(")") << std::endl;
+				o_cpp << INDENT << _XPLATSTR("ON_IMPLEMENT_COMPLEX_DERIVED_TYPE_CREATOR_MAP(") << CLASS_NAME_PREFIX << derived_class_name << _XPLATSTR(", ") <<  derived_class_creator_name << _XPLATSTR(")") << std::endl;
 			}
 
-			o_cpp << U("END_IMPLEMENT_COMPLEX_DERIVED_TYPE_CREATOR_MAP(") << _class_info._class_name << U(")") << std::endl << std::endl;
+			o_cpp << _XPLATSTR("END_IMPLEMENT_COMPLEX_DERIVED_TYPE_CREATOR_MAP(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(")") << std::endl << std::endl;
 		}
 	}
 
 	output_empty_line(o_cpp, 1);
 
-	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); class_iter++)
+	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); ++class_iter)
 	{
 		auto _class_info = *class_iter;
 
@@ -661,17 +665,17 @@ void odata_codegen_writer::generate_derived_creator(::utility::ofstream_t& o_cpp
 		auto find_iter = _schema_info.m_derived_classes.find(_class_info._class_name);
 		if (find_iter != _schema_info.m_derived_classes.end())
 		{
-			for (auto derived_iter = find_iter->second.cbegin(); derived_iter != find_iter->second.cend(); derived_iter++)
+			for (auto derived_iter = find_iter->second.cbegin(); derived_iter != find_iter->second.cend(); ++derived_iter)
 			{
-				auto derived_class_name = *derived_iter; 
+				auto derived_class_name = *derived_iter;
 				::utility::string_t derived_class_creator_name = derived_class_name;
 				std::transform(derived_class_name.begin(), derived_class_name.end(), derived_class_creator_name.begin(), ::tolower);
-				o_cpp << U("DECLARE_DERIVED_ENTITY_CREATOR_FUNC(") << derived_class_name << U(", ") <<  derived_class_creator_name << U(")") << std::endl;
+				o_cpp << _XPLATSTR("DECLARE_DERIVED_ENTITY_CREATOR_FUNC(") << CLASS_NAME_PREFIX << derived_class_name << _XPLATSTR(", ") <<  derived_class_creator_name << _XPLATSTR(")") << std::endl;
 			}
 		}
 	}
 
-	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); class_iter++)
+	for (auto class_iter = _schema_info.m_class_vec.cbegin(); class_iter != _schema_info.m_class_vec.cend(); ++class_iter)
 	{
 		auto _class_info = *class_iter;
 
@@ -683,102 +687,113 @@ void odata_codegen_writer::generate_derived_creator(::utility::ofstream_t& o_cpp
 		auto find_iter = _schema_info.m_derived_classes.find(_class_info._class_name);
 		if (find_iter == _schema_info.m_derived_classes.end())
 		{
-			o_cpp << U("IMPLEMENT_EMPTY_DERIVED_TYPE_CREATOR_MAP(") << _class_info._class_name << U(")") << std::endl;
+			o_cpp << _XPLATSTR("IMPLEMENT_EMPTY_DERIVED_TYPE_CREATOR_MAP(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(")") << std::endl;
 		}
 		else
 		{
-			o_cpp << std::endl << U("BEGIN_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(") << _class_info._class_name << U(")") << std::endl;
+			o_cpp << std::endl << _XPLATSTR("BEGIN_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(")") << std::endl;
 
-			for (auto derived_iter = find_iter->second.cbegin(); derived_iter != find_iter->second.cend(); derived_iter++)
+			for (auto derived_iter = find_iter->second.cbegin(); derived_iter != find_iter->second.cend(); ++derived_iter)
 			{
-				auto derived_class_name = *derived_iter; 
+				auto derived_class_name = *derived_iter;
 				::utility::string_t derived_class_creator_name = derived_class_name;
 				std::transform(derived_class_name.begin(), derived_class_name.end(), derived_class_creator_name.begin(), ::tolower);
-				o_cpp << INDENT << U("ON_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(") << derived_class_name << U(", ") <<  derived_class_creator_name << U(")") << std::endl;
+				o_cpp << INDENT << _XPLATSTR("ON_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(") << CLASS_NAME_PREFIX << derived_class_name << _XPLATSTR(", ") <<  derived_class_creator_name << _XPLATSTR(")") << std::endl;
 			}
 
-			o_cpp << U("END_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(") << _class_info._class_name << U(")") << std::endl << std::endl;
+			o_cpp << _XPLATSTR("END_IMPLEMENT_ENTITY_DERIVED_TYPE_CREATOR_MAP(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(")") << std::endl << std::endl;
 		}
 	}
 }
 
 //class Item : public Entity
 //{
-//public: 
+//public:
 
-void odata_codegen_writer::generate_declare_class_begin(::utility::ofstream_t& out, const ::utility::string_t& class_name, const ::utility::string_t& base_class_name)
+void odata_codegen_writer::generate_declare_class_begin(::utility::ofstream_t& out, const ::odata::string_t& class_name, const ::odata::string_t& base_class_name)
 {
-	out << U("class ") << class_name << U(" : public ") << base_class_name << std::endl;
-	out << U("{") << std::endl;
-	out << U("public:") << std::endl;
+	out << _XPLATSTR("class ") << CLASS_NAME_PREFIX << class_name << _XPLATSTR(" : public ");
+	if (base_class_name != _XPLATSTR("type_base"))
+	{
+		 out << CLASS_NAME_PREFIX;
+	}
+	out << base_class_name << std::endl;
+	out << _XPLATSTR("{") << std::endl;
+	out << _XPLATSTR("public:") << std::endl;
 }
 
 void odata_codegen_writer::generate_declare_class_end(::utility::ofstream_t& out)
 {
-	out << U("};") << std::endl << std::endl;
+	out << _XPLATSTR("};") << std::endl << std::endl;
 }
 
 //DECLARE_COMPLEX_CONSTRUCTOR(ItemBody);
 //DECLARE_COMPLEX_DESTRUCTOR(ItemBody);
 //DECLARE_EDM_INFO();
 //ENABLE_PROPERTY_IN_COMPLEX_MAPPING();
-void odata_codegen_writer::generate_declare_common_functions_in_complex(::utility::ofstream_t& out, const ::utility::string_t& class_name)
+void odata_codegen_writer::generate_declare_common_functions_in_complex(::utility::ofstream_t& out, const ::odata::string_t& class_name)
 {
-	out << INDENT << U("DECLARE_COMPLEX_CONSTRUCTOR(") << class_name << U(");") << std::endl;
-	out << INDENT << U("DECLARE_COMPLEX_DESTRUCTOR(") << class_name << U(");") << std::endl;
-	out << INDENT << U("DECLARE_EDM_INFO();") << std::endl;
-	out << INDENT << U("ENABLE_PROPERTY_IN_COMPLEX_MAPPING();") << std::endl << std::endl;
+	out << INDENT << _XPLATSTR("DECLARE_COMPLEX_CONSTRUCTOR(") << CLASS_NAME_PREFIX << class_name << _XPLATSTR(");") << std::endl;
+	out << INDENT << _XPLATSTR("DECLARE_COMPLEX_DESTRUCTOR(") << CLASS_NAME_PREFIX << class_name << _XPLATSTR(");") << std::endl;
+	out << INDENT << _XPLATSTR("DECLARE_EDM_INFO();") << std::endl;
+	out << INDENT << _XPLATSTR("ENABLE_PROPERTY_IN_COMPLEX_MAPPING();") << std::endl << std::endl;
 }
 
 //DECLARE_NULLABLE_ENUM_PROPERTY_IN_COMPLEX_MAPPING(contenttype, ContentType, BodyType);
-//DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(content, Content, ::utility::string_t);
+//DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(content, Content, ::odata::string_t);
 void odata_codegen_writer::generate_declare_class_member_in_complex(::utility::ofstream_t& out, const property_info& _property_info)
 {
-	::utility::string_t member_macro;
+	::odata::string_t member_macro;
 
 	if (_property_info._type == PROPERTY_TYPE::E_PRIMITIVE)
 	{
 		if (_property_info._is_nullable)
 		{
-			member_macro = U("DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(");
+			member_macro = _XPLATSTR("DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(");
 		}
 		else
 		{
-			member_macro = U("DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(");
+			member_macro = _XPLATSTR("DECLARE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(");
 		}
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_COMPLEX)
 	{
 		if (_property_info._is_nullable)
 		{
-			member_macro = U("DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(");
+			member_macro = _XPLATSTR("DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(");
 		}
 		else
 		{
-			member_macro = U("DECLARE_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(");
+			member_macro = _XPLATSTR("DECLARE_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(");
 		}
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_ENUM)
 	{
 		if (_property_info._is_nullable)
 		{
-			member_macro = U("DECLARE_NULLABLE_ENUM_PROPERTY_IN_COMPLEX_MAPPING(");
+			member_macro = _XPLATSTR("DECLARE_NULLABLE_ENUM_PROPERTY_IN_COMPLEX_MAPPING(");
 		}
 		else
 		{
-			member_macro = U("DECLARE_ENUM_PROPERTY_IN_COMPLEX_MAPPING(");
+			member_macro = _XPLATSTR("DECLARE_ENUM_PROPERTY_IN_COMPLEX_MAPPING(");
 		}
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_COLLECTION_PRIMITIVE)
 	{
-		member_macro = U("DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(");
+		member_macro = _XPLATSTR("DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(");
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_COLLECTION_ENUM)
 	{
-		member_macro = U("DECLARE_COLLECTION_ENUM_PROPERTY_IN_COMPLEX_MAPPING(");
+		member_macro = _XPLATSTR("DECLARE_COLLECTION_ENUM_PROPERTY_IN_COMPLEX_MAPPING(");
+	}
+	else
+	{
+		// We end up here if we encounter a (not yet) supported declaration, e.g. a navigation property in a complex type.
+		// It's better to completely leave away the unsupported declaration than to write broken garbage into the declaration!
+		return;
 	}
 
-	out << INDENT << member_macro << _property_info._class_member_name << U(", ") << _property_info._edm_name << U(", ") << _property_info._strong_type_name << U(");") << std::endl;
+	out << INDENT << member_macro << _property_info._class_member_name << _XPLATSTR(", ") << _property_info._edm_name << _XPLATSTR(", ") << _property_info._strong_type_name << _XPLATSTR(");") << std::endl;
 }
 
 //BEGIN_COMPLEX_CONSTRUCTOR(AccountInfo, type_base)
@@ -786,89 +801,105 @@ void odata_codegen_writer::generate_declare_class_member_in_complex(::utility::o
 //END_COMPLEX_CONSTRUCTOR(AccountInfo, type_base)
 void odata_codegen_writer::generate_implement_begin_constructor_in_complex(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << U("BEGIN_COMPLEX_CONSTRUCTOR(") << _class_info._class_name << U(", ") << _class_info._base_class_name << U(")") << std::endl;
+	out << _XPLATSTR("BEGIN_COMPLEX_CONSTRUCTOR(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ");
+	if (_class_info._base_class_name != _XPLATSTR("type_base"))
+	{
+		out << CLASS_NAME_PREFIX;
+	}
+	out << _class_info._base_class_name << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_on_constructor_in_complex(::utility::ofstream_t& out, const property_info& _property_info)
 {
-	out << INDENT << U("ON_PROPERTY_IN_COMPLEX_CONSTRUCTOR(") << _property_info._class_member_name << U(", ") << _property_info._default_value << U(")") << std::endl;
+	out << INDENT << _XPLATSTR("ON_PROPERTY_IN_COMPLEX_CONSTRUCTOR(") << _property_info._class_member_name << _XPLATSTR(", ") << _property_info._default_value << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_end_constructor_in_complex(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << U("END_COMPLEX_CONSTRUCTOR(") << _class_info._class_name << U(", ") << _class_info._base_class_name << U(")") << std::endl << std::endl;
+	out << _XPLATSTR("END_COMPLEX_CONSTRUCTOR(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ");
+	if (_class_info._base_class_name != _XPLATSTR("type_base"))
+	{
+		out << CLASS_NAME_PREFIX;
+	}
+	out << _class_info._base_class_name << _XPLATSTR(")") << std::endl << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_begin_destructor_in_complex(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << U("BEGIN_COMPLEX_DESTRUCTOR(") << _class_info._class_name << U(")") << std::endl;
+	out << _XPLATSTR("BEGIN_COMPLEX_DESTRUCTOR(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_on_destructor_in_complex(::utility::ofstream_t& out, const property_info& _property_info)
 {
-	out << INDENT << U("ON_PROPERTY_IN_COMPLEX_DESTRUCTOR(") << _property_info._class_member_name << U(")") << std::endl;
+	out << INDENT << _XPLATSTR("ON_PROPERTY_IN_COMPLEX_DESTRUCTOR(") << _property_info._class_member_name << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_end_destructor_in_complex(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << U("END_COMPLEX_DESTRUCTOR(") << _class_info._class_name << U(")") << std::endl << std::endl;
+	out << _XPLATSTR("END_COMPLEX_DESTRUCTOR(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(")") << std::endl << std::endl;
 }
 
 //IMPLEMENT_EDM_INFO(Address, Microsoft.Test.OData.Services.ODataWCFService, Address)
 void odata_codegen_writer::generate_implement_common_functions_in_complex(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << std::endl << U("IMPLEMENT_EDM_INFO(") << _class_info._class_name << U(", ") << _class_info._edm_namespace << U(", ") << _class_info._edm_name << U(")")  << std::endl  << std::endl;
+	out << std::endl << _XPLATSTR("IMPLEMENT_EDM_INFO(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _class_info._edm_namespace << _XPLATSTR(", ") << _class_info._edm_name << _XPLATSTR(")")  << std::endl  << std::endl;
 }
 
-//IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo, firstname, FirstName, ::utility::string_t);
-//IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo, lastname, LastName, ::utility::string_t);
+//IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo, firstname, FirstName, ::odata::string_t);
+//IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(AccountInfo, lastname, LastName, ::odata::string_t);
 void odata_codegen_writer::generate_implement_class_member_in_complex(::utility::ofstream_t& out, const class_info& _class_info, const property_info& _property_info)
 {
-	::utility::string_t member_macro;
+	::odata::string_t member_macro;
 
 	if (_property_info._type == PROPERTY_TYPE::E_PRIMITIVE)
 	{
 		if (_property_info._is_nullable)
 		{
-			member_macro = U("IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(");
+			member_macro = _XPLATSTR("IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(");
 		}
 		else
 		{
-			member_macro = U("IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(");
+			member_macro = _XPLATSTR("IMPLEMENT_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(");
 		}
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_COMPLEX)
 	{
 		if (_property_info._is_nullable)
 		{
-			member_macro = U("IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(");
+			member_macro = _XPLATSTR("IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(");
 		}
 		else
 		{
-			member_macro = U("IMPLEMENT_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(");
+			member_macro = _XPLATSTR("IMPLEMENT_COMPLEX_PROPERTY_IN_COMPLEX_MAPPING(");
 		}
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_ENUM)
 	{
 		if (_property_info._is_nullable)
 		{
-			member_macro = U("IMPLEMENT_NULLABLE_ENUM_PROPERTY_IN_COMPLEX_MAPPING(");
+			member_macro = _XPLATSTR("IMPLEMENT_NULLABLE_ENUM_PROPERTY_IN_COMPLEX_MAPPING(");
 		}
 		else
 		{
-			member_macro = U("IMPLEMENT_ENUM_PROPERTY_IN_COMPLEX_MAPPING(");
+			member_macro = _XPLATSTR("IMPLEMENT_ENUM_PROPERTY_IN_COMPLEX_MAPPING(");
 		}
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_COLLECTION_PRIMITIVE)
 	{
-		member_macro = U("IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(");
+		member_macro = _XPLATSTR("IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_COMPLEX_MAPPING(");
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_COLLECTION_ENUM)
 	{
-		member_macro = U("IMPLEMENT_COLLECTION_ENUM_PROPERTY_IN_COMPLEX_MAPPING(");
+		member_macro = _XPLATSTR("IMPLEMENT_COLLECTION_ENUM_PROPERTY_IN_COMPLEX_MAPPING(");
+	}
+	else
+	{
+		// We end up here if we encounter a (not yet) supported implemetation, e.g. a navigation property in a complex type.
+		// It's better to completely leave away the unsupported implemetation than to write broken garbage into the implemetation!
+		return;
 	}
 
-	out << member_macro << _class_info._class_name << U(", ") << _property_info._class_member_name << U(", ") << _property_info._edm_name << U(", ") <<_property_info._strong_type_name  << U(");") << std::endl;
+	out << member_macro << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name << _XPLATSTR(", ") << _property_info._edm_name << _XPLATSTR(", ") <<_property_info._strong_type_name  << _XPLATSTR(");") << std::endl;
 }
 
 //BEGIN_PROPERTY_IN_COMPLEX_MAPPING(Address)
@@ -882,36 +913,36 @@ void odata_codegen_writer::generate_implement_class_member_in_complex(::utility:
 //END_PROPERTY_IN_COMPLEX_MAPPING_WITH_BASE_CLASS(HomeAddress, Address)
 void odata_codegen_writer::generate_implement_begin_materialize_in_complex(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	if (_class_info._base_class_name != U("type_base"))
+	if (_class_info._base_class_name != _XPLATSTR("type_base"))
 	{
-		out << U("BEGIN_PROPERTY_IN_COMPLEX_MAPPING_WITH_BASE_CLASS(") << _class_info._class_name << U(", ") << _class_info._base_class_name << U(")") << std::endl;
+		out << _XPLATSTR("BEGIN_PROPERTY_IN_COMPLEX_MAPPING_WITH_BASE_CLASS(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << CLASS_NAME_PREFIX << _class_info._base_class_name << _XPLATSTR(")") << std::endl;
 	}
 	else
 	{
-		out << U("BEGIN_PROPERTY_IN_COMPLEX_MAPPING(") << _class_info._class_name << U(")") << std::endl;
-	} 
+		out << _XPLATSTR("BEGIN_PROPERTY_IN_COMPLEX_MAPPING(") << _class_info._class_name << _XPLATSTR(")") << std::endl;
+	}
 }
 
 void odata_codegen_writer::generate_implement_on_materialize_in_complex(::utility::ofstream_t& out, const class_info& _class_info, const property_info& _property_info)
 {
 	if (_property_info._type == PROPERTY_TYPE::E_ACTION || _property_info._type == PROPERTY_TYPE::E_FUNCTION)
 	{
-		return ;
+		return;
 	}
 
-	out << INDENT << U("ON_PROPERTY_IN_COMPLEX_MAPPING(") << _class_info._class_name << U(", ") << _property_info._class_member_name << U(")") << std::endl;
+	out << INDENT << _XPLATSTR("ON_PROPERTY_IN_COMPLEX_MAPPING(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_end_materialize_in_complex(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	if (_class_info._base_class_name != U("type_base"))
+	if (_class_info._base_class_name != _XPLATSTR("type_base"))
 	{
-		out << U("END_PROPERTY_IN_COMPLEX_MAPPING_WITH_BASE_CLASS(") << _class_info._class_name << U(", ") << _class_info._base_class_name << U(")") << std::endl;
+		out << _XPLATSTR("END_PROPERTY_IN_COMPLEX_MAPPING_WITH_BASE_CLASS(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << CLASS_NAME_PREFIX << _class_info._base_class_name << _XPLATSTR(")") << std::endl;
 	}
 	else
 	{
-		out << U("END_PROPERTY_IN_COMPLEX_MAPPING(") << _class_info._class_name << U(")") << std::endl << std::endl;
-	}  
+		out << _XPLATSTR("END_PROPERTY_IN_COMPLEX_MAPPING(") << _class_info._class_name << _XPLATSTR(")") << std::endl << std::endl;
+	}
 }
 
 //BEGIN_SERIALIZE_PROPERTY_IN_COMPLEX_MAPPING(Address)
@@ -921,34 +952,34 @@ void odata_codegen_writer::generate_implement_end_materialize_in_complex(::utili
 //END_SERIALIZE_PROPERTY_IN_COMPLEX_MAPPING(Address)
 void odata_codegen_writer::generate_implement_begin_serialize_in_complex(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << U("BEGIN_SERIALIZE_PROPERTY_IN_COMPLEX_MAPPING(") << _class_info._class_name << U(")") << std::endl;
+	out << _XPLATSTR("BEGIN_SERIALIZE_PROPERTY_IN_COMPLEX_MAPPING(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_on_serialize_in_complex(::utility::ofstream_t& out, const class_info& _class_info, const property_info& _property_info)
 {
 	if (_property_info._type == PROPERTY_TYPE::E_ACTION || _property_info._type == PROPERTY_TYPE::E_FUNCTION)
 	{
-		return ;
+		return;
 	}
 
-	out << INDENT << U("ON_SERIALIZE_PROPERTY_IN_COMPLEX_MAPPING(") << _class_info._class_name << U(", ") << _property_info._class_member_name << U(")") << std::endl;
+	out << INDENT << _XPLATSTR("ON_SERIALIZE_PROPERTY_IN_COMPLEX_MAPPING(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_end_serialize_in_complex(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << U("END_SERIALIZE_PROPERTY_IN_COMPLEX_MAPPING(") << _class_info._class_name << U(")") << std::endl << std::endl;
+	out << _XPLATSTR("END_SERIALIZE_PROPERTY_IN_COMPLEX_MAPPING(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(")") << std::endl << std::endl;
 }
 
 //DECLARE_ENTITY_CONSTRUCTOR(Person);
 //DECLARE_ENTITY_DESTRUCTOR(Person);
 //DECLARE_EDM_INFO();
-//ENABLE_PROPERTY_IN_ENTITY_MAPPING();	
-void odata_codegen_writer::generate_declare_common_functions_in_entity(::utility::ofstream_t& out, const ::utility::string_t& class_name)
+//ENABLE_PROPERTY_IN_ENTITY_MAPPING();
+void odata_codegen_writer::generate_declare_common_functions_in_entity(::utility::ofstream_t& out, const ::odata::string_t& class_name)
 {
-	out << INDENT << U("DECLARE_ENTITY_CONSTRUCTOR(") << class_name << U(");") << std::endl;
-	out << INDENT << U("DECLARE_ENTITY_DESTRUCTOR(") << class_name << U(");") << std::endl;
-	out << INDENT << U("DECLARE_EDM_INFO();") << std::endl;
-	out << INDENT << U("ENABLE_PROPERTY_IN_ENTITY_MAPPING();") << std::endl << std::endl;
+	out << INDENT << _XPLATSTR("DECLARE_ENTITY_CONSTRUCTOR(") << CLASS_NAME_PREFIX << class_name << _XPLATSTR(");") << std::endl;
+	out << INDENT << _XPLATSTR("DECLARE_ENTITY_DESTRUCTOR(") << CLASS_NAME_PREFIX << class_name << _XPLATSTR(");") << std::endl;
+	out << INDENT << _XPLATSTR("DECLARE_EDM_INFO();") << std::endl;
+	out << INDENT << _XPLATSTR("ENABLE_PROPERTY_IN_ENTITY_MAPPING();") << std::endl << std::endl;
 }
 
 //DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(type_base, PersonID, personid);
@@ -963,101 +994,111 @@ void odata_codegen_writer::generate_declare_class_keys_in_entity(::utility::ofst
 
 	if (keys.size() == 0)
 	{
-		out << INDENT << U("DECLARE_GET_KEY_PROPERTY_STRING_NO_PARAM(");
+		out << INDENT << _XPLATSTR("DECLARE_GET_KEY_PROPERTY_STRING_NO_PARAM(");
 	}
 	else if (keys.size() == 1)
 	{
-		out << INDENT << U("DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(");
+		out << INDENT << _XPLATSTR("DECLARE_GET_KEY_PROPERTY_STRING_ONE_PARAM(");
 	}
 	else if (keys.size() == 2)
 	{
-		out << INDENT << U("DECLARE_GET_KEY_PROPERTY_STRING_TWO_PARAM(");
+		out << INDENT << _XPLATSTR("DECLARE_GET_KEY_PROPERTY_STRING_TWO_PARAM(");
 	}
 	else if (keys.size() == 3)
 	{
-		out << INDENT << U("DECLARE_GET_KEY_PROPERTY_STRING_THREE_PARAM(");
+		out << INDENT << _XPLATSTR("DECLARE_GET_KEY_PROPERTY_STRING_THREE_PARAM(");
 	}
 	else if (keys.size() == 4)
 	{
-		out << INDENT << U("DECLARE_GET_KEY_PROPERTY_STRING_FOUR_PARAM(");
+		out << INDENT << _XPLATSTR("DECLARE_GET_KEY_PROPERTY_STRING_FOUR_PARAM(");
 	}
 
+	if (_class_info._base_class_name != _XPLATSTR("type_base"))
+	{
+		out << CLASS_NAME_PREFIX;
+	}
 	out << _class_info._base_class_name;
 
-	for (auto iter_keys = keys.cbegin(); iter_keys != keys.cend(); iter_keys++)
+	for (auto iter_keys = keys.cbegin(); iter_keys != keys.cend(); ++iter_keys)
 	{
-		out << U(", ") << iter_keys->_edm_name << U(", ") << iter_keys->_class_member_name;
+		out << _XPLATSTR(", ") << iter_keys->_edm_name << _XPLATSTR(", ") << iter_keys->_class_member_name;
 	}
 
-	out << U(");") << std::endl;
+	out << _XPLATSTR(");") << std::endl;
 }
 
 void odata_codegen_writer::generate_declare_class_member_in_entity(::utility::ofstream_t& out, const class_info& _class_info, const property_info& _property_info)
 {
 	if (_property_info._type == PROPERTY_TYPE::E_ACTION || _property_info._type == PROPERTY_TYPE::E_FUNCTION)
 	{
-	    generate_declare_operation_in_entity(out, _class_info, _property_info);
+		generate_declare_operation_in_entity(out, _class_info, _property_info);
 
-		return ;
+		return;
 	}
 
-	::utility::string_t member_macro;
+	::odata::string_t member_macro;
 
 	if (_property_info._type == PROPERTY_TYPE::E_PRIMITIVE)
 	{
 		if (_property_info._is_nullable)
 		{
-			member_macro = U("DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(");
+			member_macro = _XPLATSTR("DECLARE_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(");
 		}
 		else
 		{
-			member_macro = U("DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(");
+			member_macro = _XPLATSTR("DECLARE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(");
 		}
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_ENUM)
 	{
 		if (_property_info._is_nullable)
 		{
-			member_macro = U("DECLARE_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(");
+			member_macro = _XPLATSTR("DECLARE_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(");
 		}
 		else
 		{
-			member_macro = U("DECLARE_ENUM_PROPERTY_IN_ENTITY_MAPPING(");
+			member_macro = _XPLATSTR("DECLARE_ENUM_PROPERTY_IN_ENTITY_MAPPING(");
 		}
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_COMPLEX)
 	{
 		if (_property_info._is_nullable)
 		{
-			member_macro = U("DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(");
+			member_macro = _XPLATSTR("DECLARE_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(");
 		}
 		else
 		{
-			member_macro = U("DECLARE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(");
+			member_macro = _XPLATSTR("DECLARE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(");
 		}
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_ENTITY)
 	{
-		member_macro = U("DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(");
+		member_macro = _XPLATSTR("DECLARE_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(");
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_COLLECTION_PRIMITIVE)
 	{
-		member_macro = U("DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(");
+		member_macro = _XPLATSTR("DECLARE_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(");
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_COLLECTION_ENUM)
 	{
-		member_macro = U("DECLARE_COLLECTION_ENUM_PROPERTY_IN_ENTITY_MAPPING(");
+		member_macro = _XPLATSTR("DECLARE_COLLECTION_ENUM_PROPERTY_IN_ENTITY_MAPPING(");
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_COLLECTION_COMPLEX)
 	{
-		member_macro = U("DECLARE_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(");
+		member_macro = _XPLATSTR("DECLARE_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(");
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_COLLECTION_ENTITY)
 	{
-		member_macro = U("DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(");
+		member_macro = _XPLATSTR("DECLARE_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(");
+	}
+	else
+	{
+		// We end up here if we encounter a (not yet) supported declaration, e.g. a navigation property in a complex type.
+		// It's better to completely leave away the unsupported declaration than to write broken garbage into the declaration!
+		return;
 	}
 
-	out << INDENT << member_macro << _property_info._class_member_name << U(", ") << _property_info._edm_name << U(", ") << _property_info._strong_type_name << U(");") << std::endl;
+	out << INDENT << member_macro << _property_info._class_member_name << _XPLATSTR(", ") << _property_info._edm_name << _XPLATSTR(", ") << _property_info._strong_type_name << _XPLATSTR(");") << std::endl;
 }
 
 //DECLARE_FUNCTION_P1(Product, GetProductDetails, odata_entityset_query_executor<ProductDetail>, count, int, count);
@@ -1067,46 +1108,46 @@ void odata_codegen_writer::generate_declare_operation_in_entity(::utility::ofstr
 
 	if (!_operation_info)
 	{
-		return ;
+		return;
 	}
 
-	::utility::string_t _declare_name;
+	::odata::string_t _declare_name;
 	if (_property_info._type == PROPERTY_TYPE::E_ACTION)
 	{
-		_declare_name = U("DECLARE_ACTION_P");
+		_declare_name = _XPLATSTR("DECLARE_ACTION_P");
 	}
 	else
 	{
-		_declare_name = U("DECLARE_FUNCTION_P");
+		_declare_name = _XPLATSTR("DECLARE_FUNCTION_P");
 	}
 
 	// typedef odata_enum_query_executor<Color, enum_type_resolver> enum_GetDefaultColor_excecutor;
-	if ( _operation_info->_executor_name == U("odata_enum_query_executor"))
+	if ( _operation_info->_executor_name == _XPLATSTR("odata_enum_query_executor"))
 	{
 		// DECLARE_FUNCTION_IMPORT_P0(InMemoryEntities, GetDefaultColor, enum_GetDefaultColor_excecutor);
-		out << INDENT << U("typedef odata_enum_query_executor<") << _operation_info->_return_type << U(", enum_type_resolver> ")
-			<< U("enum_") << _property_info._class_member_name << U("_excecutor;") << std::endl;
+		out << INDENT << _XPLATSTR("typedef odata_enum_query_executor<") << _operation_info->_return_type << _XPLATSTR(", enum_type_resolver> ")
+			<< _XPLATSTR("enum_") << _property_info._class_member_name << _XPLATSTR("_excecutor;") << std::endl;
 
-	    out << INDENT << _declare_name << _operation_info->vec_params.size() << U("(") << _class_info._class_name << U(", ") << _property_info._class_member_name 
-		    << U(", ") << U("enum_") << _property_info._class_member_name << U("_excecutor");
+		out << INDENT << _declare_name << _operation_info->vec_params.size() << _XPLATSTR("(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name
+			<< _XPLATSTR(", ") << _XPLATSTR("enum_") << _property_info._class_member_name << _XPLATSTR("_excecutor");
 	}
-	else if (_operation_info->_executor_name == U("odata_void_query_executor"))
+	else if (_operation_info->_executor_name == _XPLATSTR("odata_void_query_executor"))
 	{
-	    out << INDENT << _declare_name << _operation_info->vec_params.size() << U("(") << _class_info._class_name << U(", ") << _property_info._class_member_name 
-		    << U(", ") << _operation_info->_executor_name;
+		out << INDENT << _declare_name << _operation_info->vec_params.size() << _XPLATSTR("(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name
+			<< _XPLATSTR(", ") << _operation_info->_executor_name;
 	}
 	else
 	{
-	    out << INDENT << _declare_name << _operation_info->vec_params.size() << U("(") << _class_info._class_name << U(", ") << _property_info._class_member_name 
-		    << U(", ") << _operation_info->_executor_name << U("<") << _operation_info->_return_type << U(">");
+		out << INDENT << _declare_name << _operation_info->vec_params.size() << _XPLATSTR("(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name
+			<< _XPLATSTR(", ") << _operation_info->_executor_name << _XPLATSTR("<") << _operation_info->_return_type << _XPLATSTR(">");
 	}
 
-	for (auto param_iter = _operation_info->vec_params.cbegin(); param_iter != _operation_info->vec_params.cend(); param_iter++)
+	for (auto param_iter = _operation_info->vec_params.cbegin(); param_iter != _operation_info->vec_params.cend(); ++param_iter)
 	{
-		out << U(", ") << param_iter->_edm_name << U(", ") << param_iter->_member_strong_type_name << U(", ") <<  param_iter->_member_name;
+		out << _XPLATSTR(", ") << param_iter->_edm_name << _XPLATSTR(", ") << param_iter->_member_strong_type_name << _XPLATSTR(", ") <<  param_iter->_member_name;
 	}
 
-	out << U(");") << std::endl;
+	out << _XPLATSTR(");") << std::endl;
 }
 
 //IMPLEMENT_EDM_INFO(Address, Microsoft.Test.OData.Services.ODataWCFService, Address)
@@ -1121,66 +1162,72 @@ void odata_codegen_writer::generate_implement_class_member_in_entity(::utility::
 	{
 		generate_implement_operation_in_entity(out, _class_info, _property_info);
 
-		return ;
+		return;
 	}
 
-	::utility::string_t member_macro;
+	::odata::string_t member_macro;
 
 	if (_property_info._type == PROPERTY_TYPE::E_PRIMITIVE)
 	{
 		if (_property_info._is_nullable)
 		{
-			member_macro = U("IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(");
+			member_macro = _XPLATSTR("IMPLEMENT_NULLABLE_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(");
 		}
 		else
 		{
-			member_macro = U("IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(");
+			member_macro = _XPLATSTR("IMPLEMENT_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(");
 		}
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_ENUM)
 	{
 		if (_property_info._is_nullable)
 		{
-			member_macro = U("IMPLEMENT_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(");
+			member_macro = _XPLATSTR("IMPLEMENT_NULLABLE_ENUM_PROPERTY_IN_ENTITY_MAPPING(");
 		}
 		else
 		{
-			member_macro = U("IMPLEMENT_ENUM_PROPERTY_IN_ENTITY_MAPPING(");
+			member_macro = _XPLATSTR("IMPLEMENT_ENUM_PROPERTY_IN_ENTITY_MAPPING(");
 		}
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_COMPLEX)
 	{
 		if (_property_info._is_nullable)
 		{
-			member_macro = U("IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(");
+			member_macro = _XPLATSTR("IMPLEMENT_NULLABLE_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(");
 		}
 		else
 		{
-			member_macro = U("IMPLEMENT_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(");
+			member_macro = _XPLATSTR("IMPLEMENT_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(");
 		}
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_ENTITY)
 	{
-		member_macro = U("IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(");
+		member_macro = _XPLATSTR("IMPLEMENT_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(");
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_COLLECTION_PRIMITIVE)
 	{
-		member_macro = U("IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(");
+		member_macro = _XPLATSTR("IMPLEMENT_COLLECTION_PRIMITIVE_PROPERTY_IN_ENTITY_MAPPING(");
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_COLLECTION_ENUM)
 	{
-		member_macro = U("IMPLEMENT_COLLECTION_ENUM_PROPERTY_IN_ENTITY_MAPPING(");
+		member_macro = _XPLATSTR("IMPLEMENT_COLLECTION_ENUM_PROPERTY_IN_ENTITY_MAPPING(");
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_COLLECTION_COMPLEX)
 	{
-		member_macro = U("IMPLEMENT_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(");
+		member_macro = _XPLATSTR("IMPLEMENT_COLLECTION_COMPLEX_PROPERTY_IN_ENTITY_MAPPING(");
 	}
 	else if (_property_info._type == PROPERTY_TYPE::E_COLLECTION_ENTITY)
 	{
-		member_macro = U("IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(");
+		member_macro = _XPLATSTR("IMPLEMENT_COLLECTION_NAVIGATION_PROPERTY_IN_ENTITY_MAPPING(");
+	}
+	else
+	{
+		// We end up here if we encounter a (not yet) supported implemetation, e.g. a navigation property in a complex type.
+		// It's better to completely leave away the unsupported implemetation than to write broken garbage into the implementation!
+		return;
 	}
 
-	out << member_macro << _class_info._class_name << U(", ") << _property_info._class_member_name << U(", ") << _property_info._edm_name << U(", ") <<_property_info._strong_type_name  << U(");") << std::endl;
+	out << member_macro << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name << _XPLATSTR(", ") << _property_info._edm_name << _XPLATSTR(", ") <<_property_info._strong_type_name  << _XPLATSTR(");") << std::endl;
 }
 
 //IMPLEMENT_FUNCTION_P1(Product, GetProductDetails, odata_entityset_query_executor<ProductDetail>, count, int, count);
@@ -1190,232 +1237,254 @@ void odata_codegen_writer::generate_implement_operation_in_entity(::utility::ofs
 
 	if (!_operation_info)
 	{
-		return ;
+		return;
 	}
 
-	::utility::string_t _declare_name;
+	::odata::string_t _declare_name;
 	if (_property_info._type == PROPERTY_TYPE::E_ACTION)
 	{
-		_declare_name = U("IMPLEMENT_ACTION_P");
+		_declare_name = _XPLATSTR("IMPLEMENT_ACTION_P");
 	}
 	else
 	{
-		_declare_name = U("IMPLEMENT_FUNCTION_P");
+		_declare_name = _XPLATSTR("IMPLEMENT_FUNCTION_P");
 	}
 
-	if (_operation_info->_executor_name == U("odata_enum_query_executor"))
+	if (_operation_info->_executor_name == _XPLATSTR("odata_enum_query_executor"))
 	{
-	    out << _declare_name << _operation_info->vec_params.size() << U("(") << _class_info._class_name << U(", ") << _property_info._class_member_name 
-		    << U(", ") << _class_info._class_name << U("::enum_") << _property_info._class_member_name << U("_excecutor");
+		out << _declare_name << _operation_info->vec_params.size() << _XPLATSTR("(") << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name
+			<< _XPLATSTR(", ") << _class_info._class_name << _XPLATSTR("::enum_") << _property_info._class_member_name << _XPLATSTR("_excecutor");
 	}
-	else if (_operation_info->_executor_name == U("odata_void_query_executor"))
+	else if (_operation_info->_executor_name == _XPLATSTR("odata_void_query_executor"))
 	{
-	    out << _declare_name << _operation_info->vec_params.size() << U("(") << _class_info._class_name << U(", ") << _property_info._class_member_name 
-		    << U(", ") << _operation_info->_executor_name;
+		out << _declare_name << _operation_info->vec_params.size() << _XPLATSTR("(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name
+			<< _XPLATSTR(", ") << _operation_info->_executor_name;
 	}
 	else
 	{
-	    out << _declare_name << _operation_info->vec_params.size() << U("(") << _class_info._class_name << U(", ") << _property_info._class_member_name 
-		    << U(", ") << _operation_info->_executor_name << U("<") << _operation_info->_return_type << U(">");
+		out << _declare_name << _operation_info->vec_params.size() << _XPLATSTR("(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name
+			<< _XPLATSTR(", ") << _operation_info->_executor_name << _XPLATSTR("<") << _operation_info->_return_type << _XPLATSTR(">");
 	}
 
-	for (auto param_iter = _operation_info->vec_params.cbegin(); param_iter != _operation_info->vec_params.cend(); param_iter++)
+	for (auto param_iter = _operation_info->vec_params.cbegin(); param_iter != _operation_info->vec_params.cend(); ++param_iter)
 	{
-		out << U(", ") << param_iter->_edm_name << U(", ") << param_iter->_member_strong_type_name << U(", ") <<  param_iter->_member_name;
+		out << _XPLATSTR(", ") << param_iter->_edm_name << _XPLATSTR(", ") << param_iter->_member_strong_type_name << _XPLATSTR(", ") <<  param_iter->_member_name;
 	}
 
-	out << U(");") << std::endl;
+	out << _XPLATSTR(");") << std::endl;
 }
 
 //BEGIN_ENTITY_CONSTRUCTOR(GiftCard, type_base)
-//    ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(giftcardid, 0)
-//    ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(amount, 0.0)
+//	ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(giftcardid, 0)
+//	ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(amount, 0.0)
 //END_ENTITY_CONSTRUCTOR(GiftCard, type_base)
 void odata_codegen_writer::generate_implement_begin_constructor_in_entity(::utility::ofstream_t& out, const class_info& _class_info)
 {
-    out << U("BEGIN_ENTITY_CONSTRUCTOR(") << _class_info._class_name << U(", ") << _class_info._base_class_name << U(")") << std::endl;
+	out << _XPLATSTR("BEGIN_ENTITY_CONSTRUCTOR(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ");
+	if (_class_info._base_class_name != _XPLATSTR("type_base"))
+	{
+		out << CLASS_NAME_PREFIX;
+	}
+	out << _class_info._base_class_name << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_on_constructor_in_entity(::utility::ofstream_t& out, const property_info& _property_info)
 {
-	out << INDENT << U("ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(") << _property_info._class_member_name << U(", ") << _property_info._default_value << U(")") << std::endl;
+	out << INDENT << _XPLATSTR("ON_PROPERTY_IN_ENTITY_CONSTRUCTOR(") << _property_info._class_member_name << _XPLATSTR(", ") << _property_info._default_value << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_end_constructor_in_entity(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << U("END_ENTITY_CONSTRUCTOR(") << _class_info._class_name << U(", ") << _class_info._base_class_name << U(")") << std::endl<< std::endl;
+	out << _XPLATSTR("END_ENTITY_CONSTRUCTOR(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ");
+	if (_class_info._base_class_name != _XPLATSTR("type_base"))
+	{
+		out << CLASS_NAME_PREFIX;
+	}
+	out << _class_info._base_class_name << _XPLATSTR(")") << std::endl<< std::endl;
 }
 
 void odata_codegen_writer::generate_implement_begin_destructor_in_entity(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << U("BEGIN_ENTITY_DESTRUCTOR(") << _class_info._class_name << U(")") << std::endl;
+	out << _XPLATSTR("BEGIN_ENTITY_DESTRUCTOR(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_on_destructor_in_entity(::utility::ofstream_t& out, const property_info& _property_info)
 {
-	out << INDENT << U("ON_PROPERTY_IN_ENTITY_DESTRUCTOR(") << _property_info._class_member_name << U(")") << std::endl;
+	out << INDENT << _XPLATSTR("ON_PROPERTY_IN_ENTITY_DESTRUCTOR(") << _property_info._class_member_name << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_end_destructor_in_entity(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << U("END_ENTITY_DESTRUCTOR(") << _class_info._class_name << U(")") << std::endl<< std::endl;
+	out << _XPLATSTR("END_ENTITY_DESTRUCTOR(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(")") << std::endl<< std::endl;
 }
 
 //BEGIN_PROPERTY_IN_ENTITY_MAPPING(Account)
-//    ON_PROPERTY_IN_ENTITY_MAPPING(Account, accountid)
-//    ON_PROPERTY_IN_ENTITY_MAPPING(Account, countryregion)
+//	ON_PROPERTY_IN_ENTITY_MAPPING(Account, accountid)
+//	ON_PROPERTY_IN_ENTITY_MAPPING(Account, countryregion)
 //	ON_PROPERTY_IN_ENTITY_MAPPING(Account, accountinfo)
 //	ON_PROPERTY_IN_ENTITY_MAPPING(Account, giftcard)
 //	ON_PROPERTY_IN_ENTITY_MAPPING(Account, mypaymentinstruments)
 //END_PROPERTY_IN_ENTITY_MAPPING(Account)
 // or
 ////BEGIN_PROPERTY_IN_ENTITY_MAPPING_WITH_BASE_CLASS(CreditCardPI, PaymentInstrument)
-//    ON_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, cardnumber)
-//    ON_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, cvv)
+//	ON_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, cardnumber)
+//	ON_PROPERTY_IN_ENTITY_MAPPING(CreditCardPI, cvv)
 //END_PROPERTY_IN_ENTITY_MAPPING_WITH_BASE_CLASS(CreditCardPI, PaymentInstrument)
 void odata_codegen_writer::generate_implement_begin_materialize_in_entity(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	if (_class_info._base_class_name != U("type_base"))
+	if (_class_info._base_class_name != _XPLATSTR("type_base"))
 	{
-		out << U("BEGIN_PROPERTY_IN_ENTITY_MAPPING_WITH_BASE_CLASS(") << _class_info._class_name << U(", ") << _class_info._base_class_name << U(")") << std::endl;
+		out << _XPLATSTR("BEGIN_PROPERTY_IN_ENTITY_MAPPING_WITH_BASE_CLASS(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << CLASS_NAME_PREFIX << _class_info._base_class_name << _XPLATSTR(")") << std::endl;
 	}
 	else
 	{
-		out << U("BEGIN_PROPERTY_IN_ENTITY_MAPPING(") << _class_info._class_name << U(")") << std::endl;
-	}   
+		out << _XPLATSTR("BEGIN_PROPERTY_IN_ENTITY_MAPPING(") << _class_info._class_name << _XPLATSTR(")") << std::endl;
+	}
 }
 
 void odata_codegen_writer::generate_implement_on_materialize_in_entity(::utility::ofstream_t& out, const class_info& _class_info, const property_info& _property_info)
 {
 	if (_property_info._type == PROPERTY_TYPE::E_ACTION || _property_info._type == PROPERTY_TYPE::E_FUNCTION)
 	{
-		return ;
+		return;
 	}
 
-	out << INDENT << U("ON_PROPERTY_IN_ENTITY_MAPPING(") << _class_info._class_name << U(", ") << _property_info._class_member_name << U(")") << std::endl;
+	out << INDENT << _XPLATSTR("ON_PROPERTY_IN_ENTITY_MAPPING(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name << _XPLATSTR(")") << std::endl;
 }
 
 
 
 void odata_codegen_writer::generate_implement_end_materialize_in_entity(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	if (_class_info._base_class_name != U("type_base"))
+	if (_class_info._base_class_name != _XPLATSTR("type_base"))
 	{
-		out << U("END_PROPERTY_IN_ENTITY_MAPPING_WITH_BASE_CLASS(") << _class_info._class_name << U(", ") << _class_info._base_class_name << U(")") << std::endl;
+		out << _XPLATSTR("END_PROPERTY_IN_ENTITY_MAPPING_WITH_BASE_CLASS(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << CLASS_NAME_PREFIX << _class_info._base_class_name << _XPLATSTR(")") << std::endl;
 	}
 	else
 	{
-		out << U("END_PROPERTY_IN_ENTITY_MAPPING(") << _class_info._class_name << U(")") << std::endl << std::endl;
-	}  
-	
+		out << _XPLATSTR("END_PROPERTY_IN_ENTITY_MAPPING(") << _class_info._class_name << _XPLATSTR(")") << std::endl << std::endl;
+	}
+
 }
 
 //BEGIN_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Account)
-//    ON_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Account, accountid)
-//    ON_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Account, countryregion)
+//	ON_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Account, accountid)
+//	ON_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Account, countryregion)
 //	ON_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Account, accountinfo)
 //END_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(Account)
 void odata_codegen_writer::generate_implement_begin_serialize_in_entity(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << U("BEGIN_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(") << _class_info._class_name << U(")") << std::endl;
+	out << _XPLATSTR("BEGIN_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_on_serialize_in_entity(::utility::ofstream_t& out, const class_info& _class_info, const property_info& _property_info)
 {
-	if (_property_info._type == PROPERTY_TYPE::E_ACTION || _property_info._type == PROPERTY_TYPE::E_FUNCTION 
+	if (_property_info._type == PROPERTY_TYPE::E_ACTION || _property_info._type == PROPERTY_TYPE::E_FUNCTION
 		|| _property_info._type == PROPERTY_TYPE::E_ENTITY || _property_info._type == PROPERTY_TYPE::E_COLLECTION_ENTITY)
 	{
-		return ;
+		return;
 	}
 
-	out << INDENT << U("ON_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(") << _class_info._class_name << U(", ") << _property_info._class_member_name << U(")") << std::endl;
+	out << INDENT << _XPLATSTR("ON_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(", ") << _property_info._class_member_name << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_end_serialize_in_entity(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << U("END_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(") << _class_info._class_name << U(")") << std::endl << std::endl;
+	out << _XPLATSTR("END_SERIALIZE_PROPERTY_IN_ENTITY_MAPPING(") << CLASS_NAME_PREFIX << _class_info._class_name << _XPLATSTR(")") << std::endl << std::endl;
 }
 
 void odata_codegen_writer::generate_declare_enum_begin(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << U("enum ") << _class_info._class_name << std::endl;
-	out << U("{") << std::endl;
+	out << _XPLATSTR("enum ") << _class_info._class_name << std::endl;
+	out << _XPLATSTR("{") << std::endl;
 }
 
 void odata_codegen_writer::generate_declare_enum_member(::utility::ofstream_t& out, const property_info& _property_info)
 {
-	out << INDENT << _property_info._class_member_name << U(" = ") << _property_info._default_value << U(",") << std::endl;
+	// Only write a value if $metadata contains one, else have the compiler automatically chose one
+	#ifdef _UTF16_STRINGS
+		bool HasValue = wcstoul(_property_info._default_value.c_str(), nullptr, 10) != (std::numeric_limits<unsigned long>::max)();
+	#else
+		bool HasValue = strtoul(_property_info._default_value.c_str(), nullptr, 10) != (std::numeric_limits<unsigned long>::max)();
+	#endif
+
+	out << INDENT << _property_info._class_member_name;
+	if (HasValue)
+	{
+		out << _XPLATSTR(" = ") << _property_info._default_value;
+	}
+	out << _XPLATSTR(",") << std::endl;
 }
 
 void odata_codegen_writer::generate_declare_enum_end(::utility::ofstream_t& out)
 {
-	out << U("};") << std::endl << std::endl;
+	out << _XPLATSTR("};") << std::endl << std::endl;
 }
 
 void odata_codegen_writer::generate_declare_enum_resolver_begin(::utility::ofstream_t& out)
 {
-	out << U("class enum_type_resolver") << std::endl;
-	out << U("{") << std::endl;
-	out << U("public:") << std::endl;
+	out << _XPLATSTR("class enum_type_resolver") << std::endl;
+	out << _XPLATSTR("{") << std::endl;
+	out << _XPLATSTR("public:") << std::endl;
 }
 
 void odata_codegen_writer::generate_declare_enum_resolver_on(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << INDENT << U("DECLARE_FUNCTION_ENUM_TYPE_FROM_STRING(") << _class_info._class_name << U(");") << std::endl;
-	out << INDENT << U("DECLARE_FUNCTION_STRING_FROM_ENUM_TYPE(") << _class_info._class_name << U(");") << std::endl;
-	out << INDENT << U("DECLARE_GET_ENUM_TYPE_NAMESPACE(") << _class_info._class_name << U(", ") << _class_info._edm_namespace << U(");") << std::endl;
+	out << INDENT << _XPLATSTR("DECLARE_FUNCTION_ENUM_TYPE_FROM_STRING(") << _class_info._class_name << _XPLATSTR(");") << std::endl;
+	out << INDENT << _XPLATSTR("DECLARE_FUNCTION_STRING_FROM_ENUM_TYPE(") << _class_info._class_name << _XPLATSTR(");") << std::endl;
+	out << INDENT << _XPLATSTR("DECLARE_GET_ENUM_TYPE_NAMESPACE(") << _class_info._class_name << _XPLATSTR(", ") << _class_info._edm_namespace << _XPLATSTR(");") << std::endl;
 }
 
 void odata_codegen_writer::generate_declare_enum_resolver_end(::utility::ofstream_t& out)
 {
-	out << U("};") << std::endl << std::endl;
+	out << _XPLATSTR("};") << std::endl << std::endl;
 }
 
 //BGEIN_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(Color)
-//    ON_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(Red, Color::Red)
-//    ON_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(Green, Color::Green)
-//    ON_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(Blue, Color::Blue)
+//	ON_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(Red, Color::Red)
+//	ON_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(Green, Color::Green)
+//	ON_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(Blue, Color::Blue)
 //END_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(Color)
 void odata_codegen_writer::generate_implement_enum_type_to_string_begin(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << U("IMPLEMENT_GET_ENUM_TYPE_NAMESPACE(") << _class_info._class_name << U(", ") << _class_info._edm_namespace << U(");") << std::endl;
-	out << U("BGEIN_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(") << _class_info._class_name << U(")") << std::endl;
+	out << _XPLATSTR("IMPLEMENT_GET_ENUM_TYPE_NAMESPACE(") << _class_info._class_name << _XPLATSTR(", ") << _class_info._edm_namespace << _XPLATSTR(");") << std::endl;
+	out << _XPLATSTR("BGEIN_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(") << _class_info._class_name << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_enum_type_to_string_member(::utility::ofstream_t& out, const class_info& _class_info, const property_info& _property_info)
 {
-	out << INDENT << U("ON_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(") << _property_info._class_member_name << U(", ") << _class_info._class_name << U("::") << _property_info._class_member_name << U(")") << std::endl;
+	out << INDENT << _XPLATSTR("ON_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(") << _property_info._class_member_name << _XPLATSTR(", ") << _class_info._class_name << _XPLATSTR("::") << _property_info._class_member_name << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_enum_type_to_string_end(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << U("END_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(") << _class_info._class_name << U(")") << std::endl << std::endl;
+	out << _XPLATSTR("END_IMPLEMENT_FUNCTION_ENUM_TYPE_FROM_STRING(") << _class_info._class_name << _XPLATSTR(")") << std::endl << std::endl;
 }
 
 //BGEIN_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(Color)
-//    ON_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(Color::Red, Red)
-//    ON_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(Color::Green, Green)
-//    ON_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(Color::Blue, Blue)
+//	ON_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(Color::Red, Red)
+//	ON_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(Color::Green, Green)
+//	ON_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(Color::Blue, Blue)
 //END_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(Color)
 void odata_codegen_writer::generate_implement_string_to_enum_type_begin(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << U("BGEIN_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(") << _class_info._class_name << U(")") << std::endl;
+	out << _XPLATSTR("BGEIN_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(") << _class_info._class_name << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_string_to_enum_type_member(::utility::ofstream_t& out, const class_info& _class_info, const property_info& _property_info)
 {
-	
-	out << INDENT << U("ON_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(") << _class_info._class_name << U("::") << _property_info._class_member_name << U(", ") << _property_info._class_member_name << U(")") << std::endl;
+
+	out << INDENT << _XPLATSTR("ON_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(") << _class_info._class_name << _XPLATSTR("::") << _property_info._class_member_name << _XPLATSTR(", ") << _property_info._class_member_name << _XPLATSTR(")") << std::endl;
 }
 
 void odata_codegen_writer::generate_implement_string_to_enum_type_end(::utility::ofstream_t& out, const class_info& _class_info)
 {
-	out << U("END_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(") << _class_info._class_name << U(")") << std::endl << std::endl;
+	out << _XPLATSTR("END_IMPLEMENT_FUNCTION_STRING_FROM_ENUM_TYPE(") << _class_info._class_name << _XPLATSTR(")") << std::endl << std::endl;
 }
 
-void odata_codegen_writer::output_line_content(::utility::ostream_t& out, const ::utility::string_t& content, unsigned int indent_number)
+void odata_codegen_writer::output_line_content(::utility::ostream_t& out, const ::odata::string_t& content, unsigned int indent_number)
 {
-	for (unsigned int i = 0; i < indent_number; i++)
+	for (unsigned int i = 0; i < indent_number; ++i)
 	{
 		out << INDENT;
 	}
@@ -1425,10 +1494,10 @@ void odata_codegen_writer::output_line_content(::utility::ostream_t& out, const 
 
 void odata_codegen_writer::output_empty_line(::utility::ostream_t& out, unsigned int line_number)
 {
-	for (unsigned int i = 0; i < line_number; i++)
+	for (unsigned int i = 0; i < line_number; ++i)
 	{
 		out << std::endl;
-	}	
+	}
 }
 
 }}}

--- a/tools/codegentool/odata_codegen_writer.h
+++ b/tools/codegentool/odata_codegen_writer.h
@@ -26,10 +26,10 @@ public:
 
 private:
 	void generate_declare_include_files(::utility::ofstream_t& out);
-    void generate_declare_include_files_end(::utility::ofstream_t& out);
+	void generate_declare_include_files_end(::utility::ofstream_t& out);
 	void generate_implement_include_files(::utility::ofstream_t& out);
-	void generate_declare_namespace_begin(::utility::ofstream_t& out, const ::utility::string_t& _namespace);
-	void generate_implement_namespace_begin(::utility::ofstream_t& out, const ::utility::string_t& _namespace);
+	void generate_declare_namespace_begin(::utility::ofstream_t& out, const ::odata::string_t& _namespace);
+	void generate_implement_namespace_begin(::utility::ofstream_t& out, const ::odata::string_t& _namespace);
 	void generate_declare_namespace_end(::utility::ofstream_t& out);
 	void generate_implement_namespace_end(::utility::ofstream_t& out);
 
@@ -47,11 +47,11 @@ private:
 	void generate_implement_operation_imports_in_entity_container(::utility::ofstream_t& out, const class_info& _class_info, const property_info& _property_info);
 
 	// common headers for complex and entity
-	void generate_declare_class_begin(::utility::ofstream_t& out, const ::utility::string_t& class_name, const ::utility::string_t& base_class_name);
+	void generate_declare_class_begin(::utility::ofstream_t& out, const ::odata::string_t& class_name, const ::odata::string_t& base_class_name);
 	void generate_declare_class_end(::utility::ofstream_t& out);
 
 	// complex type
-	void generate_declare_common_functions_in_complex(::utility::ofstream_t& out, const ::utility::string_t& class_name);
+	void generate_declare_common_functions_in_complex(::utility::ofstream_t& out, const ::odata::string_t& class_name);
 	void generate_declare_class_member_in_complex(::utility::ofstream_t& out, const property_info& _property_info);
 	void generate_implement_common_functions_in_complex(::utility::ofstream_t& out, const class_info& _class_info);
 	void generate_implement_class_member_in_complex(::utility::ofstream_t& out, const class_info& _class_info, const property_info& _property_info);
@@ -69,7 +69,7 @@ private:
 	void generate_implement_end_serialize_in_complex(::utility::ofstream_t& out, const class_info& _class_info);
 
 	// entity type
-	void generate_declare_common_functions_in_entity(::utility::ofstream_t& out, const ::utility::string_t& class_name);
+	void generate_declare_common_functions_in_entity(::utility::ofstream_t& out, const ::odata::string_t& class_name);
 	void generate_declare_class_keys_in_entity(::utility::ofstream_t& out, const class_info& _class_info, const std::vector<property_info>& keys);
 	void generate_declare_class_member_in_entity(::utility::ofstream_t& out, const class_info& _class_info, const property_info& _property_info);
 	void generate_declare_operation_in_entity(::utility::ofstream_t& out, const class_info& _class_info, const property_info& _property_info);
@@ -103,12 +103,11 @@ private:
 	void generate_implement_string_to_enum_type_member(::utility::ofstream_t& out, const class_info& _class_info, const property_info& _property_info);
 	void generate_implement_string_to_enum_type_end(::utility::ofstream_t& out, const class_info& _class_info);
 
-	void output_line_content(::utility::ostream_t& out, const ::utility::string_t& content, unsigned int indent_number = 0);
+	void output_line_content(::utility::ostream_t& out, const ::odata::string_t& content, unsigned int indent_number = 0);
 	void output_empty_line(::utility::ostream_t& out, unsigned int line_number = 1);
 
 private:
 	std::shared_ptr<odata_codegen_initializer> m_initializer;
 };
-
 
 }}}


### PR DESCRIPTION
OData changes:
- Implement log option for http trafic via a callback
- Access to the http headers of a regular message and the $metadata
- Use of _XPLAT() macro instead of the U() macro, allowing the define of U() to not be present if it disturbes
- Naked arrays are allowed
- Collections may legally contain entities, not just primitive or complex types
- Implement open property types
- Implement proper handling of namespace aliases
- Remove the model of this instance from the model cache and the instance on request
- Suppress the output of @OData.type in requests. This is a WAR for TM1 servers that will unjustifiedly choke on such annotations!
- Search query available
- Update an array of values
- Strings can alternatively be a string_t or a ::boost::flyweight<sting_t>
- shared_ptr can be instanciated by make_shared or new
- Fix: Corrected broken overload of what()
- Fix: Missing const added in nemerous places
- Fix: Corrected some typos in the source
- Implement return value of call available
- Fix: Typos in code-generation.h that prevented compilation
- Extended number of parameters from 6 to 12
- Completed operations according to the OData standard
- Implemented the operators of the open property map
- Support VS 2017 and 2019
- Removed warnings to improve code quality
- Added @odata.bind
- Numerous small improvements and fixes

TODOs:
- Make base class of types instanciable (currently not possible due to an abstract class but desirable)
- Implement OData type stream (currently not implemented and an atempt to do so causes a compile error)
- Still large memory consuption if types are complex and there are a lot of them. This is due to the many(!) nullptrs that could be present
- Test not checked for compilability and correctness after changes
- Do checks for compilation under VS 11 and VS12 if desired and make source code compile under those
- shared_ptr of flyweight is of course redundant, so make the strings not use shared_ptr anymore